### PR TITLE
feat: implement islamic, persian and um al qura calendars

### DIFF
--- a/pyoda_time/fields.py
+++ b/pyoda_time/fields.py
@@ -1,0 +1,96 @@
+__all__: list[str] = []
+
+import abc as _abc
+import typing as _typing
+
+from pyoda_time import LocalDate as _LocalDate
+from pyoda_time.utility import _Preconditions, _sealed
+
+
+class _IDatePeriodField:
+    """General representation of the difference between two dates in a particular time unit, such as "days" or
+    "months"."""
+
+    @_abc.abstractmethod
+    def add(self, local_date: _LocalDate, value: int) -> _LocalDate:
+        """Adds a duration value (which may be negative) to the date. This may not be reversible; for example, adding a
+        month to January 30th will result in February 28th or February 29th.
+
+        :param local_date: The local date to add to.
+        :param value: The value to add, in the units of the field.
+        :return: The updated local date.
+        """
+        raise NotImplementedError
+
+    @_abc.abstractmethod
+    def units_between(self, start: _LocalDate, end: _LocalDate) -> int:
+        """Computes the difference between two local dates, as measured in the units of this field, rounding towards
+        zero. This rounding means that unit.Add(start, unit.UnitsBetween(start, end)) always ends up with a date between
+        start and end. (Ideally equal to end, but importantly, it never overshoots.)
+
+        :param start: The start date.
+        :param end: The end date.
+        :return: The difference in the units of this field.
+        """
+        raise NotImplementedError
+
+
+@_sealed
+class _MonthsPeriodField(_IDatePeriodField):
+    def add(self, local_date: _LocalDate, value: int) -> _LocalDate:
+        from pyoda_time import LocalDate
+
+        calendar = local_date.calendar
+        calculator = calendar._year_month_day_calculator
+        year_month_day = calculator._add_months(local_date._year_month_day, value)
+        return LocalDate._ctor(year_month_day_calendar=year_month_day._with_calendar(calendar))
+
+    def units_between(self, start: _LocalDate, end: _LocalDate) -> int:
+        return start.calendar._year_month_day_calculator._months_between(start._year_month_day, end._year_month_day)
+
+
+@_sealed
+class _YearsPeriodField(_IDatePeriodField):
+    def add(self, local_date: _LocalDate, value: int) -> _LocalDate:
+        from pyoda_time import LocalDate
+
+        if value == 0:
+            return local_date
+        year_month_day = local_date._year_month_day
+        calendar = local_date.calendar
+        calculator = calendar._year_month_day_calculator
+        current_year = year_month_day._year
+        # Adjust argument range based on current year
+        _Preconditions._check_argument_range(
+            "value", value, calculator._min_year - current_year, calculator._max_year - current_year
+        )
+        return LocalDate._ctor(
+            year_month_day_calendar=calculator._set_year(year_month_day, current_year + value)._with_calendar_ordinal(
+                calendar._ordinal
+            )
+        )
+
+    def units_between(self, start: _LocalDate, end: _LocalDate) -> int:
+        diff: int = end.year - start.year
+
+        # If we just add the difference in years to subtrahendInstant, what do we get?
+        simple_addition = self.add(start, diff)
+
+        if start <= end:
+            # Moving forward: if the result of the simple addition is before or equal to the end,
+            # we're done. Otherwise, rewind a year because we've overshot.
+            return diff if simple_addition <= end else diff - 1
+        else:
+            # Moving backward: if the result of the simple addition (of a non-positive number)
+            # is after or equal to the end, we're done. Otherwise, increment by a year because
+            # we've overshot backwards.
+            return diff if simple_addition >= end else diff + 1
+
+
+class _DatePeriodFields:
+    """All the period fields."""
+
+    # TODO: DaysField
+    # TODO: WeeksField
+    _months_field: _typing.Final[_IDatePeriodField] = _MonthsPeriodField()
+    _years_field: _typing.Final[_IDatePeriodField] = _YearsPeriodField()

