### PR TITLE
fix: remove v3 release-please config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: release
 on:
-  workflow_dispatch:
   push:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   release:
@@ -17,22 +17,6 @@ jobs:
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           release-type: python
-          package-name: pyoda-time
-          changelog-types: >
-            [
-              {"type": "build", "section": "🏗️ Build System", "hidden": true},
-              {"type": "chore", "section": "🧹 Miscellaneous Chores", "hidden": true},
-              {"type": "ci", "section": "👷 Continuous Integration", "hidden": true},
-              {"type": "docs", "section": "📝 Documentation"},
-              {"type": "feat", "section": "🚀 Features"},
-              {"type": "fix", "section": "🐛 Bug Fixes"},
-              {"type": "perf", "section": "⚡ Performance Improvements"},
-              {"type": "refactor", "section": "♻️ Code Refactoring", "hidden": true},
-              {"type": "revert", "section": "⏪️ Reverts"},
-              {"type": "style", "section": "💄 Styles", "hidden": true},
-              {"type": "test", "section": "✅ Tests", "hidden": true}
-            ]
-          include-v-in-tag: false
 
   publish:
     name: publish


### PR DESCRIPTION
Now that this project is on release-please-action v4.x, the "advanced configuration" has been [moved to json config/manifest files](https://github.com/google-github-actions/release-please-action#upgrading-from-v3-to-v4). I don't particularly want the "advanced" stuff, so I'm going with a more minimal setup.