### PR TITLE
fix(Instant): Raise OverflowError when Instant._plus() is passed a sufficiently large or small Offset

### DIFF
--- a/pyoda_time/__init__.py
+++ b/pyoda_time/__init__.py
@@ -1674,7 +1674,7 @@ class _LocalInstant:
         if nanoseconds is not None:
             days = nanoseconds._floor_days
             if days < Instant._MIN_DAYS or days > Instant._MAX_DAYS:
-                raise ValueError("Operation would overflow bounds of local date/time")
+                raise OverflowError("Operation would overflow bounds of local date/time")
             self.__duration = nanoseconds
         elif days is not None:
             self.__duration = Duration._ctor(days=days, nano_of_day=nano_of_day)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -259,3 +259,8 @@ def assert_argument_null(func: Callable[..., TOut], *args: Any) -> TOut:
     # TODO: In Noda Time ArgumentNullException is thrown
     with pytest.raises(TypeError):
         return func(*args)
+
+
+def assert_overflow(func: Callable[[TArg], TOut], param: TArg) -> None:
+    with pytest.raises(OverflowError):
+        func(param)

--- a/tests/test_instant.py
+++ b/tests/test_instant.py
@@ -11,6 +11,7 @@ from pyoda_time import (
     _LocalInstant,
 )
 from pyoda_time.utility import _towards_zero_division
+from tests import helpers
 
 
 class TestInstant:
@@ -24,9 +25,9 @@ class TestInstant:
 
     # TODO def test_in_zone(self):
 
-    # TODO def test_with_offset(self):
+    # TODO def test_with_offset(self): [requires OffsetDateTime]
 
-    # TODO def test_with_offset_non_iso_calendar(self):
+    # TODO def test_with_offset_non_iso_calendar(self): [requires CalendarSystem.GetIslamicCalendar]
 
     def test_from_ticks_since_unix_epoch(self) -> None:
         instant = Instant.from_unix_time_ticks(12345)
@@ -211,7 +212,9 @@ class TestInstant:
         assert Instant.min_value() == Instant.max_value() + huge_and_negative
         assert Instant.min_value() == Instant.max_value() - huge_and_positive
 
-    # TODO def test_plus_offset_overflow(self):
+    def test_plus_offset_overflow(self) -> None:
+        helpers.assert_overflow(Instant.min_value()._plus, Offset.from_seconds(-1))
+        helpers.assert_overflow(Instant.max_value()._plus, Offset.from_seconds(1))
 
     def test_from_unix_time_milliseconds_range(self) -> None:
         smallest_valid = _towards_zero_division(


### PR DESCRIPTION
The relevant test wasn't implementable previously as we hadn't ported Offset yet. Once we had Offset, the test could be added and the bug was discovered.