### PR TITLE
fix: add missing calendar tests

### DIFF
--- a/pyoda_time/__init__.py
+++ b/pyoda_time/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 __all__: list[str] = [
     "CalendarSystem",
+    "DateAdjusters",
     "DateInterval",
     "DateTimeZone",
     "Duration",
@@ -772,6 +773,20 @@ class CalendarSystem(metaclass=_CalendarSystemMeta):
                 raise RuntimeError(
                     f"CalendarOrdinal '{getattr(ordinal, "name", ordinal)}' not mapped to CalendarSystem."
                 )
+
+
+class DateAdjusters:
+    # TODO: In Noda Time, these are properties which return functions. Any reason not to just use staticmethod?
+
+    @staticmethod
+    def end_of_month(date: LocalDate) -> LocalDate:
+        """A date adjuster to move to the last day of the current month."""
+        return LocalDate(
+            year=date.year,
+            month=date.month,
+            day=date.calendar.get_days_in_month(date.year, date.month),
+            calendar=date.calendar,
+        )
 
 
 @_sealed
@@ -2124,6 +2139,12 @@ class LocalDate:
         :return: The ``LocalDateTime`` representation of the given time on this date.
         """
         return self + time
+
+    # region Formatting
+
+    # TODO: def __str__(self): [requires LocalDatePattern.BclSupport]
+
+    # endregion
 
 
 @_typing.final

--- a/pyoda_time/__init__.py
+++ b/pyoda_time/__init__.py
@@ -2161,12 +2161,11 @@ class LocalDate:
         if era is not None and year_of_era is not None and month is not None and day is not None:
             year = calendar.get_absolute_year(year_of_era, era)
 
-        elif year is not None and month is not None and day is not None:
+        if year is not None and month is not None and day is not None:
             calendar._validate_year_month_day(year, month, day)
             self.__year_month_day_calendar = _YearMonthDayCalendar._ctor(
                 year=year, month=month, day=day, calendar_ordinal=calendar._ordinal
             )
-
         else:
             raise TypeError
 

--- a/pyoda_time/fields.py
+++ b/pyoda_time/fields.py
@@ -1,10 +1,26 @@
+from __future__ import annotations as _annotations
+
 __all__: list[str] = []
 
 import abc as _abc
 import typing as _typing
 
-from pyoda_time import LocalDate as _LocalDate
-from pyoda_time.utility import _Preconditions, _sealed
+from pyoda_time import (
+    LocalDate as _LocalDate,
+)
+from pyoda_time import (
+    LocalDateTime as _LocalDateTime,
+)
+from pyoda_time import (
+    LocalTime as _LocalTime,
+)
+from pyoda_time import (
+    PyodaConstants as _PyodaConstants,
+)
+from pyoda_time import (
+    _YearMonthDayCalendar,
+)
+from pyoda_time.utility import _csharp_modulo, _Preconditions, _sealed, _towards_zero_division
 
 
 class _IDatePeriodField:
@@ -36,6 +52,62 @@ class _IDatePeriodField:
 
 
 @_sealed
+@_typing.final
+class _FixedLengthDatePeriodField(_IDatePeriodField):
+    """Date period field for fixed-length periods (weeks and days)."""
+
+    def __init__(self, unit_days: int) -> None:
+        self.__unit_days = unit_days
+
+    def add(self, local_date: _LocalDate, value: int) -> _LocalDate:
+        if value == 0:
+            return local_date
+        days_to_add = value * self.__unit_days
+        calendar = local_date.calendar
+        # If we know it will be in this year, next year, or the previous year...
+        if 300 > days_to_add > -300:
+            calculator = calendar._year_month_day_calculator
+            year_month_day = local_date._year_month_day
+            year = local_date.year
+            month = local_date.month
+            day = local_date.day
+            new_day_of_month = day + days_to_add
+            if 1 <= new_day_of_month <= calculator._get_days_in_month(year, month):
+                return _LocalDate._ctor(
+                    year_month_day_calendar=_YearMonthDayCalendar._ctor(
+                        year=year, month=month, day=new_day_of_month, calendar_ordinal=calendar._ordinal
+                    )
+                )
+            day_of_year = calculator._get_day_of_year(year_month_day)
+            new_day_of_year = day_of_year + days_to_add
+
+            if new_day_of_year < 1:
+                new_day_of_year += calculator._get_days_in_year(year - 1)
+                year -= 1
+                if year < calculator._min_year:
+                    raise OverflowError("Date computation would underflow the minimum year of the calendar")
+            else:
+                days_in_year = calculator._get_days_in_year(year)
+                if new_day_of_year > days_in_year:
+                    new_day_of_year -= days_in_year
+                    year += 1
+                    if year > calculator._max_year:
+                        raise OverflowError("Date computation would overflow the maximum year of the calendar")
+            return _LocalDate._ctor(
+                year_month_day_calendar=calculator._get_year_month_day(
+                    year=year, day_of_year=new_day_of_year
+                )._with_calendar_ordinal(calendar._ordinal)
+            )
+        # LocalDate constructor will validate
+        days = local_date._days_since_epoch + days_to_add
+        return _LocalDate._ctor(days_since_epoch=days, calendar=calendar)
+
+    def units_between(self, start: _LocalDate, end: _LocalDate) -> int:
+        raise NotImplementedError("requires Period.InternalDaysBetween()")
+
+
+@_sealed
+@_typing.final
 class _MonthsPeriodField(_IDatePeriodField):
     def add(self, local_date: _LocalDate, value: int) -> _LocalDate:
         from pyoda_time import LocalDate
@@ -90,7 +162,65 @@ class _YearsPeriodField(_IDatePeriodField):
 class _DatePeriodFields:
     """All the period fields."""
 
-    # TODO: DaysField
-    # TODO: WeeksField
+    _days_field: _typing.Final[_IDatePeriodField] = _FixedLengthDatePeriodField(1)
+    _weeks_field: _typing.Final[_IDatePeriodField] = _FixedLengthDatePeriodField(7)
     _months_field: _typing.Final[_IDatePeriodField] = _MonthsPeriodField()
     _years_field: _typing.Final[_IDatePeriodField] = _YearsPeriodField()
+
+
+class _TimePeriodFieldMeta(type):
+    @property
+    def _ticks(self) -> _TimePeriodField:
+        return _TimePeriodField(_PyodaConstants.NANOSECONDS_PER_TICK)
+
+
+class _TimePeriodField(metaclass=_TimePeriodFieldMeta):
+    def __init__(self, unit_nanoseconds: int) -> None:
+        self.__unit_nanoseconds = unit_nanoseconds
+        self.__units_per_day = int(_PyodaConstants.NANOSECONDS_PER_DAY / unit_nanoseconds)
+
+    def _add_local_date_time(self, start: _LocalDateTime, units: int) -> _LocalDateTime:
+        time, extra_days = self._add_local_time_with_extra_days(start.time_of_day, units)
+        date = start.date if extra_days == 0 else start.date.plus_days(extra_days)
+        return _LocalDateTime._ctor(local_date=date, local_time=time)
+
+    # TODO: def _add_local_time(self, local_time: _LocalTime, value: int) -> _LocalTime:
+
+    def _add_local_time_with_extra_days(self, local_time: _LocalTime, value: int) -> tuple[_LocalTime, int]:
+        extra_days = 0
+        # TODO: unchecked
+        if value == 0:
+            return local_time, extra_days
+        days = 0
+        # It's possible that there are better ways to do this, but this at least feels simple.
+        if value >= 0:
+            if value >= self.__units_per_day:
+                # TODO: checked
+                # If this overflows, that's fine. (An OverflowException is a reasonable outcome.)
+                # days = checked((int) longDays);
+                value = _csharp_modulo(value, self.__units_per_day)
+            nanos_to_add = value * self.__unit_nanoseconds
+            new_nanos = local_time.nanosecond_of_day + nanos_to_add
+            if new_nanos >= _PyodaConstants.NANOSECONDS_PER_DAY:
+                new_nanos -= _PyodaConstants.NANOSECONDS_PER_DAY
+                # TODO: checked
+                days += 1
+            # TODO: checked
+            extra_days += days
+            return _LocalTime._ctor(nanoseconds=new_nanos), extra_days
+        else:
+            if value <= self.__units_per_day:
+                long_days = _towards_zero_division(value, self.__units_per_day)  # noqa
+                # TODO: checked
+                # If this overflows, that's fine. (An OverflowException is a reasonable outcome.)
+                # days = checked((int) longDays);
+                value = _csharp_modulo(value, self.__units_per_day)
+            nanos_to_add = value * self.__unit_nanoseconds
+            new_nanos = local_time.nanosecond_of_day + nanos_to_add
+            if new_nanos < 0:
+                new_nanos += _PyodaConstants.NANOSECONDS_PER_DAY
+                # TODO: checked
+                days -= 1
+            # TODO: checked
+            extra_days += days
+            return _LocalTime._ctor(nanoseconds=new_nanos), extra_days

--- a/pyoda_time/time_zones.py
+++ b/pyoda_time/time_zones.py
@@ -1,0 +1,233 @@
+from __future__ import annotations as _annotations
+
+import typing as _typing
+
+if _typing.TYPE_CHECKING:
+    from . import (
+        Duration as _Duration,
+    )
+    from . import (
+        Instant as _Instant,
+    )
+    from . import (
+        LocalDateTime as _LocalDateTime,
+    )
+    from . import (
+        Offset as _Offset,
+    )
+    from . import (
+        _LocalInstant,
+    )
+
+from pyoda_time.utility import _hash_code_helper, _Preconditions, _sealed
+
+
+@_sealed
+@_typing.final
+class ZoneInterval:
+    """Represents a range of time for which a particular Offset applies.
+
+    Equality is defined component-wise in terms of all properties: the name, the start and end, and the offsets.
+    There is no ordering defined between zone intervals.
+    """
+
+    @property
+    def _raw_start(self) -> _Instant:
+        """Returns the underlying start instant of this zone interval.
+
+        If the zone interval extends to the beginning of time, the return
+        value will be ``Instant._before_min_value``; this value
+        should *not* be exposed publicly.
+        """
+        return self.__raw_start
+
+    @property
+    def _raw_end(self) -> _Instant:
+        """Returns the underlying end instant of this zone interval.
+
+        If the zone interval extends to the end of time, the return
+        value will be ``Instant._after_max_value``; this value
+        should *not* be exposed publicly.
+        """
+        return self.__raw_end
+
+    @property
+    def standard_offset(self) -> _Offset:
+        """Gets the standard offset for this period.
+
+        This is the offset without any daylight savings contributions.
+        """
+        return self.wall_offset - self.savings
+
+    @property
+    def duration(self) -> _Duration:
+        """The Duration of this zone interval."""
+        return self.end - self.start
+
+    @property
+    def has_start(self) -> bool:
+        """Returns ``True`` if this zone interval has a fixed start point, or ``False`` if it extends to the beginning
+        of time."""
+        return self._raw_start._is_valid
+
+    @property
+    def end(self) -> _Instant:
+        """The last Instant (exclusive) that the Offset applies."""
+        _Preconditions._check_state(self._raw_end._is_valid, "Zone interval extends to the end of time")
+        return self._raw_end
+
+    @property
+    def has_end(self) -> bool:
+        """Returns ``True`` if this zone interval has a fixed end point, or ``False`` if it extends to the beginning of
+        time."""
+        return self._raw_end._is_valid
+
+    @property
+    def iso_local_start(self) -> _LocalDateTime:
+        """Gets the local start time of the interval, as a ``LocalDateTime`` in the ISO calendar."""
+        # Use the Start property to trigger the appropriate end-of-time exception.
+        # Call Plus to trigger an appropriate out-of-range exception.
+        from . import LocalDateTime
+
+        return LocalDateTime._ctor(local_instant=self.start._plus(self.wall_offset))
+
+    @property
+    def iso_local_end(self) -> _LocalDateTime:
+        """Gets the local end time of the interval, as a ``LocalDateTime`` in the ISO calendar."""
+        # Use the End property to trigger the appropriate end-of-time exception.
+        # Call Plus to trigger an appropriate out-of-range exception.
+        from . import LocalDateTime
+
+        return LocalDateTime._ctor(local_instant=self.end._plus(self.wall_offset))
+
+    @property
+    def name(self) -> str:
+        """The name of this offset period (e.g. PST or PDT)."""
+        return self.__name
+
+    @property
+    def wall_offset(self) -> _Offset:
+        """The offset from UTC for this period.
+
+        This includes any daylight savings value.
+        """
+        return self.__wall_offset
+
+    @property
+    def savings(self) -> _Offset:
+        """The daylight savings value for this period."""
+        return self.__savings
+
+    @property
+    def start(self) -> _Instant:
+        """The first Instant that the Offset applies."""
+        _Preconditions._check_state(self._raw_start._is_valid, "Zone interval extends to the beginning of time")
+        return self._raw_start
+
+    # Note: This initialiser is intended to replicate the functionality of both
+    # of the private constructors for the equivalent Noda Time class.
+    def __init__(
+        self,
+        *,
+        name: str,
+        start: _Instant | None = None,
+        end: _Instant | None = None,
+        wall_offset: _Offset,
+        savings: _Offset,
+    ) -> None:
+        from . import Instant
+
+        # Do not expose these defaults in the __init__ signature.
+        if start is None:
+            start = Instant._before_min_value()
+        if end is None:
+            end = Instant._after_max_value()
+
+        _Preconditions._check_not_null(name, "name")
+        _Preconditions._check_argument(
+            start < end, "start", f"The start Instant must be less than the end Instant. start: {start}; end: {end}"
+        )
+        self.__name: _typing.Final[str] = name
+        self.__raw_start: _typing.Final[_Instant] = start
+        self.__raw_end: _typing.Final[_Instant] = end
+        self.__wall_offset: _typing.Final[_Offset] = wall_offset
+        self.__savings: _typing.Final[_Offset] = savings
+        # Work out the corresponding local instants, taking care to "go infinite" appropriately.
+        self.__local_start: _typing.Final[_LocalInstant] = start._safe_plus(wall_offset)
+        self.__local_end: _typing.Final[_LocalInstant] = end._safe_plus(wall_offset)
+
+    def _with_start(self, new_start: _Instant) -> ZoneInterval:
+        """Returns a copy of this zone interval, but with the given start instant."""
+        return ZoneInterval(
+            name=self.name,
+            start=new_start,
+            end=self._raw_end,
+            wall_offset=self.wall_offset,
+            savings=self.savings,
+        )
+
+    def _with_end(self, new_end: _Instant) -> ZoneInterval:
+        """Returns a copy of this zone interval, but with the given end instant."""
+        return ZoneInterval(
+            name=self.name,
+            start=self._raw_start,
+            end=new_end,
+            wall_offset=self.wall_offset,
+            savings=self.savings,
+        )
+
+    # region Contains
+
+    def __contains__(self, instant: _Instant) -> bool:
+        """Determines whether this period contains the given Instant in its range."""
+        # Implementation of ``public bool Contains(Instant instant)``
+        return self._raw_start <= instant < self._raw_end
+
+    def _contains(self, local_instant: _LocalInstant) -> bool:
+        """Determines whether this period contains the given LocalInstant in its range."""
+        # Implementation of ``internal bool Contains(LocalInstant localInstant)``
+        return self.__local_start <= local_instant < self.__local_end
+
+    def _equal_ignore_bounds(self, other: ZoneInterval) -> bool:
+        """Returns whether this zone interval has the same offsets and name as another."""
+        # TODO: Preconditions.DebugCheckNotNull(other, nameof(other));
+        return other.wall_offset == self.wall_offset and other.savings == self.savings
+
+    # endregion
+
+    # region IEquatable<ZoneInterval> Members
+
+    def equals(self, other: ZoneInterval) -> bool:
+        return self == other
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, ZoneInterval)
+            and self.name == other.name
+            and self._raw_start == other._raw_start
+            and self._raw_end == other._raw_end
+            and self.wall_offset == other.wall_offset
+            and self.savings == other.savings
+        ) or NotImplemented
+
+    def __ne__(self, other: object) -> bool:
+        return not self == other
+
+    # endregion
+
+    # region Object overrides
+
+    def __hash__(self) -> int:
+        return _hash_code_helper(
+            self.name,
+            self._raw_start,
+            self._raw_end,
+            self.wall_offset,
+            self.savings,
+        )
+
+    def __str__(self) -> str:
+        # TODO: Only the simplest case in the default culture is covered (kind of)
+        return f"{self.name}: [{self.__raw_start}, {self._raw_end}) {self.wall_offset} ({self.savings})"
+
+    # endregion

--- a/pyoda_time/utility.py
+++ b/pyoda_time/utility.py
@@ -1,3 +1,5 @@
+from __future__ import annotations as _annotations
+
 __all__: list[str] = []
 
 import datetime as _datetime
@@ -167,3 +169,13 @@ def _csharp_modulo(dividend: int, divisor: int) -> int:
     if dividend < 0 < result:
         result -= abs(divisor)
     return result
+
+
+def _hash_code_helper(*values: _typing.Hashable) -> int:
+    """Provides help with generating hash codes."""
+    # In Noda Time, this is a builder pattern struct.
+    multiplier = 37
+    ret = 17
+    for v in values:
+        ret += ret * multiplier + hash(v)
+    return ret

--- a/tests/calendars/test_badi_calendar_system.py
+++ b/tests/calendars/test_badi_calendar_system.py
@@ -1,0 +1,438 @@
+from typing import Final
+
+import pytest
+
+from pyoda_time import CalendarSystem, DateAdjusters, IsoDayOfWeek, LocalDate
+from pyoda_time.calendars import Era, _BadiYearMonthDayCalculator
+from pyoda_time.utility import _Preconditions
+
+
+class TestBadiCalendarSystem:
+    """Tests for the Badíʿ calendar system."""
+
+    # For use with CreateBadíʿDate, this is a notional "month"
+    # containing Ayyam-i-Ha. The days here are represented in month
+    # 18 in LocalDate etc.
+    __AYYAMI_HA_MONTH: Final[int] = 0
+
+    # TODO: def test_badi_epoch(self) -> None: [requires LocalDatePattern.bclsupport]
+
+    # TODO: def test_unix_epoch(self) -> None: [requires DateTimeZone.utc]
+
+    def test_sample_date(self) -> None:
+        badi_calendar: CalendarSystem = CalendarSystem.badi
+        iso: LocalDate = LocalDate(year=2017, month=3, day=4)
+        badi: LocalDate = iso.with_calendar(badi_calendar)
+
+        assert self._badi_month(badi) == 19
+
+        assert badi.era == Era.bahai
+        assert badi.year_of_era == 173
+
+        assert badi.year == 173
+        assert not badi_calendar.is_leap_year(173)
+
+        assert self._badi_day(badi) == 4
+
+        assert badi.day_of_week == IsoDayOfWeek.SATURDAY
+
+    @pytest.mark.parametrize(
+        "g_year,g_month,g_day,b_year,b_month,b_day",
+        [
+            (2016, 2, 26, 172, __AYYAMI_HA_MONTH, 1),
+            (2016, 2, 29, 172, __AYYAMI_HA_MONTH, 4),
+            (2016, 3, 1, 172, 19, 1),
+            (2016, 3, 20, 173, 1, 1),
+            (2016, 3, 21, 173, 1, 2),
+            (2016, 5, 26, 173, 4, 11),
+            (2017, 3, 20, 174, 1, 1),
+            (2018, 3, 21, 175, 1, 1),
+            (2019, 3, 21, 176, 1, 1),
+            (2020, 3, 20, 177, 1, 1),
+            (2021, 3, 20, 178, 1, 1),
+            (2022, 3, 21, 179, 1, 1),
+            (2023, 3, 21, 180, 1, 1),
+            (2024, 3, 20, 181, 1, 1),
+            (2025, 3, 20, 182, 1, 1),
+            (2026, 3, 21, 183, 1, 1),
+            (2027, 3, 21, 184, 1, 1),
+            (2028, 3, 20, 185, 1, 1),
+            (2029, 3, 20, 186, 1, 1),
+            (2030, 3, 20, 187, 1, 1),
+            (2031, 3, 21, 188, 1, 1),
+            (2032, 3, 20, 189, 1, 1),
+            (2033, 3, 20, 190, 1, 1),
+            (2034, 3, 20, 191, 1, 1),
+            (2035, 3, 21, 192, 1, 1),
+            (2036, 3, 20, 193, 1, 1),
+            (2037, 3, 20, 194, 1, 1),
+            (2038, 3, 20, 195, 1, 1),
+            (2039, 3, 21, 196, 1, 1),
+            (2040, 3, 20, 197, 1, 1),
+            (2041, 3, 20, 198, 1, 1),
+            (2042, 3, 20, 199, 1, 1),
+            (2043, 3, 21, 200, 1, 1),
+            (2044, 3, 20, 201, 1, 1),
+            (2045, 3, 20, 202, 1, 1),
+            (2046, 3, 20, 203, 1, 1),
+            (2047, 3, 21, 204, 1, 1),
+            (2048, 3, 20, 205, 1, 1),
+            (2049, 3, 20, 206, 1, 1),
+            (2050, 3, 20, 207, 1, 1),
+            (2051, 3, 21, 208, 1, 1),
+            (2052, 3, 20, 209, 1, 1),
+            (2053, 3, 20, 210, 1, 1),
+            (2054, 3, 20, 211, 1, 1),
+            (2055, 3, 21, 212, 1, 1),
+            (2056, 3, 20, 213, 1, 1),
+            (2057, 3, 20, 214, 1, 1),
+            (2058, 3, 20, 215, 1, 1),
+            (2059, 3, 20, 216, 1, 1),
+            (2060, 3, 20, 217, 1, 1),
+            (2061, 3, 20, 218, 1, 1),
+            (2062, 3, 20, 219, 1, 1),
+            (2063, 3, 20, 220, 1, 1),
+            (2064, 3, 20, 221, 1, 1),
+        ],
+    )
+    def test_general_conversion_near_naw_ruz(
+        self, g_year: int, g_month: int, g_day: int, b_year: int, b_month: int, b_day: int
+    ) -> None:
+        # create in the Badíʿ calendar
+        b_date = self.__create_badi_date(b_year, b_month, b_day)
+        g_date = b_date.with_calendar(CalendarSystem.gregorian)
+        assert g_date.year == g_year
+        assert g_date.month == g_month
+        assert g_date.day == g_day
+
+        # convert to the Badíʿ calendar
+        b_date_2 = LocalDate(year=g_year, month=g_month, day=g_day).with_calendar(CalendarSystem.badi)
+        assert b_date_2.year == b_date.year
+        assert self._badi_month(b_date_2) == b_month
+        assert self._badi_day(b_date_2) == b_day
+
+    @pytest.mark.parametrize(
+        "g_year,g_month,g_day,b_year,b_month,b_day",
+        [
+            (2012, 2, 29, 168, __AYYAMI_HA_MONTH, 4),
+            (2012, 3, 1, 168, __AYYAMI_HA_MONTH, 5),
+            (2015, 3, 1, 171, __AYYAMI_HA_MONTH, 4),
+            (2016, 3, 1, 172, 19, 1),
+            (2016, 3, 19, 172, 19, 19),
+            (2017, 3, 1, 173, 19, 1),
+            (2017, 3, 19, 173, 19, 19),
+            (2018, 2, 24, 174, 18, 19),
+            (2018, 2, 25, 174, __AYYAMI_HA_MONTH, 1),
+            (2018, 3, 1, 174, __AYYAMI_HA_MONTH, 5),
+            (2018, 3, 2, 174, 19, 1),
+            (2018, 3, 19, 174, 19, 18),
+        ],
+    )
+    def test_special_cases(self, g_year: int, g_month: int, g_day: int, b_year: int, b_month: int, b_day: int) -> None:
+        # create in test calendar
+        b_date: LocalDate = self.__create_badi_date(b_year, b_month, b_day)
+
+        # convert to gregorian
+        g_date: LocalDate = b_date.with_calendar(CalendarSystem.gregorian)
+
+        assert f"{g_date.year}-{g_date.month}-{g_date.day}" == f"{g_year}-{g_month}-{g_day}"
+
+    @pytest.mark.parametrize(
+        "b_year,b_month,b_day,g_year,g_month,g_day",
+        [
+            (1, 1, 1, 1844, 3, 21),
+            (169, 1, 1, 2012, 3, 21),
+            (170, 1, 1, 2013, 3, 21),
+            (171, 1, 1, 2014, 3, 21),
+            (172, __AYYAMI_HA_MONTH, 1, 2016, 2, 26),
+            (172, __AYYAMI_HA_MONTH, 2, 2016, 2, 27),
+            (172, __AYYAMI_HA_MONTH, 3, 2016, 2, 28),
+            (172, __AYYAMI_HA_MONTH, 4, 2016, 2, 29),
+            (172, 1, 1, 2015, 3, 21),
+            (172, 17, 18, 2016, 2, 5),
+            (172, 18, 17, 2016, 2, 23),
+            (172, 18, 19, 2016, 2, 25),
+            (172, 19, 1, 2016, 3, 1),
+            (173, 1, 1, 2016, 3, 20),
+            (174, 1, 1, 2017, 3, 20),
+            (175, 1, 1, 2018, 3, 21),
+            (176, 1, 1, 2019, 3, 21),
+            (177, 1, 1, 2020, 3, 20),
+            (178, 1, 1, 2021, 3, 20),
+            (179, 1, 1, 2022, 3, 21),
+            (180, 1, 1, 2023, 3, 21),
+            (181, 1, 1, 2024, 3, 20),
+            (182, 1, 1, 2025, 3, 20),
+            (183, 1, 1, 2026, 3, 21),
+            (184, 1, 1, 2027, 3, 21),
+            (185, 1, 1, 2028, 3, 20),
+            (186, 1, 1, 2029, 3, 20),
+            (187, 1, 1, 2030, 3, 20),
+            (188, 1, 1, 2031, 3, 21),
+            (189, 1, 1, 2032, 3, 20),
+            (190, 1, 1, 2033, 3, 20),
+            (191, 1, 1, 2034, 3, 20),
+            (192, 1, 1, 2035, 3, 21),
+            (193, 1, 1, 2036, 3, 20),
+            (194, 1, 1, 2037, 3, 20),
+            (195, 1, 1, 2038, 3, 20),
+            (196, 1, 1, 2039, 3, 21),
+            (197, 1, 1, 2040, 3, 20),
+            (198, 1, 1, 2041, 3, 20),
+            (199, 1, 1, 2042, 3, 20),
+            (200, 1, 1, 2043, 3, 21),
+            (201, 1, 1, 2044, 3, 20),
+            (202, 1, 1, 2045, 3, 20),
+            (203, 1, 1, 2046, 3, 20),
+            (204, 1, 1, 2047, 3, 21),
+            (205, 1, 1, 2048, 3, 20),
+            (206, 1, 1, 2049, 3, 20),
+            (207, 1, 1, 2050, 3, 20),
+            (208, 1, 1, 2051, 3, 21),
+            (209, 1, 1, 2052, 3, 20),
+            (210, 1, 1, 2053, 3, 20),
+            (211, 1, 1, 2054, 3, 20),
+            (212, 1, 1, 2055, 3, 21),
+            (213, 1, 1, 2056, 3, 20),
+            (214, 1, 1, 2057, 3, 20),
+            (215, 1, 1, 2058, 3, 20),
+            (216, 1, 1, 2059, 3, 20),
+            (217, 1, 1, 2060, 3, 20),
+            (218, 1, 1, 2061, 3, 20),
+            (219, 1, 1, 2062, 3, 20),
+            (220, 1, 1, 2063, 3, 20),
+            (221, 1, 1, 2064, 3, 20),
+        ],
+    )
+    def test_general_w_to_g(self, b_year: int, b_month: int, b_day: int, g_year: int, g_month: int, g_day: int) -> None:
+        # create in this calendar
+        b_date = self.__create_badi_date(b_year, b_month, b_day)
+        g_date = b_date.with_calendar(CalendarSystem.gregorian)
+        assert g_date.year == g_year
+        assert g_date.month == g_month
+        assert g_date.day == g_day
+
+        # convert to this calendar
+        b_date_2 = LocalDate(year=g_year, month=g_month, day=g_day).with_calendar(CalendarSystem.badi)
+        assert b_date_2.year == b_year
+        assert self._badi_month(b_date_2) == b_month
+        assert self._badi_day(b_date_2) == b_day
+
+    @pytest.mark.parametrize(
+        "b_year,days",
+        [
+            (172, 4),
+            (173, 4),
+            (174, 5),
+            (175, 4),
+            (176, 4),
+            (177, 4),
+            (178, 5),
+            (179, 4),
+            (180, 4),
+            (181, 4),
+            (182, 5),
+            (183, 4),
+            (184, 4),
+            (185, 4),
+            (186, 4),
+            (187, 5),
+            (188, 4),
+            (189, 4),
+            (190, 4),
+            (191, 5),
+            (192, 4),
+            (193, 4),
+            (194, 4),
+            (195, 5),
+            (196, 4),
+            (197, 4),
+            (198, 4),
+            (199, 5),
+            (200, 4),
+            (201, 4),
+            (202, 4),
+            (203, 5),
+            (204, 4),
+            (205, 4),
+            (206, 4),
+            (207, 5),
+            (208, 4),
+            (209, 4),
+            (210, 4),
+            (211, 5),
+            (212, 4),
+            (213, 4),
+            (214, 4),
+            (215, 4),
+            (216, 5),
+            (217, 4),
+            (218, 4),
+            (219, 4),
+            (220, 5),
+            (221, 4),
+        ],
+    )
+    def test_days_in_ayyami_ha(self, b_year: int, days: int) -> None:
+        assert _BadiYearMonthDayCalculator._get_days_in_ayyami_ha(b_year) == days
+
+    @pytest.mark.parametrize(
+        "b_year,b_month,b_day,day_of_year",
+        [
+            (165, 1, 1, 1),
+            (170, 1, 1, 1),
+            (172, 1, 1, 1),
+            (175, 1, 1, 1),
+            (173, 18, 1, 17 * 19 + 1),
+            (173, 18, 19, 18 * 19),
+            (173, __AYYAMI_HA_MONTH, 1, 18 * 19 + 1),
+            (173, 19, 1, 18 * 19 + 5),
+            (220, __AYYAMI_HA_MONTH, 1, 18 * 19 + 1),
+            (220, __AYYAMI_HA_MONTH, 5, 18 * 19 + 5),
+            (220, 19, 1, 18 * 19 + 6),
+        ],
+    )
+    def test_day_of_year(self, b_year: int, b_month: int, b_day: int, day_of_year: int) -> None:
+        badi = _BadiYearMonthDayCalculator()
+        assert badi._get_day_of_year(self.__create_badi_date(b_year, b_month, b_day)._year_month_day) == day_of_year
+
+    @pytest.mark.parametrize(
+        "year,month,day,eom_month,eom_day",
+        [
+            (173, 1, 1, 1, 19),
+            (173, 18, 1, __AYYAMI_HA_MONTH, 4),
+            (173, __AYYAMI_HA_MONTH, 1, __AYYAMI_HA_MONTH, 4),
+            (173, 19, 1, 19, 19),
+            (220, 19, 1, 19, 19),
+            (220, 4, 5, 4, 19),
+            (220, 18, 1, __AYYAMI_HA_MONTH, 5),
+            (220, __AYYAMI_HA_MONTH, 1, __AYYAMI_HA_MONTH, 5),
+        ],
+    )
+    def test_end_of_month(self, year: int, month: int, day: int, eom_month: int, eom_day: int) -> None:
+        start: LocalDate = self.__create_badi_date(year, month, day)
+        end: LocalDate = self.__create_badi_date(year, eom_month, eom_day)
+        assert self.as_badi_string(DateAdjusters.end_of_month(start)) == self.as_badi_string(end)
+
+    def test_leap_year(self) -> None:
+        calendar: CalendarSystem = CalendarSystem.badi
+        assert not calendar.is_leap_year(172)
+        assert not calendar.is_leap_year(173)
+        assert calendar.is_leap_year(207)
+        assert calendar.is_leap_year(220)
+
+    def test_get_months_in_year(self) -> None:
+        calendar: CalendarSystem = CalendarSystem.badi
+        assert calendar.get_months_in_year(180) == 19
+
+    def test_create_date_in_ayyami_ha(self) -> None:
+        d1 = self.__create_badi_date(180, 0, 3)
+        d3 = self.__create_badi_date(180, 18, 22)
+
+        assert d3 == d1
+
+    @pytest.mark.parametrize(
+        "year,month,day",
+        [
+            (180, -1, 1),
+            (180, 1, -1),
+            (180, 0, 0),
+            (180, 0, 5),
+            (182, 0, 6),
+            (180, 1, 0),
+            (180, 1, 20),
+            (180, 20, 1),
+        ],
+    )
+    def test_create_date_invalid(self, year: int, month: int, day: int) -> None:
+        with pytest.raises(ValueError):
+            self.__create_badi_date(year, month, day)
+
+    # TODO: Period-based tests
+
+    def test_plus_months_overflow(self) -> None:
+        calendar: CalendarSystem = CalendarSystem.badi
+        early_date: LocalDate = LocalDate(year=calendar.min_year, month=1, day=1, calendar=calendar)
+        late_date: LocalDate = LocalDate(year=calendar.max_year, month=19, day=1, calendar=calendar)
+
+        with pytest.raises(OverflowError):
+            early_date.plus_months(-1)
+        with pytest.raises(OverflowError):
+            late_date.plus_months(1)
+
+    @classmethod
+    def __create_badi_date(cls, year: int, month: int, day: int) -> LocalDate:
+        """Create a ``LocalDate`` in the Badíʿ calendar, treating 0 as the month containing Ayyam-i-Ha.
+
+        :param year: Year in the Badíʿ calendar
+        :param month: Month (use 0 for Ayyam-i-Ha)
+        :param day: Day in month
+        :return: A ``LocalDate`` in the Badíʿ calendar
+        """
+        if month == cls.__AYYAMI_HA_MONTH:
+            _Preconditions._check_argument_range(
+                "day", day, 1, _BadiYearMonthDayCalculator._get_days_in_ayyami_ha(year)
+            )
+            # Move Ayyam-i-Ha days to fall after the last day of month 18.
+            month = _BadiYearMonthDayCalculator._MONTH_18
+            day += _BadiYearMonthDayCalculator._DAYS_IN_MONTH
+        return LocalDate(year=year, month=month, day=day, calendar=CalendarSystem.badi)
+
+    @classmethod
+    def _badi_day(cls, input: LocalDate) -> int:
+        _Preconditions._check_argument(
+            input.calendar == CalendarSystem.badi, "input", "Only valid when using the Badíʿ calendar"
+        )
+
+        if (
+            input.month == _BadiYearMonthDayCalculator._MONTH_18
+            and input.day > _BadiYearMonthDayCalculator._DAYS_IN_MONTH
+        ):
+            return input.day - _BadiYearMonthDayCalculator._DAYS_IN_MONTH
+        return input.day
+
+    @classmethod
+    def _badi_month(cls, input: LocalDate) -> int:
+        """Return the month of this date.
+
+        If in Ayyam-i-Ha, returns 0.
+        """
+        _Preconditions._check_argument(
+            input.calendar == CalendarSystem.badi, "input", "Only valid when using the Badíʿ calendar"
+        )
+        if (
+            input.month == _BadiYearMonthDayCalculator._MONTH_18
+            and input.day > _BadiYearMonthDayCalculator._DAYS_IN_MONTH
+        ):
+            return cls.__AYYAMI_HA_MONTH
+        return input.month
+
+    @classmethod
+    def as_badi_string(cls, input: LocalDate) -> str:
+        """Get a text representation of the date."""
+        year = input.year
+        month = cls._badi_month(input)
+        day = cls._badi_day(input)
+
+        return f"{year}-{month}-{day}"
+
+    def test_helper_method_badi_day(self) -> None:
+        # ensure that this helper method is working
+        assert self._badi_day(self.__create_badi_date(180, 10, 10)) == 10
+        assert self._badi_day(self.__create_badi_date(180, 18, 19)) == 19
+        assert self._badi_day(self.__create_badi_date(180, 0, 3)) == 3
+        assert self._badi_day(self.__create_badi_date(180, 19, 1)) == 1
+
+    def test_helper_method_badi_month(self) -> None:
+        # ensure that this helper method is working
+        assert self._badi_month(self.__create_badi_date(180, 10, 10)) == 10
+        assert self._badi_month(self.__create_badi_date(180, 18, 19)) == 18
+        assert self._badi_month(self.__create_badi_date(180, 0, 3)) == 0
+        assert self._badi_month(self.__create_badi_date(180, 19, 1)) == 19
+
+    def test_helper_method_as_badi_string(self) -> None:
+        # ensure that this helper method is working
+        assert self.as_badi_string(self.__create_badi_date(180, 10, 10)) == "180-10-10"
+        assert self.as_badi_string(self.__create_badi_date(180, 18, 19)) == "180-18-19"
+        assert self.as_badi_string(self.__create_badi_date(180, 0, 3)) == "180-0-3"
+        assert self.as_badi_string(self.__create_badi_date(180, 19, 1)) == "180-19-1"

--- a/tests/calendars/test_coptic_calendar_system.py
+++ b/tests/calendars/test_coptic_calendar_system.py
@@ -1,0 +1,57 @@
+import pytest
+
+from pyoda_time import CalendarSystem, DateTimeZone, IsoDayOfWeek, LocalDateTime, PyodaConstants
+from pyoda_time.calendars import Era
+
+
+class TestCopticCalendarSystem:
+    """Tests for the Coptic calendar system."""
+
+    def test_coptic_epoch(self) -> None:
+        coptic: CalendarSystem = CalendarSystem.coptic
+        coptic_epoch: LocalDateTime = LocalDateTime(1, 1, 1, 0, 0, calendar=coptic)
+
+        julian: CalendarSystem = CalendarSystem.julian
+        converted: LocalDateTime = coptic_epoch.with_calendar(julian)
+
+        expected: LocalDateTime = LocalDateTime(284, 8, 29, 0, 0, calendar=julian)
+        assert converted == expected
+
+    def test_unix_epoch(self) -> None:
+        coptic: CalendarSystem = CalendarSystem.coptic
+        unix_epoch_in_coptic_calendar: LocalDateTime = PyodaConstants.UNIX_EPOCH.in_zone(
+            DateTimeZone.utc, coptic
+        ).local_date_time
+        expected: LocalDateTime = LocalDateTime(1686, 4, 23, 0, 0, calendar=coptic)
+        assert unix_epoch_in_coptic_calendar == expected
+
+    def test_sample_date(self) -> None:
+        coptic_calendar: CalendarSystem = CalendarSystem.coptic
+        iso = LocalDateTime(2004, 6, 9, 0, 0, 0, 0)
+        coptic = iso.with_calendar(coptic_calendar)
+
+        assert coptic.era == Era.anno_martyrum
+        assert coptic.year_of_era == 1720
+
+        assert coptic.year == 1720
+        assert not coptic_calendar.is_leap_year(1720)
+
+        assert coptic.month == 10
+        assert coptic.day == 2
+
+        assert coptic.day_of_week == IsoDayOfWeek.WEDNESDAY
+
+        assert coptic.day_of_year == 9 * 30 + 2
+
+        assert coptic.hour == 0
+        assert coptic.minute == 0
+        assert coptic.second == 0
+        assert coptic.millisecond == 0
+
+    def test_invalid_era(self) -> None:
+        # TODO: This is ArgumentNullException in Noda Time
+        with pytest.raises(TypeError):
+            CalendarSystem.coptic.get_absolute_year(1720, None)  # type: ignore
+        # TODO: This is ArgumentException in Noda Time
+        with pytest.raises(ValueError):
+            CalendarSystem.coptic.get_absolute_year(1720, Era.anno_hegirae)

--- a/tests/calendars/test_era.py
+++ b/tests/calendars/test_era.py
@@ -1,0 +1,15 @@
+import inspect
+
+import pytest
+
+from pyoda_time.calendars import Era, _EraMeta
+
+ALL_ERAS = [getattr(Era, name) for name, member in inspect.getmembers(_EraMeta) if isinstance(member, property)]
+
+
+class TestEra:
+    # TODO: test_resource_presence(self, era: Era) -> None:
+
+    @pytest.mark.parametrize("era", ALL_ERAS, ids=lambda x: x.name)
+    def test_to_string_returns_name(self, era: Era) -> None:
+        assert str(era) == era.name

--- a/tests/calendars/test_gregorian_calendar_system.py
+++ b/tests/calendars/test_gregorian_calendar_system.py
@@ -1,0 +1,26 @@
+from pyoda_time import CalendarSystem, LocalDate, LocalDateTime
+from pyoda_time.calendars import Era
+
+
+class TestGregorianCalendarSystem:
+    def test_leap_year(self) -> None:
+        calendar = CalendarSystem.gregorian
+        assert not calendar.is_leap_year(1900)
+        assert not calendar.is_leap_year(1901)
+        assert calendar.is_leap_year(1904)
+        assert calendar.is_leap_year(1996)
+        assert calendar.is_leap_year(2000)
+        assert not calendar.is_leap_year(2100)
+        assert calendar.is_leap_year(2400)
+
+    def test_era_property(self) -> None:
+        calendar = CalendarSystem.gregorian
+        start_of_era = LocalDateTime(1, 1, 1, 0, 0, 0, calendar=calendar)
+        assert start_of_era.era == Era.common
+        assert start_of_era.plus_ticks(-1).era == Era.before_common
+
+    def test_add_months_boundary_condition(self) -> None:
+        start = LocalDate(year=2017, month=8, day=20)
+        end = start.plus_months(-19)
+        expected = LocalDate(year=2016, month=1, day=20)
+        assert end == expected

--- a/tests/calendars/test_hebrew_calendar_system.py
+++ b/tests/calendars/test_hebrew_calendar_system.py
@@ -58,7 +58,6 @@ class TestHebrewCalendarSystem:
         with pytest.raises(ValueError):
             _HebrewScripturalCalculator._get_days_from_start_of_year_to_start_of_month(5502, 0)
 
-    # TODO: requires LocalDate.plus_months()
     @pytest.mark.parametrize(
         "month_numbering",
         (

--- a/tests/calendars/test_hebrew_ecclesiastical_calculator.py
+++ b/tests/calendars/test_hebrew_ecclesiastical_calculator.py
@@ -1,0 +1,6 @@
+class TestHebrewScripturalCalculator:
+    # TODO: def test_days_in_year(self) -> None: [requires bcl]
+
+    # TODO: test_days_in_month(self) -> None: [requires bcl]
+
+    pass

--- a/tests/calendars/test_islamic_calendar_system.py
+++ b/tests/calendars/test_islamic_calendar_system.py
@@ -340,4 +340,5 @@ class TestIslamicCalendarSystem:
     def test_constructor_invalid_enums_for_coverage(self) -> None:
         with pytest.raises(ValueError):
             _IslamicYearMonthDayCalculator(IslamicLeapYearPattern.BASE15 + 100, IslamicEpoch.ASTRONOMICAL)  # type: ignore
+        with pytest.raises(ValueError):
             _IslamicYearMonthDayCalculator(IslamicLeapYearPattern.BASE15, IslamicEpoch.ASTRONOMICAL + 100)  # type: ignore

--- a/tests/calendars/test_iso_calendar.py
+++ b/tests/calendars/test_iso_calendar.py
@@ -1,0 +1,177 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from pyoda_time import (
+    CalendarSystem,
+    Instant,
+    IsoDayOfWeek,
+    LocalDate,
+    LocalDateTime,
+    PyodaConstants,
+    _LocalInstant,
+    _towards_zero_division,
+)
+from pyoda_time.calendars import Era
+
+ISO: CalendarSystem = CalendarSystem.iso
+
+
+class TestIsoCalendarSystem:
+    UNIX_EPOCH_DATE_TIME = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    TIME_OF_GREAT_ACHIEVEMENT = datetime(2009, 11, 27, 18, 38, 25, 345 * 1000, tzinfo=timezone.utc) + timedelta(
+        microseconds=8765 * 0.1
+    )
+
+    time_of_great_achievement_ticks = 633949439053458765
+    unix_epoch_ticks = 621355968000000000
+
+    def test_fields_of_unix_epoch(self) -> None:
+        # It's easiest to test this using a LocalDateTime in the ISO calendar system.
+        # LocalDateTime just passes everything through anyway.
+        epoch: LocalDateTime = PyodaConstants.UNIX_EPOCH.in_utc().local_date_time
+
+        assert epoch.year == 1970
+        assert epoch.year_of_era == 1970
+        # TODO: Assert.AreEqual(1970, WeekYearRules.Iso.GetWeekYear(epoch.Date));
+        # TODO: Assert.AreEqual(1, WeekYearRules.Iso.GetWeekOfWeekYear(epoch.Date));
+        assert epoch.month == 1
+        assert epoch.day == 1
+        assert epoch.day_of_year == 1
+        assert epoch.day_of_week == IsoDayOfWeek.THURSDAY
+        assert epoch.era == Era.common
+        assert epoch.hour == 0
+        assert epoch.minute == 0
+        assert epoch.second == 0
+        assert epoch.millisecond == 0
+        assert epoch.tick_of_day == 0
+        assert epoch.tick_of_second == 0
+
+    def test_fields_of_great_achievement(self) -> None:
+        # TODO: In Noda Time, `now` is assigned to:
+        #  `Instant.FromUnixTimeTicks((TimeOfGreatAchievement - UnixEpochDateTime).Ticks).InUtc().LocalDateTime;`
+        #  A naive python implementation would use:
+        #  ```
+        #  from pyoda_time.utility import _to_ticks
+        #  Instant.from_unix_time_ticks(
+        #       _to_ticks(self.TIME_OF_GREAT_ACHIEVEMENT) - _to_ticks(self.UNIX_EPOCH_DATE_TIME)
+        #  )
+        #  ```
+        #  But because python's datetime resolution is not as granular as C#'s DateTime,
+        #  this leads to test failures when asserting on anything tick-related.
+        #  So we are using hard-coded, manually-gathered ticks here instead.
+
+        now: LocalDateTime = (
+            Instant.from_unix_time_ticks(self.time_of_great_achievement_ticks - self.unix_epoch_ticks)
+            .in_utc()
+            .local_date_time
+        )
+
+        assert now.year == 2009
+        assert now.year_of_era == 2009
+        # TODO: Assert.AreEqual(2009, WeekYearRules.Iso.GetWeekYear(now.Date));
+        # TODO: Assert.AreEqual(48, WeekYearRules.Iso.GetWeekOfWeekYear(now.Date));
+        assert now.month == 11
+        assert now.day == 27
+        assert now.day_of_year == self.TIME_OF_GREAT_ACHIEVEMENT.timetuple().tm_yday
+        assert now.day_of_week == IsoDayOfWeek.FRIDAY
+        assert now.era == Era.common
+        assert now.hour == 18
+        assert now.minute == 38
+        assert now.second == 25
+        assert now.millisecond == 345
+        assert now.tick_of_second == 3458765
+        assert now.tick_of_day == (
+            18 * PyodaConstants.TICKS_PER_HOUR
+            + 38 * PyodaConstants.TICKS_PER_MINUTE
+            + 25 * PyodaConstants.TICKS_PER_SECOND
+            + 3458765
+        )
+
+    def test_construct_local_instant(self) -> None:
+        local_achievement: _LocalInstant = (
+            LocalDateTime(2009, 11, 27, 18, 38, 25, 345).plus_ticks(8765)._to_local_instant()
+        )
+        bcl_ticks = self.time_of_great_achievement_ticks - self.unix_epoch_ticks
+        bcl_days = _towards_zero_division(bcl_ticks, PyodaConstants.TICKS_PER_DAY)
+        bcl_tick_of_day = bcl_ticks % PyodaConstants.TICKS_PER_DAY
+        assert local_achievement._days_since_epoch == bcl_days
+        assert local_achievement._nanosecond_of_day / PyodaConstants.NANOSECONDS_PER_TICK == bcl_tick_of_day
+
+    def test_is_leap_year(self) -> None:
+        assert CalendarSystem.iso.is_leap_year(2012)
+        assert not CalendarSystem.iso.is_leap_year(2011)
+        assert not CalendarSystem.iso.is_leap_year(2100)
+        assert CalendarSystem.iso.is_leap_year(2000)
+
+    def test_get_days_in_month(self) -> None:
+        assert CalendarSystem.iso.get_days_in_month(2010, 9) == 30
+        assert CalendarSystem.iso.get_days_in_month(2010, 1) == 31
+        assert CalendarSystem.iso.get_days_in_month(2010, 2) == 28
+        assert CalendarSystem.iso.get_days_in_month(2012, 2) == 29
+
+    def test_before_common_era(self) -> None:
+        # Year -1 in absolute terms is 2BCE
+        local_date = LocalDate(year=-1, month=1, day=1)
+        assert local_date.era == Era.before_common
+        assert local_date.year == -1
+        assert local_date.year_of_era == 2
+
+    def test_before_common_era_by_specifying_era(self) -> None:
+        # Year -1 in absolute terms is 2BCE
+        local_date = LocalDate(era=Era.before_common, year_of_era=2, month=1, day=1)
+        assert local_date.era == Era.before_common
+        assert local_date.year == -1
+        assert local_date.year_of_era == 2
+
+
+class TestIsoCalendarEra:
+    def test_get_max_year_of_era(self) -> None:
+        date = LocalDate(year=ISO.max_year, month=1, day=1)
+        assert ISO.get_max_year_of_era(Era.common) == date.year_of_era
+        assert date.era == Era.common
+        date = LocalDate(year=ISO.min_year, month=1, day=1)
+        assert date.year == ISO.min_year
+        assert ISO.get_max_year_of_era(Era.before_common) == date.year_of_era
+        assert date.era == Era.before_common
+
+    def test_get_min_year_of_era(self) -> None:
+        date = LocalDate(year=1, month=1, day=1)
+        assert ISO.get_min_year_of_era(Era.common) == date.year_of_era
+        assert date.era == Era.common
+        date = LocalDate(year=0, month=1, day=1)
+        assert ISO.get_min_year_of_era(Era.before_common) == date.year_of_era
+        assert date.era == Era.before_common
+
+    def test_get_absolute_year(self) -> None:
+        assert ISO.get_absolute_year(1, Era.common) == 1
+        assert ISO.get_absolute_year(1, Era.before_common) == 0
+        assert ISO.get_absolute_year(2, Era.before_common) == -1
+        assert ISO.get_absolute_year(ISO.get_max_year_of_era(Era.common), Era.common) == ISO.max_year
+        assert ISO.get_absolute_year(ISO.get_max_year_of_era(Era.before_common), Era.before_common) == ISO.min_year
+
+
+class TestIsoCalendarSystemFields:
+    # These tests assume that if the method doesn't throw, it's doing the right thing - this
+    # is all tested elsewhere.
+
+    def test_validate_year_month_day_all_values_valid_values_doesnt_throw(self) -> None:
+        ISO._validate_year_month_day(20, 2, 20)
+
+    def test_validate_year_month_day_invalid_year_throws(self) -> None:
+        # TODO: ArgumentOutOfRangeException
+        with pytest.raises(ValueError):
+            ISO._validate_year_month_day(50000, 2, 20)
+
+    def test_get_local_instant_invalid_month_throws(self) -> None:
+        # TODO: ArgumentOutOfRangeException
+        with pytest.raises(ValueError):
+            ISO._validate_year_month_day(2010, 13, 20)
+
+    def test_get_local_instant_29th_of_february_in_non_leap_year_throws(self) -> None:
+        # TODO: ArgumentOutOfRangeException
+        with pytest.raises(ValueError):
+            ISO._validate_year_month_day(2010, 2, 29)
+
+    def test_get_local_instant_29th_of_february_in_leap_year_doesnt_throw(self) -> None:
+        ISO._validate_year_month_day(2012, 2, 29)

--- a/tests/calendars/test_julian_calendar_system.py
+++ b/tests/calendars/test_julian_calendar_system.py
@@ -1,0 +1,60 @@
+from pyoda_time import CalendarSystem, DateTimeZone, LocalDate, LocalDateTime, PyodaConstants
+from pyoda_time.calendars import Era
+
+JULIAN: CalendarSystem = CalendarSystem.julian
+
+
+class TestJulianCalendarSystem:
+    """Tests for the Julian calendar system via JulianYearMonthDayCalculator."""
+
+    def test_epoch(self) -> None:
+        """The Unix epoch is equivalent to December 19th 1969 in the Julian calendar."""
+        julian_epoch: LocalDateTime = PyodaConstants.UNIX_EPOCH.in_zone(DateTimeZone.utc, JULIAN).local_date_time
+        assert julian_epoch.year == 1969
+        assert julian_epoch.month == 12
+        assert julian_epoch.day == 19
+
+    def test_leap_years(self) -> None:
+        assert JULIAN.is_leap_year(1900)  # No 100 year rule...
+        assert not JULIAN.is_leap_year(1901)
+        assert JULIAN.is_leap_year(1904)
+        assert JULIAN.is_leap_year(2000)
+        assert JULIAN.is_leap_year(2100)  # No 100 year rule...
+        assert JULIAN.is_leap_year(2400)
+        # Check 1BC, 5BC etc...
+        assert JULIAN.is_leap_year(0)
+        assert JULIAN.is_leap_year(-4)
+
+
+class TestJulianCalendarSystemEra:
+    def test_get_max_year_of_era(self) -> None:
+        date = LocalDate(year=JULIAN.max_year, month=1, day=1, calendar=JULIAN)
+        assert JULIAN.get_max_year_of_era(Era.common) == date.year_of_era
+        assert date.era == Era.common
+        date = LocalDate(year=JULIAN.min_year, month=1, day=1, calendar=JULIAN)
+        assert date.year == JULIAN.min_year
+        assert JULIAN.get_max_year_of_era(Era.before_common) == date.year_of_era
+        assert date.era == Era.before_common
+
+    def test_get_min_year_of_era(self) -> None:
+        date = LocalDate(year=1, month=1, day=1, calendar=JULIAN)
+        assert JULIAN.get_min_year_of_era(Era.common) == date.year_of_era
+        assert date.era == Era.common
+        date = LocalDate(year=0, month=1, day=1, calendar=JULIAN)
+        assert JULIAN.get_min_year_of_era(Era.before_common) == date.year_of_era
+        assert date.era == Era.before_common
+
+    def test_get_absolute_year(self) -> None:
+        assert JULIAN.get_absolute_year(1, Era.common) == 1
+        assert JULIAN.get_absolute_year(1, Era.before_common) == 0
+        assert JULIAN.get_absolute_year(2, Era.before_common) == -1
+        assert JULIAN.get_absolute_year(JULIAN.get_max_year_of_era(Era.common), Era.common) == JULIAN.max_year
+        assert (
+            JULIAN.get_absolute_year(JULIAN.get_max_year_of_era(Era.before_common), Era.before_common)
+            == JULIAN.min_year
+        )
+
+    def test_era_property(self) -> None:
+        start_of_era = LocalDateTime(1, 1, 1, 0, 0, 0, calendar=JULIAN)
+        assert start_of_era.era == Era.common
+        assert start_of_era.plus_ticks(-1).era == Era.before_common

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -60,7 +60,8 @@ def _validate_input(value: T, equal_value: T, unequal_values: T | Iterable[T], u
 
 
 def test_equals(value: T_IEquatable, equal_value: T_IEquatable, *unequal_values: T_IEquatable) -> None:
-    """A combination of ``TestHelpers.TestEqualsStruct`` and ``TestHelpers.TestObjectEquals`` from Noda Time.
+    """A combination of ``TestHelpers.TestEqualsClass``, ``TestHelpers.TestEqualsStruct`` and
+    ``TestHelpers.TestObjectEquals`` from Noda Time.
 
     In Pyoda Time we don't have structs, so we don't need separate helpers for "value types".
 

--- a/tests/test_instant.py
+++ b/tests/test_instant.py
@@ -315,3 +315,23 @@ class TestInstant:
         )
         actual = start._safe_plus(Offset.from_hours(offset_to_add))
         assert actual == expected
+
+
+class TestInstantFormat:
+    # TODO: def test_to_string_invalid_format(self) -> None:
+
+    def test_to_string_min_value(self) -> None:
+        self.__test_to_string_base(Instant.min_value(), "-9998-01-01T00:00:00Z")
+
+    def test_to_string_max_value(self) -> None:
+        self.__test_to_string_base(Instant.max_value(), "9999-12-31T23:59:59Z")
+
+    def test_to_string_unix_epoch(self) -> None:
+        self.__test_to_string_base(PyodaConstants.UNIX_EPOCH, "1970-01-01T00:00:00Z")
+
+    def test_to_string_padding(self) -> None:
+        self.__test_to_string_base(Instant.from_utc(1, 1, 1, 12, 34, 56), "0001-01-01T12:34:56Z")
+
+    @staticmethod
+    def __test_to_string_base(value: Instant, gvalue: str) -> None:
+        assert str(value) == gvalue

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -31,5 +31,6 @@ def test_public_api_does_not_leak_imports(namespace: types.ModuleType) -> None:
     # Special case for top-level namespace as it is used to import submodules
     if namespace is pyoda_time:
         public_symbols_not_included_in_all_list.remove("calendars")
+        public_symbols_not_included_in_all_list.remove("time_zones")
         public_symbols_not_included_in_all_list.remove("utility")
     assert not public_symbols_not_included_in_all_list

--- a/tests/time_zones/test_zone_interval.py
+++ b/tests/time_zones/test_zone_interval.py
@@ -1,0 +1,227 @@
+import pytest
+
+from pyoda_time import Duration, Instant, LocalDateTime, Offset
+from pyoda_time.time_zones import ZoneInterval
+from tests import helpers
+
+
+class TestZoneInterval:
+    SAMPLE_START = Instant.from_utc(2011, 6, 3, 10, 15)
+    SAMPLE_END = Instant.from_utc(2011, 8, 2, 13, 45)
+
+    SAMPLE_INTERVAL = ZoneInterval(
+        name="TestTime",
+        start=SAMPLE_START,
+        end=SAMPLE_END,
+        wall_offset=Offset.from_hours(9),
+        savings=Offset.from_hours(1),
+    )
+
+    def test_passthrough_properties(self) -> None:
+        assert self.SAMPLE_INTERVAL.name == "TestTime"
+        assert self.SAMPLE_INTERVAL.standard_offset == Offset.from_hours(8)
+        assert self.SAMPLE_INTERVAL.savings == Offset.from_hours(1)
+        assert self.SAMPLE_INTERVAL.wall_offset == Offset.from_hours(9)
+        assert self.SAMPLE_INTERVAL.start == self.SAMPLE_START
+        assert self.SAMPLE_INTERVAL.end == self.SAMPLE_END
+
+    def test_computed_properties(self) -> None:
+        start = LocalDateTime(2011, 6, 3, 19, 15)
+        end = LocalDateTime(2011, 8, 2, 22, 45)
+        assert self.SAMPLE_INTERVAL.iso_local_start == start
+        assert self.SAMPLE_INTERVAL.iso_local_end == end
+        assert self.SAMPLE_INTERVAL.duration == self.SAMPLE_END - self.SAMPLE_START
+
+    def test_contains_instant_normal(self) -> None:
+        assert self.SAMPLE_START in self.SAMPLE_INTERVAL
+        assert self.SAMPLE_END not in self.SAMPLE_INTERVAL
+        assert Instant.min_value() not in self.SAMPLE_INTERVAL
+        assert Instant.max_value() not in self.SAMPLE_INTERVAL
+
+    def test_contains_instant_whole_of_time_via_nullity(self) -> None:
+        interval = ZoneInterval(
+            name="All Time",
+            start=None,
+            end=None,
+            wall_offset=Offset.from_hours(9),
+            savings=Offset.from_hours(1),
+        )
+        assert self.SAMPLE_START in interval
+        assert Instant.min_value() in interval
+        assert Instant.max_value() in interval
+
+    def test_contains_instant_whole_of_time_via_special_instants(self) -> None:
+        interval = ZoneInterval(
+            name="All Time",
+            start=Instant._before_min_value(),
+            end=Instant._after_max_value(),
+            wall_offset=Offset.from_hours(9),
+            savings=Offset.from_hours(1),
+        )
+        assert self.SAMPLE_START in interval
+        assert Instant.min_value() in interval
+        assert Instant.max_value() in interval
+
+    def test_contains_local_instant_whole_of_time(self) -> None:
+        interval = ZoneInterval(
+            name="All Time",
+            start=Instant._before_min_value(),
+            end=Instant._after_max_value(),
+            wall_offset=Offset.from_hours(9),
+            savings=Offset.from_hours(1),
+        )
+        assert interval._contains(self.SAMPLE_START._plus(Offset.zero))
+        assert interval._contains(Instant.min_value()._plus(Offset.zero))
+        assert interval._contains(Instant.max_value()._plus(Offset.zero))
+
+    def test_contains_outside_local_instant_range(self) -> None:
+        very_early = ZoneInterval(
+            name="Very early",
+            start=Instant._before_min_value(),
+            end=Instant.min_value() + Duration.from_hours(8),
+            wall_offset=Offset.from_hours(-9),
+            savings=Offset.zero,
+        )
+        very_late = ZoneInterval(
+            name="Very late",
+            start=Instant.max_value() - Duration.from_hours(8),
+            end=Instant._after_max_value(),
+            wall_offset=Offset.from_hours(9),
+            savings=Offset.zero,
+        )
+        # The instants are contained...
+        assert (Instant.min_value() + Duration.from_hours(4)) in very_early
+        assert (Instant.max_value() - Duration.from_hours(4)) in very_late
+        # But there are no valid local instants
+        assert not very_early._contains(Instant.min_value()._plus(Offset.zero))
+        assert not very_early._contains(Instant.max_value()._plus(Offset.zero))
+
+    def test_iso_local_start_and_end_infinite(self) -> None:
+        interval = ZoneInterval(
+            name="All time",
+            start=None,
+            end=None,
+            wall_offset=Offset.zero,
+            savings=Offset.zero,
+        )
+        with pytest.raises(RuntimeError):
+            str(interval.iso_local_start)
+        with pytest.raises(RuntimeError):
+            str(interval.iso_local_end)
+
+    def test_iso_local_start_and_end_out_of_range(self) -> None:
+        interval = ZoneInterval(
+            name="All time",
+            start=Instant.min_value(),
+            end=None,
+            wall_offset=Offset.from_hours(-1),
+            savings=Offset.zero,
+        )
+        with pytest.raises(OverflowError):
+            str(interval.iso_local_start)
+        interval = ZoneInterval(
+            name="All time",
+            start=None,
+            end=Instant.max_value(),
+            wall_offset=Offset.from_hours(11),
+            savings=Offset.zero,
+        )
+        with pytest.raises(OverflowError):
+            str(interval.iso_local_end)
+
+    def test_equality(self) -> None:
+        helpers.test_equals(
+            # Equal values
+            ZoneInterval(
+                name="name",
+                start=self.SAMPLE_START,
+                end=self.SAMPLE_END,
+                wall_offset=Offset.from_hours(1),
+                savings=Offset.from_hours(2),
+            ),
+            ZoneInterval(
+                name="name",
+                start=self.SAMPLE_START,
+                end=self.SAMPLE_END,
+                wall_offset=Offset.from_hours(1),
+                savings=Offset.from_hours(2),
+            ),
+            # Unequal values
+            ZoneInterval(
+                name="name2",
+                start=self.SAMPLE_START,
+                end=self.SAMPLE_END,
+                wall_offset=Offset.from_hours(1),
+                savings=Offset.from_hours(2),
+            ),
+            ZoneInterval(
+                name="name",
+                start=self.SAMPLE_START.plus_nanoseconds(1),
+                end=self.SAMPLE_END,
+                wall_offset=Offset.from_hours(1),
+                savings=Offset.from_hours(2),
+            ),
+            ZoneInterval(
+                name="name",
+                start=self.SAMPLE_START,
+                end=self.SAMPLE_END.plus_nanoseconds(1),
+                wall_offset=Offset.from_hours(1),
+                savings=Offset.from_hours(2),
+            ),
+            ZoneInterval(
+                name="name",
+                start=self.SAMPLE_START,
+                end=self.SAMPLE_END,
+                wall_offset=Offset.from_hours(2),
+                savings=Offset.from_hours(2),
+            ),
+            ZoneInterval(
+                name="name",
+                start=self.SAMPLE_START,
+                end=self.SAMPLE_END,
+                wall_offset=Offset.from_hours(1),
+                savings=Offset.from_hours(3),
+            ),
+        )
+
+    def test_equality_operators(self) -> None:
+        val1 = ZoneInterval(
+            name="name",
+            start=self.SAMPLE_START,
+            end=self.SAMPLE_END,
+            wall_offset=Offset.from_hours(1),
+            savings=Offset.from_hours(2),
+        )
+        val2 = ZoneInterval(
+            name="name",
+            start=self.SAMPLE_START,
+            end=self.SAMPLE_END,
+            wall_offset=Offset.from_hours(1),
+            savings=Offset.from_hours(2),
+        )
+        val3 = ZoneInterval(
+            name="name2",
+            start=self.SAMPLE_START,
+            end=self.SAMPLE_END,
+            wall_offset=Offset.from_hours(1),
+            savings=Offset.from_hours(2),
+        )
+        val4 = None
+
+        assert val1 == val2
+        assert not val1 == val3
+        assert not val1 == val4
+        assert not val4 == val1
+        assert not val4 != None  # noqa
+        assert None == val4  # noqa
+
+        assert not val1 != val2
+        assert val1 != val3
+        assert val1 != val4
+        assert val4 != val1
+        assert not val4 != None  # noqa
+        assert not None != val4  # noqa
+
+    def test_zone_interval_to_string(self) -> None:
+        # TODO: Only the simplest case in the default culture is covered (kind of)
+        assert self.SAMPLE_INTERVAL.__str__() == "TestTime: [2011-06-03T10:15:00Z, 2011-08-02T13:45:00Z) +09 (+01)"


### PR DESCRIPTION
Ports heretofore absent tests from the `NodaTime.Test.Calendars` namespace.