--- a/pyoda_time/utility.py
+++ b/pyoda_time/utility.py
@@ -80,14 +80,14 @@ class _TickArithmetic:
         return days * PyodaConstants.TICKS_PER_DAY + tick_of_day
 
 
-def _towards_zero_division(x: int | float, y: int) -> int:
-    """Divide two integers using "towards zero" rounding.
+def _towards_zero_division(x: int | float, y: int | float) -> int:
+    """Divide two numbers using "towards zero" rounding.
 
     This ensures that integer division produces the same result as it would do in C#.
     """
     from decimal import ROUND_DOWN, Decimal
 
-    return int((Decimal(x) / y).quantize(0, ROUND_DOWN))
+    return int((Decimal(x) / Decimal(y)).quantize(0, ROUND_DOWN))
 
 
 def _to_ticks(dt: _datetime.datetime) -> int:

--- a/tests/calendars/test_hebrew_calendar_system.py
+++ b/tests/calendars/test_hebrew_calendar_system.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pyoda_time import _YearMonthDay
+from pyoda_time import CalendarSystem, LocalDate, _YearMonthDay
 from pyoda_time.calendars import HebrewMonthNumbering, _HebrewScripturalCalculator, _HebrewYearMonthDayCalculator
 
 
@@ -11,7 +11,7 @@ class TestHebrewCalendarSystem:
     # TODO: def test_set_year (requires LocalDatePattern)
     # TODO: def test_add_months_months_between (requires LocalDatePattern)
     # TODO: def test_months_between (requires LocalDatePattern)
-    # TODO: def test_months_between_time_of_day(self) (requires LocalDateTime)
+    # TODO: def test_months_between_time_of_day(self) -> None:  (requires Period.Between())
 
     @pytest.mark.parametrize(
         "numbering",
@@ -59,21 +59,21 @@ class TestHebrewCalendarSystem:
             _HebrewScripturalCalculator._get_days_from_start_of_year_to_start_of_month(5502, 0)
 
     # TODO: requires LocalDate.plus_months()
-    # @pytest.mark.parametrize(
-    #     "month_numbering",
-    #     (
-    #         HebrewMonthNumbering.CIVIL,
-    #         HebrewMonthNumbering.SCRIPTURAL,
-    #     ),
-    # )
-    # def test_plus_months_overflow(self, month_numbering: HebrewMonthNumbering) -> None:
-    #     calendar = CalendarSystem.get_hebrew_calendar(month_numbering)
-    #     # TODO: It would be nice to have an easy way of getting the smallest/largest LocalDate for
-    #     #  a calendar. Or possibly FromDayOfYear as well... instead, we'll just add/subtract 8 months instead
-    #     early_date = LocalDate(year=calendar.min_year, month=1, day=1, calendar=calendar)
-    #     late_date = LocalDate(year=calendar.max_year, month=12, day=1, calendar=calendar)
-    #
-    #     with pytest.raises(OverflowError):
-    #         early_date.plus_months(-7)
-    #     with pytest.raises(OverflowError):
-    #         late_date.plus_months(7)
+    @pytest.mark.parametrize(
+        "month_numbering",
+        (
+            HebrewMonthNumbering.CIVIL,
+            HebrewMonthNumbering.SCRIPTURAL,
+        ),
+    )
+    def test_plus_months_overflow(self, month_numbering: HebrewMonthNumbering) -> None:
+        calendar = CalendarSystem.get_hebrew_calendar(month_numbering)
+        # TODO: It would be nice to have an easy way of getting the smallest/largest LocalDate for
+        #  a calendar. Or possibly FromDayOfYear as well... instead, we'll just add/subtract 8 months instead
+        early_date = LocalDate(year=calendar.min_year, month=1, day=1, calendar=calendar)
+        late_date = LocalDate(year=calendar.max_year, month=12, day=1, calendar=calendar)
+
+        with pytest.raises(OverflowError):
+            early_date.plus_months(-7)
+        with pytest.raises(OverflowError):
+            late_date.plus_months(7)

--- a/tests/calendars/test_islamic_calendar_system.py
+++ b/tests/calendars/test_islamic_calendar_system.py
@@ -1,0 +1,343 @@
+import pytest
+
+from pyoda_time import CalendarSystem, IsoDayOfWeek, LocalDate, LocalDateTime
+from pyoda_time.calendars import Era, IslamicEpoch, IslamicLeapYearPattern, _IslamicYearMonthDayCalculator
+
+
+class TestIslamicCalendarSystem:
+    SAMPLE_CALENDAR = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE16, IslamicEpoch.CIVIL)
+
+    def test_sample_date_1(self) -> None:
+        ldt = LocalDateTime(1945, 11, 12, 0, 0, 0, 0, CalendarSystem.iso)
+        ldt = ldt.with_calendar(self.SAMPLE_CALENDAR)
+        assert ldt.year_of_era == 1364
+
+        assert ldt.year == 1364
+        assert ldt.month == 12
+        assert ldt.day == 6
+        assert ldt.day_of_week == IsoDayOfWeek.MONDAY
+        assert ldt.day_of_year == 6 * 30 + 5 * 29 + 6
+
+        assert ldt.hour == 0
+        assert ldt.minute == 0
+        assert ldt.second == 0
+        assert ldt.tick_of_second == 0
+
+    def test_sample_date_2(self) -> None:
+        ldt = LocalDateTime(2005, 11, 26, 0, 0, 0, 0, CalendarSystem.iso)
+        ldt = ldt.with_calendar(self.SAMPLE_CALENDAR)
+        assert ldt.era == Era.anno_hegirae
+        assert ldt.year_of_era == 1426
+
+        assert ldt.year == 1426
+        assert ldt.month == 10
+        assert ldt.day == 24
+        assert ldt.day_of_week == IsoDayOfWeek.SATURDAY
+        assert ldt.day_of_year == 5 * 30 + 4 * 29 + 24
+        assert ldt.hour == 0
+        assert ldt.minute == 0
+        assert ldt.second == 0
+        assert ldt.tick_of_second == 0
+
+    def test_sample_date_3(self) -> None:
+        ldt = LocalDateTime(1426, 12, 24, 0, 0, 0, 0, calendar=self.SAMPLE_CALENDAR)
+        assert ldt.era == Era.anno_hegirae
+
+        assert ldt.year == 1426
+        assert ldt.month == 12
+        assert ldt.day == 24
+        assert ldt.day_of_week == IsoDayOfWeek.TUESDAY
+        assert ldt.day_of_year == 6 * 30 + 5 * 29 + 24
+        assert ldt.hour == 0
+        assert ldt.minute == 0
+        assert ldt.second == 0
+        assert ldt.tick_of_second == 0
+
+    def test_internal_consistency(self) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE15, IslamicEpoch.CIVIL)
+        # Check construction and then deconstruction for every day of every year in one 30-year cycle.
+        for year in range(1, 31):
+            for month in range(1, 13):
+                month_length = calendar.get_days_in_month(year, month)
+                for day in range(1, month_length + 1):
+                    date = LocalDate(year=year, month=month, day=day, calendar=calendar)
+                    assert date.year == year, f"Year of {year}-{month}-{day}"
+                    assert date.month == month, f"Month of {year}-{month}-{day}"
+                    assert date.day == day, f"Day of {year}-{month}-{day}"
+
+    @pytest.mark.parametrize(
+        "year,expected",
+        [
+            (1, False),
+            (2, True),
+            (3, False),
+            (4, False),
+            (5, True),
+            (6, False),
+            (7, True),
+            (8, False),
+            (9, False),
+            (10, True),
+            (11, False),
+            (12, False),
+            (13, True),
+            (14, False),
+            (15, True),
+            (16, False),
+            (17, False),
+            (18, True),
+            (19, False),
+            (20, False),
+            (21, True),
+            (22, False),
+            (23, False),
+            (24, True),
+            (25, False),
+            (26, True),
+            (27, False),
+            (28, False),
+            (29, True),
+            (30, False),
+        ],
+    )
+    def test_base15_leap_year(self, year: int, expected: bool) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE15, IslamicEpoch.CIVIL)
+        assert calendar.is_leap_year(year) is expected
+
+    @pytest.mark.parametrize(
+        "year,expected",
+        [
+            (1, False),
+            (2, True),
+            (3, False),
+            (4, False),
+            (5, True),
+            (6, False),
+            (7, True),
+            (8, False),
+            (9, False),
+            (10, True),
+            (11, False),
+            (12, False),
+            (13, True),
+            (14, False),
+            (15, False),
+            (16, True),
+            (17, False),
+            (18, True),
+            (19, False),
+            (20, False),
+            (21, True),
+            (22, False),
+            (23, False),
+            (24, True),
+            (25, False),
+            (26, True),
+            (27, False),
+            (28, False),
+            (29, True),
+            (30, False),
+        ],
+    )
+    def test_base16_leap_year(self, year: int, expected: bool) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE16, IslamicEpoch.CIVIL)
+        assert calendar.is_leap_year(year) is expected
+
+    @pytest.mark.parametrize(
+        "year,expected",
+        [
+            (1, False),
+            (2, True),
+            (3, False),
+            (4, False),
+            (5, True),
+            (6, False),
+            (7, False),
+            (8, True),
+            (9, False),
+            (10, True),
+            (11, False),
+            (12, False),
+            (13, True),
+            (14, False),
+            (15, False),
+            (16, True),
+            (17, False),
+            (18, False),
+            (19, True),
+            (20, False),
+            (21, True),
+            (22, False),
+            (23, False),
+            (24, True),
+            (25, False),
+            (26, False),
+            (27, True),
+            (28, False),
+            (29, True),
+            (30, False),
+        ],
+    )
+    def test_indian_based_leap_year(self, year: int, expected: bool) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.INDIAN, IslamicEpoch.CIVIL)
+        assert calendar.is_leap_year(year) is expected
+
+    @pytest.mark.parametrize(
+        "year,expected",
+        [
+            (1, False),
+            (2, True),
+            (3, False),
+            (4, False),
+            (5, True),
+            (6, False),
+            (7, False),
+            (8, True),
+            (9, False),
+            (10, False),
+            (11, True),
+            (12, False),
+            (13, True),
+            (14, False),
+            (15, False),
+            (16, True),
+            (17, False),
+            (18, False),
+            (19, True),
+            (20, False),
+            (21, True),
+            (22, False),
+            (23, False),
+            (24, True),
+            (25, False),
+            (26, False),
+            (27, True),
+            (28, False),
+            (29, False),
+            (30, True),
+        ],
+    )
+    def test_habash_al_hasib_based_leap_year(self, year: int, expected: bool) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.HABASH_AL_HASIB, IslamicEpoch.CIVIL)
+        assert calendar.is_leap_year(year) is expected
+
+    def test_thursday_epoch(self) -> None:
+        thursday_epoch_calendar = CalendarSystem.islamic_bcl
+        julian_calendar = CalendarSystem.julian
+
+        thursday_epoch = LocalDate(year=1, month=1, day=1, calendar=thursday_epoch_calendar)
+        thursday_epoch_julian = LocalDate(year=622, month=7, day=15, calendar=julian_calendar)
+        assert thursday_epoch.with_calendar(julian_calendar) == thursday_epoch_julian
+
+    def test_friday_epoch(self) -> None:
+        friday_epoch_calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE16, IslamicEpoch.CIVIL)
+        julian_calendar = CalendarSystem.julian
+
+        friday_epoch = LocalDate(year=1, month=1, day=1, calendar=friday_epoch_calendar)
+        friday_epoch_julian = LocalDate(year=622, month=7, day=16, calendar=julian_calendar)
+        assert friday_epoch.with_calendar(julian_calendar) == friday_epoch_julian
+
+    # TODO: def test_bcl_uses_astronomical_epoch(self) -> None: [requires System.Globalization.HijriCalendar]
+    # TODO: def test_sample_date_bcl_compatibility(self) -> None: [requires System.Globalization.HijriCalendar]
+    # TODO: def test_bcl_through_history(self) -> None: [requires System.Globalization.HijriCalendar]
+
+    @pytest.mark.parametrize(
+        "year,month,expected",
+        [
+            (7, 1, 30),
+            (7, 2, 29),
+            (7, 3, 30),
+            (7, 4, 29),
+            (7, 5, 30),
+            (7, 6, 29),
+            (7, 7, 30),
+            (7, 8, 29),
+            (7, 9, 30),
+            (7, 10, 29),
+            (7, 11, 30),
+            # As noted before, 7 isn't a leap year in this calendar
+            (7, 12, 29),
+            # As noted before, 8 is a leap year in this calendar
+            (8, 12, 30),
+        ],
+    )
+    def test_get_days_in_month(self, year: int, month: int, expected: int) -> None:
+        # Just check that we've got the long/short the right way round...
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.HABASH_AL_HASIB, IslamicEpoch.CIVIL)
+        assert calendar.get_days_in_month(year, month) == expected
+
+    def test_get_instance_caching(self) -> None:
+        from collections import deque
+
+        queue: deque = deque()
+        set_: set[CalendarSystem] = set()
+        ids: set[str] = set()
+        for leap_year_pattern in IslamicLeapYearPattern:
+            for epoch in IslamicEpoch:
+                calendar = CalendarSystem.get_islamic_calendar(leap_year_pattern, epoch)
+                queue.append(calendar)
+                assert calendar not in set_  # Check we haven't already seen it...
+                set_.add(calendar)
+                assert calendar.id not in ids
+                ids.add(calendar.id)
+        # Now check we get the same references again...
+        for leap_year_pattern in IslamicLeapYearPattern:
+            for epoch in IslamicEpoch:
+                old_calendar = queue.popleft()
+                new_calendar = CalendarSystem.get_islamic_calendar(leap_year_pattern, epoch)
+                assert new_calendar.id == old_calendar.id
+                assert new_calendar is old_calendar
+
+    def test_get_instance_argument_validation(self) -> None:
+        # This first invocation is just to ensure that passing ints doesn't cause an exception.
+        # That way, we can be assured that any exception raised below is coming from our validation.
+        CalendarSystem.get_islamic_calendar(min(IslamicLeapYearPattern) + 0, min(IslamicEpoch) - 0)  # type: ignore
+        # TODO: In Noda Time, this is ArgumentOutOfRangeException
+        with pytest.raises(ValueError):
+            CalendarSystem.get_islamic_calendar(min(IslamicLeapYearPattern) - 1, min(IslamicEpoch))  # type: ignore
+        with pytest.raises(ValueError):
+            CalendarSystem.get_islamic_calendar(min(IslamicLeapYearPattern), min(IslamicEpoch) - 1)  # type: ignore
+        with pytest.raises(ValueError):
+            CalendarSystem.get_islamic_calendar(max(IslamicLeapYearPattern) + 1, max(IslamicEpoch))  # type: ignore
+        with pytest.raises(ValueError):
+            CalendarSystem.get_islamic_calendar(max(IslamicLeapYearPattern), max(IslamicEpoch) + 1)  # type: ignore
+
+    def test_plus_years_simple(self) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE15, IslamicEpoch.CIVIL)
+
+        start = LocalDateTime(5, 8, 20, 2, 0, calendar=calendar)
+        expected_end = LocalDateTime(10, 8, 20, 2, 0, calendar=calendar)
+        assert start.plus_years(5) == expected_end
+
+    def test_plus_years_truncates_at_leap_year(self) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE15, IslamicEpoch.CIVIL)
+        assert calendar.is_leap_year(2)
+        assert not calendar.is_leap_year(3)
+
+        start = LocalDateTime(2, 12, 30, 2, 0, calendar=calendar)
+        expected_end = LocalDateTime(3, 12, 29, 2, 0, calendar=calendar)
+        assert start.plus_years(1) == expected_end
+
+    def test_plus_years_does_not_truncate_from_one_leap_year_to_another(self) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE15, IslamicEpoch.CIVIL)
+        assert calendar.is_leap_year(2)
+        assert calendar.is_leap_year(5)
+
+        start: LocalDateTime = LocalDateTime(2, 12, 30, 2, 0, calendar=calendar)
+        expected_end: LocalDateTime = LocalDateTime(5, 12, 30, 2, 0, calendar=calendar)
+        assert start.plus_years(3) == expected_end
+
+    def test_plus_months_simple(self) -> None:
+        calendar = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE15, IslamicEpoch.CIVIL)
+        assert calendar.is_leap_year(2)
+
+        start = LocalDateTime(2, 12, 30, 2, 0, calendar=calendar)
+        expected_end = LocalDateTime(3, 11, 30, 2, 0, calendar=calendar)
+        assert expected_end.month == 11
+        assert expected_end.day == 30
+        assert start.plus_months(11) == expected_end
+
+    def test_constructor_invalid_enums_for_coverage(self) -> None:
+        with pytest.raises(ValueError):
+            _IslamicYearMonthDayCalculator(IslamicLeapYearPattern.BASE15 + 100, IslamicEpoch.ASTRONOMICAL)  # type: ignore
+            _IslamicYearMonthDayCalculator(IslamicLeapYearPattern.BASE15, IslamicEpoch.ASTRONOMICAL + 100)  # type: ignore

--- a/tests/calendars/test_persian_calendar_system.py
+++ b/tests/calendars/test_persian_calendar_system.py
@@ -1,0 +1,49 @@
+import pytest
+
+from pyoda_time import CalendarSystem, LocalDate
+
+
+class TestPersianCalendarSystem:
+    # TODO: test_bcl_through_history(self): [requires bcl]
+
+    @pytest.mark.parametrize(
+        "persian_year,gregorian_year,gregorian_day_of_march",
+        [
+            (1016, 1637, 21),
+            (1049, 1670, 21),
+            (1078, 1699, 21),
+            (1082, 1703, 22),
+            (1111, 1732, 21),
+            (1115, 1736, 21),
+            (1144, 1765, 21),
+            (1177, 1798, 21),
+            (1210, 1831, 22),
+            (1243, 1864, 21),
+            (1404, 2025, 20),
+            (1437, 2058, 20),
+            (1532, 2153, 20),
+            (1565, 2186, 20),
+            (1569, 2190, 20),
+            (1598, 2219, 21),
+            (1631, 2252, 20),
+            (1660, 2281, 20),
+            (1664, 2285, 20),
+            (1693, 2314, 21),
+            (1697, 2318, 21),
+            (1726, 2347, 21),
+            (1730, 2351, 21),
+            (1759, 2380, 20),
+            (1763, 2384, 20),
+            (1788, 2409, 20),
+            (1792, 2413, 20),
+            (1796, 2417, 20),
+        ],
+    )
+    def test_arithmetic_examples(self, persian_year: int, gregorian_year: int, gregorian_day_of_march: int) -> None:
+        persian = LocalDate(year=persian_year, month=1, day=1, calendar=CalendarSystem.persian_arithmetic)
+        gregorian = persian.with_calendar(CalendarSystem.gregorian)
+        assert gregorian.year == gregorian_year
+        assert gregorian.month == 3
+        assert gregorian.day == gregorian_day_of_march
+
+    # TODO: def test_generate_data(self): [requires bcl]

--- a/tests/calendars/test_um_al_qura_year_month_day_calculator.py
+++ b/tests/calendars/test_um_al_qura_year_month_day_calculator.py
@@ -1,0 +1,49 @@
+import pytest
+
+from pyoda_time import _YearMonthDay
+from pyoda_time.calendars import _UmAlQuraYearMonthDayCalculator
+
+
+class TestUmAlQuraYearMonthDayCalculator:
+    # TODO: test_bcl_equivalence(self) [requires bcl]
+
+    # TODO def test_get_start_of_year_in_days(self) -> None: [requires bcl]
+
+    def test_get_year_month_day_days_since_epoch(self) -> None:
+        calculator = _UmAlQuraYearMonthDayCalculator()
+        days_since_epoch = calculator._get_start_of_year_in_days(calculator._min_year)
+        for year in range(calculator._min_year, calculator._max_year + 1):
+            for month in range(1, 13):
+                for day in range(1, calculator._get_days_in_month(year, month) + 1):
+                    actual = calculator._get_year_month_day(days_since_epoch=days_since_epoch)
+                    expected = _YearMonthDay._ctor(year=year, month=month, day=day)
+                    assert actual == expected, f"{days_since_epoch=}"
+                    days_since_epoch += 1
+
+    def test_get_year_month_day_year_and_day_of_year(self) -> None:
+        calculator = _UmAlQuraYearMonthDayCalculator()
+        for year in range(calculator._min_year, calculator._max_year + 1):
+            day_of_year = 1
+            for month in range(1, 13):
+                for day in range(1, calculator._get_days_in_month(year, month) + 1):
+                    actual = calculator._get_year_month_day(year=year, day_of_year=day_of_year)
+                    expected = _YearMonthDay._ctor(year=year, month=month, day=day)
+                    assert actual == expected, f"{year=}, {day_of_year=}"
+                    day_of_year += 1
+
+    def test_get_days_from_start_of_year_to_start_of_month(self) -> None:
+        calculator = _UmAlQuraYearMonthDayCalculator()
+        for year in range(calculator._min_year, calculator._max_year + 1):
+            day_of_year = 1
+            for month in range(1, 13):
+                assert (
+                    calculator._get_day_of_year(_YearMonthDay._ctor(year=year, month=month, day=1)) == day_of_year
+                ), f"{year=}, {month=}"
+                day_of_year += calculator._get_days_in_month(year, month)
+
+    def test_get_year_month_day_invalid_value_for_coverage(self) -> None:
+        calculator = _UmAlQuraYearMonthDayCalculator()
+        with pytest.raises(ValueError):  # TODO: In Noda Time this is ArgumentOutOfRangeException
+            calculator._get_year_month_day(year=calculator._min_year, day_of_year=1000)
+
+    # TODO: test_generate_data()

--- a/tests/calendars/test_year_month_day_calculator.py
+++ b/tests/calendars/test_year_month_day_calculator.py
@@ -1,13 +1,19 @@
+import itertools
 from typing import Final
 
 import pytest
 
 from pyoda_time.calendars import (
     HebrewMonthNumbering,
+    IslamicEpoch,
+    IslamicLeapYearPattern,
     _CopticYearMonthDayCalculator,
     _GregorianYearMonthDayCalculator,
     _HebrewYearMonthDayCalculator,
+    _IslamicYearMonthDayCalculator,
     _JulianYearMonthDayCalculator,
+    _PersianYearMonthDayCalculator,
+    _UmAlQuraYearMonthDayCalculator,
     _YearMonthDayCalculator,
 )
 
@@ -17,14 +23,15 @@ NON_ISLAMIC_CALCULATORS: Final[list[_YearMonthDayCalculator]] = [
     _JulianYearMonthDayCalculator(),
     _HebrewYearMonthDayCalculator(HebrewMonthNumbering.CIVIL),
     _HebrewYearMonthDayCalculator(HebrewMonthNumbering.SCRIPTURAL),
-    # TODO: PersianSimple
-    # TODO: PersianArithmetic
-    # TODO: PersianAstronomical
-    # TODO: UmAlQura
+    _PersianYearMonthDayCalculator.Simple(),
+    _PersianYearMonthDayCalculator.Arithmetic(),
+    _PersianYearMonthDayCalculator.Astronomical(),
+    _UmAlQuraYearMonthDayCalculator(),
 ]
 
 ISLAMIC_CALCULATORS: Final[list[_YearMonthDayCalculator]] = [
-    # TODO: Islamic YearMonthDayCalculators
+    _IslamicYearMonthDayCalculator(leap_year_pattern=leap_year_pattern, epoch=epoch)
+    for epoch, leap_year_pattern in itertools.product(IslamicEpoch, IslamicLeapYearPattern)
 ]
 
 ALL_CALCULATORS: Final[list[_YearMonthDayCalculator]] = NON_ISLAMIC_CALCULATORS + ISLAMIC_CALCULATORS

--- a/tests/test_calendar_system.py
+++ b/tests/test_calendar_system.py
@@ -33,6 +33,32 @@ _SUPPORTED_IDS: Final[list[str]] = list(CalendarSystem.ids)
 _SUPPORTED_CALENDARS: Final[list[CalendarSystem]] = [CalendarSystem.for_id(id_) for id_ in _SUPPORTED_IDS]
 
 
+def test_supported_ids() -> None:
+    """This is a manual test to ensure that the Calendar IDs in pyoda time match those in noda time."""
+    noda_time_calendar_ids = [
+        "ISO",
+        "Gregorian",
+        "Coptic",
+        "Badi",
+        "Julian",
+        "Hijri Civil-Indian",
+        "Hijri Civil-Base15",
+        "Hijri Civil-Base16",
+        "Hijri Civil-HabashAlHasib",
+        "Hijri Astronomical-Indian",
+        "Hijri Astronomical-Base15",
+        "Hijri Astronomical-Base16",
+        "Hijri Astronomical-HabashAlHasib",
+        "Persian Simple",
+        "Persian Arithmetic",
+        "Persian Algorithmic",
+        "Um Al Qura",
+        "Hebrew Civil",
+        "Hebrew Scriptural",
+    ]
+    assert sorted(_SUPPORTED_IDS) == sorted(noda_time_calendar_ids)
+
+
 class TestCalendarSystem:
     @pytest.mark.parametrize("calendar", _SUPPORTED_CALENDARS, ids=lambda x: x.id)
     def test_max_date(self, calendar: CalendarSystem) -> None:
@@ -109,10 +135,10 @@ class TestCalendarSystemIds:
     def test_for_ordinal_uncached_invalid(self) -> None:
         # In noda time, they use:
         # `CalendarSystem.ForOrdinalUncached((CalendarOrdinal)9999))`
-        with pytest.raises(ValueError):
-            _CalendarOrdinal(9999)
-        with pytest.raises(ValueError):
-            CalendarSystem._for_ordinal(_CalendarOrdinal.SIZE)
+        with pytest.raises(RuntimeError):
+            CalendarSystem._for_ordinal_uncached(9999)  # type: ignore
+        with pytest.raises(RuntimeError):
+            CalendarSystem._for_ordinal_uncached(_CalendarOrdinal.SIZE)
 
 
 class TestCalendarSystemTestValidation:

--- a/tests/test_local_date.py
+++ b/tests/test_local_date.py
@@ -1,0 +1,17 @@
+from pyoda_time import CalendarSystem, LocalDate, LocalDateTime, LocalTime
+
+
+class TestLocalDate:
+    def test_default_constructor(self) -> None:
+        actual = LocalDate()
+        assert actual == LocalDate(year=1, month=1, day=1)
+
+    def test_combination_with_time(self) -> None:
+        # Test all three approaches in the same test - they're logically equivalent.
+        calendar = CalendarSystem.julian
+        date = LocalDate(year=2014, month=3, day=28, calendar=calendar)
+        time = LocalTime(hour=20, minute=17, second=30)
+        expected = LocalDateTime(year=2014, month=3, day=28, hour=20, minute=17, second=30, calendar=calendar)
+        assert date + time == expected
+        assert date.at(time) == expected
+        assert time.on(date) == expected


### PR DESCRIPTION
- First pass at implementic Islamic, Persian and Um Al Qura calendars.
- Fleshed out `LocalTime`, `LocalDate` and `LocalDateTime` to the extent that is required for calendar tests
- Added TODOs for tests which rely on dotnet's Base Class Library calendars. In Noda Time, these tests are intended to check consistency against BCL implementations of specific calendar systems, but obviously we don't have access to that. I have a couple of ideas about how to create something roughly equivalent to these tests, but I don't want to do any of them in the context of this PR.