### PR TITLE
build(release): use pat so that workflows run when a release pr is created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         id: release
         uses: google-github-actions/release-please-action@v3.7.13
         with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           release-type: python
           package-name: pyoda-time
           changelog-types: >


### PR DESCRIPTION
release-please defaults to using GITHUB_TOKEN to create release PRs.

Workflows (such as our pytest, pre-commit) will not run when a commit is created by that default token.

This is to prevent people creating circular workflow runs.

To get around that protection, we need to use a PAT instead.