### PR TITLE
feat: Implement `Duration`

### DIFF
--- a/pyoda_time/__init__.py
+++ b/pyoda_time/__init__.py
@@ -30,6 +30,7 @@ __all__: list[str] = [
 
 import abc as _abc
 import datetime as _datetime
+import decimal as _decimal
 import enum as _enum
 import functools as _functools
 import typing as _typing
@@ -115,6 +116,16 @@ class PyodaConstants(metaclass=_PyodaConstantsMeta):
     TICKS_PER_HOUR: _typing.Final[int] = TICKS_PER_MINUTE * MINUTES_PER_HOUR
     TICKS_PER_DAY: _typing.Final[int] = TICKS_PER_HOUR * HOURS_PER_DAY
     TICKS_PER_WEEK: _typing.Final[int] = TICKS_PER_DAY * DAYS_PER_WEEK
+
+    # Constants which are specific to Pyoda Time
+    NANOSECONDS_PER_MICROSECOND: _typing.Final[int] = 1000
+    TICKS_PER_MICROSECOND: _typing.Final[int] = 10
+    MICROSECONDS_PER_MILLISECOND: _typing.Final[int] = 1000
+    MICROSECONDS_PER_SECOND: _typing.Final[int] = MICROSECONDS_PER_MILLISECOND * MILLISECONDS_PER_SECOND
+    MICROSECONDS_PER_MINUTE: _typing.Final[int] = MICROSECONDS_PER_SECOND * SECONDS_PER_MINUTE
+    MICROSECONDS_PER_HOUR: _typing.Final[int] = MICROSECONDS_PER_MINUTE * MINUTES_PER_HOUR
+    MICROSECONDS_PER_DAY: _typing.Final[int] = MICROSECONDS_PER_HOUR * HOURS_PER_DAY
+    MICROSECONDS_PER_WEEK: _typing.Final[int] = MICROSECONDS_PER_DAY * DAYS_PER_WEEK
 
 
 class _CalendarOrdinal(_enum.IntEnum):
@@ -925,13 +936,43 @@ class _DurationMeta(type):
     # TODO: In Noda Time, these properties use the private ctor which bypasses validation
 
     @property
-    def one_day(self) -> Duration:
-        return Duration._ctor(days=1, nano_of_day=0)
-
-    @property
     def zero(cls) -> Duration:
         """Gets a zero Duration of 0 nanoseconds."""
         return Duration()
+
+    @property
+    def epsilon(cls) -> Duration:
+        """Return a Duration representing 1 nanosecond.
+
+        This is the smallest amount by which an instant can vary.
+        """
+        return Duration._ctor(days=0, nano_of_day=1)
+
+    @property
+    def max_value(self) -> Duration:
+        """The maximum value supported by ``Duration``."""
+        return Duration._ctor(days=Duration._MAX_DAYS, nano_of_day=PyodaConstants.NANOSECONDS_PER_DAY - 1)
+
+    @property
+    def min_value(self) -> Duration:
+        """The minimum value supported by ``Duration``."""
+        return Duration._ctor(days=Duration._MIN_DAYS, nano_of_day=0)
+
+    @property
+    def one_week(self) -> Duration:
+        """Return a ``Duration`` equal to the number of nanoseconds in 1 standard week (7 days).
+
+        equal to the number of nanoseconds in 1 standard week (7 days).
+        """
+        return Duration._ctor(days=7, nano_of_day=0)
+
+    @property
+    def one_day(self) -> Duration:
+        """Represents the ``Duration`` value equal to the number of nanoseconds in 1 day.
+
+        The value of this property is 86.4 trillion nanoseconds; that is, 86,400,000,000,000 nanoseconds.
+        """
+        return Duration._ctor(days=1, nano_of_day=0)
 
 
 @_typing.final
@@ -939,15 +980,25 @@ class _DurationMeta(type):
 class Duration(metaclass=_DurationMeta):
     """Represents a fixed (and calendar-independent) length of time."""
 
-    _MAX_DAYS: _typing.Final[int] = (1 << 24) - 1
+    # TODO: Noda Time's Duration class defines MaxDays as `(1 << 24) - 1` and MinDays as
+    #  `~MaxDays`. However, that range is not sufficiently large for timedelta conversion.
+    #  The thinking here is to retain the flavour of the Noda Time implementation, while
+    #  accommodating the range of the standard way of representing durations in Python.
+    _MAX_DAYS: _typing.Final[int] = (1 << 30) - 1
     _MIN_DAYS: _typing.Final[int] = ~_MAX_DAYS
+
+    _MIN_NANOSECONDS: _typing.Final[int] = _MIN_DAYS * PyodaConstants.NANOSECONDS_PER_DAY
+    _MAX_NANOSECONDS: _typing.Final[int] = ((_MAX_DAYS + 1) * PyodaConstants.NANOSECONDS_PER_DAY) - 1
+
+    _MIN_DECIMAL_NANOSECONDS: _typing.Final[_decimal.Decimal] = _decimal.Decimal(_MIN_NANOSECONDS)
+    _MAX_DECIMAL_NANOSECONDS: _typing.Final[_decimal.Decimal] = _decimal.Decimal(_MAX_NANOSECONDS)
 
     def __init__(self) -> None:
         self.__days = 0
         self.__nano_of_day = 0
 
     @classmethod
-    def _ctor(cls, *, days: int, nano_of_day: int) -> Duration:
+    def _ctor(cls, *, days: int, nano_of_day: int = 0) -> Duration:
         if days < cls._MIN_DAYS or days > cls._MAX_DAYS:
             _Preconditions._check_argument_range("days", days, cls._MIN_DAYS, cls._MAX_DAYS)
         # TODO: _Precondition._debug_check_argument_range()
@@ -1012,6 +1063,7 @@ class Duration(metaclass=_DurationMeta):
             and units_per_day is not None
             and nanos_per_unit is not None
         ):
+            _Preconditions._check_argument_range(param_name, units, min_value, max_value)
             self.__days = _towards_zero_division(units, units_per_day)
             unit_of_day = units - (units_per_day * self.__days)
             if unit_of_day < 0:
@@ -1021,37 +1073,6 @@ class Duration(metaclass=_DurationMeta):
         else:
             raise TypeError
         return self
-
-    def __le__(self, other: Duration) -> bool:
-        if isinstance(other, Duration):
-            return self < other or self == other
-        return NotImplemented
-
-    def __lt__(self, other: Duration) -> bool:
-        if isinstance(other, Duration):
-            return self.__days < other.__days or (
-                self.__days == other.__days and self.__nano_of_day < other.__nano_of_day
-            )
-        return NotImplemented
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, Duration):
-            return self.__days == other.__days and self.__nano_of_day == other.__nano_of_day
-        return NotImplemented
-
-    def __neg__(self) -> Duration:
-        old_days = self.__days
-        old_nano_of_day = self.__nano_of_day
-        if old_nano_of_day == 0:
-            return Duration._ctor(days=-old_days, nano_of_day=0)
-        new_nano_of_day = PyodaConstants.NANOSECONDS_PER_DAY - old_nano_of_day
-        return Duration._ctor(days=-old_days - 1, nano_of_day=new_nano_of_day)
-
-    @staticmethod
-    def from_ticks(ticks: int) -> Duration:
-        """Returns a Duration that represents the given number of ticks."""
-        days, tick_of_day = _TickArithmetic.ticks_to_days_and_tick_of_day(ticks)
-        return Duration._ctor(days=days, nano_of_day=tick_of_day * PyodaConstants.NANOSECONDS_PER_TICK)
 
     @property
     def _floor_days(self) -> int:
@@ -1066,76 +1087,182 @@ class Duration(metaclass=_DurationMeta):
         """
         return self.__nano_of_day
 
-    @classmethod
-    def from_milliseconds(cls, milliseconds: int) -> Duration:
-        """Returns a Duration that represents the given number of milliseconds."""
-        return cls.__ctor(
-            units=milliseconds,
-            param_name="milliseconds",
-            min_value=cls._MIN_DAYS * PyodaConstants.MILLISECONDS_PER_DAY,
-            max_value=((cls._MAX_DAYS + 1) * PyodaConstants.MILLISECONDS_PER_DAY) - 1,
-            units_per_day=PyodaConstants.MILLISECONDS_PER_DAY,
-            nanos_per_unit=PyodaConstants.NANOSECONDS_PER_MILLISECOND,
-        )
+    @property
+    def days(self) -> int:
+        """The whole number of standard (24 hour) days within the duration.
 
-    @classmethod
-    def from_seconds(cls, seconds: int) -> Duration:
-        return cls.__ctor(
-            units=seconds,
-            param_name="seconds",
-            min_value=cls._MIN_DAYS * PyodaConstants.SECONDS_PER_DAY,
-            max_value=cls._MAX_DAYS + 1,
-            units_per_day=PyodaConstants.SECONDS_PER_DAY,
-            nanos_per_unit=PyodaConstants.NANOSECONDS_PER_SECOND,
-        )
-
-    def __add__(self, other: Duration) -> Duration:
-        if isinstance(other, Duration):
-            days = self.__days + other.__days
-            nanos = self.__nano_of_day + other.__nano_of_day
-            if nanos >= PyodaConstants.NANOSECONDS_PER_DAY:
-                days += 1
-                nanos -= PyodaConstants.NANOSECONDS_PER_DAY
-            return Duration._ctor(days=days, nano_of_day=nanos)
-        return NotImplemented
-
-    def __sub__(self, other: Duration) -> Duration:
-        if isinstance(other, Duration):
-            days = self.__days - other.__days
-            nanos = self.__nano_of_day - other.__nano_of_day
-            if nanos < 0:
-                days -= 1
-                nanos += PyodaConstants.NANOSECONDS_PER_DAY
-            return Duration._ctor(days=days, nano_of_day=nanos)
-        return NotImplemented
-
-    @classmethod
-    def epsilon(cls) -> Duration:
-        """Return a Duration representing 1 nanosecond.
-
-        This is the smallest amount by which an instant can vary.
+        This is truncated towards zero; For example, "-1.75 days" and "1.75 days" would have results of -1 and 1
+        respectively.
         """
-        return cls._ctor(days=0, nano_of_day=1)
+        return self.__days if self.__days >= 0 or self.__nano_of_day == 0 else self.__days + 1
 
-    @classmethod
-    def from_nanoseconds(cls, nanoseconds: int) -> Duration:  # TODO from_nanoseconds overrides
-        """Returns a Duration that represents the given number of nanoseconds."""
-        if nanoseconds >= 0:
-            # TODO Is divmod compatible with C# integer division?
-            quotient, remainder = divmod(nanoseconds, PyodaConstants.NANOSECONDS_PER_DAY)
-            return cls._ctor(days=quotient, nano_of_day=remainder)
+    @property
+    def nanosecond_of_day(self) -> int:
+        """The number of nanoseconds within the day of this duration.
 
-        # Work out the "floor days"; division truncates towards zero and
-        # nanoseconds is definitely negative by now, hence the addition and subtraction here.
-        days = _towards_zero_division(nanoseconds + 1, PyodaConstants.NANOSECONDS_PER_DAY) - 1
-        nano_of_day = nanoseconds - days * PyodaConstants.NANOSECONDS_PER_DAY
-        return Duration._ctor(days=days, nano_of_day=nano_of_day)
+        For negative durations, this will be negative (or zero).
+        """
+        if self.__days >= 0:
+            return self.__nano_of_day
+        if self.__nano_of_day == 0:
+            return 0
+        return self.__nano_of_day - PyodaConstants.NANOSECONDS_PER_DAY
 
-    @classmethod
-    def from_hours(cls, hours: int) -> Duration:
-        """Returns a Duration that represents the given number of hours."""
-        # TODO this is a shortcut and differs from Noda Time
-        return Duration.from_seconds(hours * PyodaConstants.SECONDS_PER_HOUR)
+    @property
+    def hours(self) -> int:
+        """The hour component of this duration, in the range [-23, 23], truncated towards zero."""
+        return _towards_zero_division(self.nanosecond_of_day, PyodaConstants.NANOSECONDS_PER_HOUR)
+
+    @property
+    def minutes(self) -> int:
+        """The minute component of this duration, in the range [-59, 59], truncated towards zero."""
+        return _csharp_modulo(
+            _towards_zero_division(self.nanosecond_of_day, PyodaConstants.NANOSECONDS_PER_MINUTE),
+            PyodaConstants.MINUTES_PER_HOUR,
+        )
+
+    @property
+    def seconds(self) -> int:
+        """The second component of this duration, in the range [-59, 59], truncated towards zero."""
+        return _csharp_modulo(
+            _towards_zero_division(self.nanosecond_of_day, PyodaConstants.NANOSECONDS_PER_SECOND),
+            PyodaConstants.SECONDS_PER_MINUTE,
+        )
+
+    @property
+    def milliseconds(self) -> int:
+        """The subsecond component of this duration, expressed in milliseconds, in the range [-999, 999] and truncated
+        towards zero."""
+        return _csharp_modulo(
+            _towards_zero_division(self.nanosecond_of_day, PyodaConstants.NANOSECONDS_PER_MILLISECOND),
+            PyodaConstants.MILLISECONDS_PER_SECOND,
+        )
+
+    @property
+    def microseconds(self) -> int:
+        """The subsecond component of this duration, expressed in microseconds, in the range [-999999, 999999] and
+        truncated towards zero."""
+        return _csharp_modulo(
+            _towards_zero_division(self.nanosecond_of_day, PyodaConstants.NANOSECONDS_PER_MICROSECOND),
+            PyodaConstants.MICROSECONDS_PER_SECOND,
+        )
+
+    @property
+    def subsecond_ticks(self) -> int:
+        """The subsecond component of this duration, expressed in ticks, in the range [-9999999, 9999999] and truncated
+        towards zero."""
+        return _csharp_modulo(
+            _towards_zero_division(self.nanosecond_of_day, PyodaConstants.NANOSECONDS_PER_TICK),
+            PyodaConstants.TICKS_PER_SECOND,
+        )
+
+    @property
+    def subsecond_nanoseconds(self) -> int:
+        """The subsecond component of this duration, expressed in nanoseconds, in the range [-999999999, 999999999]."""
+        return _csharp_modulo(self.nanosecond_of_day, PyodaConstants.NANOSECONDS_PER_SECOND)
+
+    @property
+    def bcl_compatible_ticks(self) -> int:
+        """The total number of ticks in the duration, truncated towards zero where necessary.
+
+        Within the constraints specified below, this property is intended to be equivalent to .NET's ``TimeSpan.Ticks``.
+
+        If the number of nanoseconds in a duration is not a whole number of ticks, it is truncated towards zero.
+        For example, durations in the range [-99ns, 99ns] would all count as 0 ticks.
+
+        See also: total_ticks()
+        """
+        ticks = _TickArithmetic.days_and_tick_of_day_to_ticks(
+            self.__days, _towards_zero_division(self.__nano_of_day, PyodaConstants.NANOSECONDS_PER_TICK)
+        )
+        if self.__days < 0 and self.__nano_of_day % PyodaConstants.NANOSECONDS_PER_TICK != 0:
+            ticks += 1
+        return ticks
+
+    @property
+    def total_days(self) -> float:
+        """The total number of days in this duration, as a ``float``.
+
+        This property is the ``Duration`` equivalent of ``TimeSpan.TotalDays``.
+        It represents the complete duration in days, rather than only the whole number of
+        days. For example, for a duration of 36 hours, this property would return 1.5.
+        """
+        return self.__days + self.__nano_of_day / PyodaConstants.NANOSECONDS_PER_DAY
+
+    @property
+    def total_hours(self) -> float:
+        """The total number of hours in this duration, as a ``float``.
+
+        This property is the ``Duration`` equivalent of ``TimeSpan.TotalHours``.
+        Unlike ``hours``, it represents the complete duration in hours rather than the
+        whole number of hours as part of the day. So for a duration
+        of 1 day, 2 hours and 30 minutes, the ``hours`` property will return 2, but ``total_hours``
+        will return 26.5.
+        """
+        return self.__days * 24.0 + self.__nano_of_day / PyodaConstants.NANOSECONDS_PER_HOUR
+
+    @property
+    def total_minutes(self) -> float:
+        """The total number of minutes in this duration, as a ``float``.
+
+        This property is the ``Duration`` equivalent of ``TimeSpan.TotalMinutes``.
+        Unlike ``minutes``, it represents the complete duration in minutes rather than
+        the whole number of minutes within the hour. So for a duration
+        of 2 hours, 30 minutes and 45 seconds, the ``minutes`` property will return 30, but ``total_minutes``
+        will return 150.75.
+        """
+        return self.__days * PyodaConstants.MINUTES_PER_DAY + self.__nano_of_day / PyodaConstants.NANOSECONDS_PER_MINUTE
+
+    @property
+    def total_seconds(self) -> float:
+        """The total number of seconds in this duration, as a ``float``.
+
+        This property is the <c>Duration</c> equivalent of <see cref="TimeSpan.TotalSeconds"/>.
+        Unlike ``seconds``, it represents the complete duration in seconds rather than
+        the whole number of seconds within the minute. So for a duration
+        of 10 minutes, 20 seconds and 250 milliseconds, the ``seconds`` property will return 20, but ``total_seconds``
+        will return 620.25.
+        """
+        return self.__days * PyodaConstants.SECONDS_PER_DAY + self.__nano_of_day / PyodaConstants.NANOSECONDS_PER_SECOND
+
+    @property
+    def total_milliseconds(self) -> float:
+        """The total number of milliseconds in this duration, as a ``float``.
+
+        This property is the ``Duration`` equivalent of ``TimeSpan.TotalMilliseconds``.
+        Unlike ``milliseconds``, it represents the complete duration in milliseconds rather than
+        the whole number of milliseconds within the second. So for a duration
+        of 10 minutes, 20 seconds and 250 milliseconds, the ``milliseconds`` property will return
+        250, but ``total_milliseconds`` will return 620250.
+        """
+        return (
+            self.__days * PyodaConstants.MILLISECONDS_PER_DAY
+            + self.__nano_of_day / PyodaConstants.NANOSECONDS_PER_MILLISECOND
+        )
+
+    @property
+    def total_microseconds(self) -> float:
+        # TODO: docstring
+        return self.total_ticks / PyodaConstants.TICKS_PER_MICROSECOND
+
+    @property
+    def total_ticks(self) -> float:
+        """The total number of ticks in this duration, as a ``float``.
+
+        This property is the ``Duration`` equivalent of ``TimeSpan.Ticks``.
+        """
+        return self.__days * PyodaConstants.TICKS_PER_DAY + self.__nano_of_day / PyodaConstants.NANOSECONDS_PER_TICK
+
+    @property
+    def total_nanoseconds(self) -> float:
+        """The total number of nanoseconds in this duration, as a ``float``.
+
+        The result is always an integer, but may not be precise due to the limitations
+        of the ``float`` type. In other words, ``Duration.from_nanoseconds(duration.total_nanoseconds)``
+        is not guaranteed to round-trip. To guarantee precision and round-tripping,
+        use ``to_nanoseconds()`` and ``from_nanoseconds()``.
+        """
+        return self.__days * PyodaConstants.NANOSECONDS_PER_DAY + self.__nano_of_day
 
     def _plus_small_nanoseconds(self, small_nanos: int) -> Duration:
         """Adds a "small" number of nanoseconds to this duration.
@@ -1156,6 +1283,10 @@ class Duration(metaclass=_DurationMeta):
         return Duration._ctor(days=new_days, nano_of_day=new_nanos)
 
     def _minus_small_nanoseconds(self, small_nanos: int) -> Duration:
+        """Subtracts a "small" number of nanoseconds from this duration.
+
+        It is trusted to be less or equal to than 24 hours in magnitude.
+        """
         # TODO: unchecked
         # TODO: Preconditions.DebugCheckArgumentRange
         new_days = self.__days
@@ -1168,8 +1299,479 @@ class Duration(metaclass=_DurationMeta):
             new_nanos += PyodaConstants.NANOSECONDS_PER_DAY
         return Duration._ctor(days=new_days, nano_of_day=new_nanos)
 
+    # region Object overrides
+
     def __hash__(self) -> int:
         return self.__days ^ hash(self.__nano_of_day)
+
+    # endregion Object overrides
+
+    # region Formatting
+
+    # TODO: Duration.ToString() [requires DurationPattern]
+
+    # endregion Formatting
+
+    # region Operators
+
+    def __add__(self, other: Duration) -> Duration:
+        if isinstance(other, Duration):
+            # TODO: unchecked
+            days = self.__days + other.__days
+            nanos = self.__nano_of_day + other.__nano_of_day
+            if nanos >= PyodaConstants.NANOSECONDS_PER_DAY:
+                days += 1
+                nanos -= PyodaConstants.NANOSECONDS_PER_DAY
+            # nanoOfDay is always non-negative (and much less than half of long.MaxValue), so adding two
+            # of them together will never produce a negative result.
+            return Duration._ctor(days=days, nano_of_day=nanos)
+        return NotImplemented
+
+    @staticmethod
+    def add(left: Duration, right: Duration) -> Duration:
+        """Adds one duration to another. Friendly alternative to ``__add__``.
+
+        :param left: The left hand side of the operator.
+        :param right: The right hand side of the operator.
+        :return: A new ``Duration`` representing the sum of the given values.
+        """
+        return left + right
+
+    def plus(self, other: Duration) -> Duration:
+        """Returns the result of adding another duration to this one, for a fluent alternative to ``__add__``.
+
+        :param other: The duration to add
+        :return: A new ``Duration`` representing the result of the addition.
+        """
+        return self + other
+
+    def __sub__(self, other: Duration) -> Duration:
+        if isinstance(other, Duration):
+            days = self.__days - other.__days
+            nanos = self.__nano_of_day - other.__nano_of_day
+            if nanos < 0:
+                days -= 1
+                nanos += PyodaConstants.NANOSECONDS_PER_DAY
+            return Duration._ctor(days=days, nano_of_day=nanos)
+        return NotImplemented
+
+    @staticmethod
+    def subtract(left: Duration, right: Duration) -> Duration:
+        """Subtracts one duration from another. Friendly alternative to ``__add__``.
+
+        :param left: The left hand side of the operator.
+        :param right: The right hand side of the operator.
+        :return: A new ``Duration`` representing the difference of the given values.
+        """
+        return left - right
+
+    def minus(self, other: Duration) -> Duration:
+        """Returns the result of subtracting another duration from this one, for a fluent alternative to ``__sub__``.
+
+        :param other: The duration to subtract
+        :return: A new ``Duration`` representing the result of the subtraction.
+        """
+        return self - other
+
+    @_typing.overload
+    def __truediv__(self, other: int | float) -> Duration:
+        ...
+
+    @_typing.overload
+    def __truediv__(self, other: Duration) -> float:
+        ...
+
+    def __truediv__(self, other: int | float | Duration) -> Duration | float:
+        # TODO: This is a dramatically simpler implementation for int/float than Noda Time.
+        if isinstance(other, int | float):
+            return self.from_nanoseconds(_towards_zero_division(self.total_nanoseconds, other))
+        if isinstance(other, Duration):
+            return self.total_nanoseconds / other.total_nanoseconds
+        return NotImplemented
+
+    @staticmethod
+    @_typing.overload
+    def divide(left: Duration, right: int | float) -> Duration:
+        ...
+
+    @staticmethod
+    @_typing.overload
+    def divide(left: Duration, right: Duration) -> float:
+        ...
+
+    @staticmethod
+    def divide(left: Duration, right: int | float | Duration) -> Duration | float:
+        # TODO: Duration.divide() docstring
+        return left / right
+
+    def __mul__(self, other: int | float) -> Duration:
+        # TODO: This is much simpler than the Noda Time implementation
+        if isinstance(other, int | float):
+            return self.from_nanoseconds(self.to_nanoseconds() * other)
+        return NotImplemented
+
+    def __rmul__(self, other: int | float) -> Duration:
+        if isinstance(other, int | float):
+            return self * other
+        return NotImplemented
+
+    @staticmethod
+    @_typing.overload
+    def multiply(left: Duration, right: int | float) -> Duration:
+        ...
+
+    @staticmethod
+    @_typing.overload
+    def multiply(left: int | float, right: Duration) -> Duration:
+        ...
+
+    @staticmethod
+    def multiply(left: Duration | int | float, right: Duration | int | float) -> Duration:
+        # TODO: Cursed isinstance checks are to pacify mypy - can we do better?
+        if isinstance(left, Duration) and isinstance(right, int | float):
+            return left * right
+        if isinstance(left, int | float) and isinstance(right, Duration):
+            return right * left
+        raise TypeError("Duration.multiply() accepts one Duration argument and one int/float argument.")
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Duration):
+            return self.__days == other.__days and self.__nano_of_day == other.__nano_of_day
+        return NotImplemented
+
+    def __ne__(self, other: object) -> bool:
+        return not (self == other)
+
+    def __lt__(self, other: Duration | None) -> bool:
+        if other is None:
+            return False
+        if isinstance(other, Duration):
+            return self.__days < other.__days or (
+                self.__days == other.__days and self.__nano_of_day < other.__nano_of_day
+            )
+        return NotImplemented
+
+    def __le__(self, other: Duration | None) -> bool:
+        return self < other or self == other
+
+    def __gt__(self, other: Duration | None) -> bool:
+        if other is None:
+            return True
+        if isinstance(other, Duration):
+            return (self.__days > other.__days) or (
+                (self.__days == other.__days) and (self.__nano_of_day > other.__nano_of_day)
+            )
+        return NotImplemented
+
+    def __ge__(self, other: Duration | None) -> bool:
+        return self > other or self == other
+
+    def __neg__(self) -> Duration:
+        old_days = self.__days
+        old_nano_of_day = self.__nano_of_day
+        if old_nano_of_day == 0:
+            return Duration._ctor(days=-old_days, nano_of_day=0)
+        new_nano_of_day = PyodaConstants.NANOSECONDS_PER_DAY - old_nano_of_day
+        return Duration._ctor(days=-old_days - 1, nano_of_day=new_nano_of_day)
+
+    @staticmethod
+    def negate(duration: Duration) -> Duration:
+        """Implements a friendly alternative to the unary negation operator.
+
+        :param duration: Duration to negate
+        :return: The negative value of this duration
+        """
+        return -duration
+
+    # endregion Operators
+
+    # region IComparable<Duration> Members
+
+    def compare_to(self, other: Duration) -> int:
+        """Compares the current object with another object of the same type. See the type documentation for a
+        description of ordering semantics.
+
+        :param other: An object to compare with this object.
+        :return: An integer that indicates the relative order of the objects being compared.
+        :exception TypeError: An object of an incompatible type was passed to this method.
+
+        The return value has the following meanings:
+
+        =====  ======
+        Value  Meaning
+        =====  ======
+        < 0    This object is less than the ``other`` parameter.
+        0      This object is equal to ``other``.
+        > 0    This object is greater than ``other``.
+        =====  ======
+        """
+        if other is None:
+            return 1
+        if isinstance(other, Duration):
+            if not (day_comparison := self.__days - other.__days) == 0:
+                return day_comparison
+            return self.__nano_of_day - other.__nano_of_day
+        raise TypeError
+
+    # endregion IComparable<Duration> Members
+
+    # region IEquatable<Duration> Members
+
+    def equals(self, other: Duration) -> bool:
+        """Indicates whether the current object is equal to another object of the same type. See the type documentation
+        for a description of equality semantics.
+
+        :param other: An object to compare with this object.
+        :return: true if the current object is equal to the ``other`` parameter; otherwise, false.
+        """
+        return self == other
+
+    # endregion IEquatable<Duration> Members
+
+    @classmethod
+    def from_days(cls, days: int | float) -> Duration:
+        """Returns a ``Duration`` that represents the given number of days, assuming a 'standard' 24-hour day.
+
+        :param days: The number of days.
+        :return: A ``Duration`` representing the given number of days.
+        """
+        if isinstance(days, float):
+            _Preconditions._check_argument_range(
+                "days",
+                days,
+                cls._MIN_DAYS,
+                cls._MAX_DAYS,
+            )
+            return cls.from_nanoseconds(days * PyodaConstants.NANOSECONDS_PER_DAY)
+        return cls._ctor(days=days)
+
+    @classmethod
+    def from_hours(cls, hours: int | float) -> Duration:
+        """Returns a Duration that represents the given number of hours.
+
+        :param hours: The number of hours.
+        :return: A ``Duration`` representing the number of hours.
+        """
+        if isinstance(hours, float):
+            _Preconditions._check_argument_range(
+                "hours",
+                hours,
+                cls._MIN_DAYS * PyodaConstants.HOURS_PER_DAY,
+                (cls._MAX_DAYS + 1) * PyodaConstants.HOURS_PER_DAY - 1,
+            )
+            return cls.from_nanoseconds(hours * PyodaConstants.NANOSECONDS_PER_HOUR)
+        return cls.__ctor(
+            units=hours,
+            param_name="hours",
+            min_value=cls._MIN_DAYS * PyodaConstants.HOURS_PER_DAY,
+            max_value=(cls._MAX_DAYS + 1) * PyodaConstants.HOURS_PER_DAY - 1,
+            units_per_day=PyodaConstants.HOURS_PER_DAY,
+            nanos_per_unit=PyodaConstants.NANOSECONDS_PER_HOUR,
+        )
+
+    @classmethod
+    def from_minutes(cls, minutes: int | float) -> Duration:
+        """Returns a ``Duration`` that represents the given number of minutes.
+
+        :param minutes: The number of minutes.
+        :return: A ``Duration`` representing the given number of minutes.
+        """
+        if isinstance(minutes, float):
+            _Preconditions._check_argument_range(
+                "minutes",
+                minutes,
+                cls._MIN_DAYS * PyodaConstants.MINUTES_PER_DAY,
+                (cls._MAX_DAYS + 1) * PyodaConstants.MINUTES_PER_DAY - 1,
+            )
+            return cls.from_nanoseconds(minutes * PyodaConstants.NANOSECONDS_PER_MINUTE)
+        return cls.__ctor(
+            units=minutes,
+            param_name="minutes",
+            min_value=cls._MIN_DAYS * PyodaConstants.MINUTES_PER_DAY,
+            max_value=(cls._MAX_DAYS + 1) * PyodaConstants.MINUTES_PER_DAY - 1,
+            units_per_day=PyodaConstants.MINUTES_PER_DAY,
+            nanos_per_unit=PyodaConstants.NANOSECONDS_PER_MINUTE,
+        )
+
+    @classmethod
+    def from_seconds(cls, seconds: int | float) -> Duration:
+        """Returns a ``Duration`` that represents the given number of seconds.
+
+        :param seconds: The number of seconds.
+        :return: A ``Duration`` representing the given number of seconds.
+        """
+        if isinstance(seconds, float):
+            _Preconditions._check_argument_range(
+                "seconds",
+                seconds,
+                cls._MIN_DAYS * PyodaConstants.SECONDS_PER_DAY,
+                (cls._MAX_DAYS + 1) * PyodaConstants.SECONDS_PER_DAY - 1,
+            )
+            return cls.from_nanoseconds(seconds * PyodaConstants.NANOSECONDS_PER_SECOND)
+        return cls.__ctor(
+            units=seconds,
+            param_name="seconds",
+            min_value=cls._MIN_DAYS * PyodaConstants.SECONDS_PER_DAY,
+            max_value=(cls._MAX_DAYS + 1) * PyodaConstants.SECONDS_PER_DAY - 1,
+            units_per_day=PyodaConstants.SECONDS_PER_DAY,
+            nanos_per_unit=PyodaConstants.NANOSECONDS_PER_SECOND,
+        )
+
+    @classmethod
+    def from_milliseconds(cls, milliseconds: int | float) -> Duration:
+        """Returns a ``Duration`` that represents the given number of milliseconds.
+
+        :param milliseconds: The number of milliseconds.
+        :return: A ``Duration`` representing the given number of milliseconds.
+        """
+        if isinstance(milliseconds, float):
+            _Preconditions._check_argument_range(
+                "milliseconds",
+                milliseconds,
+                cls._MIN_DAYS * PyodaConstants.MILLISECONDS_PER_DAY,
+                (cls._MAX_DAYS + 1) * PyodaConstants.MILLISECONDS_PER_DAY - 1,
+            )
+            return cls.from_nanoseconds(milliseconds * PyodaConstants.NANOSECONDS_PER_MILLISECOND)
+        return cls.__ctor(
+            units=milliseconds,
+            param_name="milliseconds",
+            min_value=cls._MIN_DAYS * PyodaConstants.MILLISECONDS_PER_DAY,
+            max_value=((cls._MAX_DAYS + 1) * PyodaConstants.MILLISECONDS_PER_DAY) - 1,
+            units_per_day=PyodaConstants.MILLISECONDS_PER_DAY,
+            nanos_per_unit=PyodaConstants.NANOSECONDS_PER_MILLISECOND,
+        )
+
+    @classmethod
+    def from_ticks(cls, ticks: int | float) -> Duration:
+        """Returns a ``Duration`` that represents the given number of ticks.
+
+        :param ticks: The number of ticks.
+        :return: A ``Duration`` representing the given number of ticks.
+        """
+        if isinstance(ticks, float):
+            _Preconditions._check_argument_range(
+                "ticks",
+                ticks,
+                cls._MIN_DAYS * float(PyodaConstants.TICKS_PER_DAY),
+                (cls._MAX_DAYS + 1) * PyodaConstants.TICKS_PER_DAY - 1,
+            )
+            return cls.from_nanoseconds(ticks * PyodaConstants.NANOSECONDS_PER_TICK)
+        # TODO: FromTicks(long) never throws.
+        #  Noda Time has the following comment:
+        #  "No precondition here, as we cover a wider range than Int64 ticks can handle..."
+        #  If this ever changes, the test_factory_methods_out_of_range test will need changed too.
+        days, tick_of_day = _TickArithmetic.ticks_to_days_and_tick_of_day(ticks)
+        return cls.__ctor(days=days, nano_of_day=tick_of_day * PyodaConstants.NANOSECONDS_PER_TICK, no_validation=True)
+
+    @classmethod
+    def from_microseconds(cls, microseconds: int | float) -> Duration:
+        """Returns a ``Duration`` that represents the given number of microseconds.
+
+        :param microseconds: The number of microseconds.
+        :return: A ``Duration`` representing the given number of microseconds.
+        """
+        if isinstance(microseconds, float):
+            _Preconditions._check_argument_range(
+                "microseconds",
+                microseconds,
+                cls._MIN_DAYS * PyodaConstants.MICROSECONDS_PER_DAY,
+                (cls._MAX_DAYS + 1) * PyodaConstants.MICROSECONDS_PER_DAY - 1,
+            )
+            return cls.from_nanoseconds(microseconds * PyodaConstants.NANOSECONDS_PER_MICROSECOND)
+        return cls.__ctor(
+            units=microseconds,
+            param_name="microseconds",
+            min_value=cls._MIN_DAYS * PyodaConstants.MICROSECONDS_PER_DAY,
+            max_value=((cls._MAX_DAYS + 1) * PyodaConstants.MICROSECONDS_PER_DAY) - 1,
+            units_per_day=PyodaConstants.MICROSECONDS_PER_DAY,
+            nanos_per_unit=PyodaConstants.NANOSECONDS_PER_MICROSECOND,
+        )
+
+    @classmethod
+    def from_nanoseconds(cls, nanoseconds: int | float) -> Duration:  # TODO from_nanoseconds overrides
+        """Returns a ``Duration`` that represents the given number of nanoseconds.
+
+        When nanoseconds is a ``float``, any fractional parts of the value are
+        truncated towards zero.
+
+        :param nanoseconds: The number of nanoseconds.
+        :return: A ``Duration`` representing the given number of nanoseconds.
+        """
+
+        _Preconditions._check_argument_range("nanoseconds", nanoseconds, cls._MIN_NANOSECONDS, cls._MAX_NANOSECONDS)
+
+        # In Noda Time, the ``double`` overload merely rounds ``nanoseconds`` towards zero
+        # and passes it to either the ``long`` or ``BigInteger`` overload.
+        # Here we just allow it to fall through to the next code block.
+        if isinstance(nanoseconds, float):
+            # TODO: Consider creating a function that rounds towards zero without any division.
+            nanoseconds = _towards_zero_division(nanoseconds, 1)
+
+        if nanoseconds >= 0:
+            # TODO: Is divmod compatible with C# integer division?
+            quotient, remainder = divmod(nanoseconds, PyodaConstants.NANOSECONDS_PER_DAY)
+            return cls._ctor(days=quotient, nano_of_day=remainder)
+
+        # Work out the "floor days"; division truncates towards zero and
+        # nanoseconds is definitely negative by now, hence the addition and subtraction here.
+        days = _towards_zero_division(nanoseconds + 1, PyodaConstants.NANOSECONDS_PER_DAY) - 1
+        nano_of_day = nanoseconds - days * PyodaConstants.NANOSECONDS_PER_DAY
+        return Duration._ctor(days=days, nano_of_day=nano_of_day)
+
+    @classmethod
+    def _from_nanoseconds(cls, nanoseconds: _decimal.Decimal) -> Duration:
+        # TODO: For comparison between min/max decimal nanoseconds (and values near
+        #  those limits) to work, we need to make sure that the precision is sufficient
+        #  to avoid truncation. This is a bit of a "finger in the air" precision which
+        #  may need revisited.
+        with _decimal.localcontext(prec=100):
+            if nanoseconds < cls._MIN_DECIMAL_NANOSECONDS or nanoseconds > cls._MAX_DECIMAL_NANOSECONDS:
+                # Note: use the BigInteger value rather than decimal to avoid decimal points in the message.
+                # They're the same values.
+                raise ValueError(f"Value should be in range [{cls._MIN_NANOSECONDS}-{cls._MAX_NANOSECONDS}]")
+
+            days = (
+                _towards_zero_division(nanoseconds, PyodaConstants.NANOSECONDS_PER_DAY)
+                if nanoseconds >= 0
+                else _towards_zero_division(nanoseconds + 1, PyodaConstants.NANOSECONDS_PER_DAY) - 1
+            )
+            nano_of_day = _towards_zero_division(
+                nanoseconds - (_decimal.Decimal(days) * PyodaConstants.NANOSECONDS_PER_DAY), 1
+            )
+            return cls._ctor(days=days, nano_of_day=nano_of_day)
+
+    @classmethod
+    def from_timedelta(cls, time_delta: _datetime.timedelta) -> Duration:
+        """Returns a ``Duration`` that represents the same number of microseconds as the given ``datetime.timedelta``.
+
+        :param time_delta: The ``datetime.timedelta`` to convert.
+        :return: A new Duration with the same number of microseconds as the given ``datetime.timedelta``.
+        """
+        # Note that we don't use `cls.from_seconds(timedelta.total_seconds())` here.
+        # That is because `total_seconds()` loses microsecond accuracy for deltas > 270 years.
+        # https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds
+        return (
+            Duration.from_days(time_delta.days)
+            + Duration.from_seconds(time_delta.seconds)
+            + Duration.from_microseconds(time_delta.microseconds)
+        )
+
+    def to_timedelta(self) -> _datetime.timedelta:
+        """Returns a ``datetime.timedelta`` that represents the same number of microseconds as this ``Duration``.
+
+        If the number of nanoseconds in a duration is not a whole number of microseconds, it will be
+        passed to ``datetime.timedelta()`` as a fractional argument, and will be subject to the internal
+        summing/rounding behaviour documented at https://docs.python.org/3/library/datetime.html#datetime.timedelta.
+
+        If the duration can be resolved to a whole number of microseconds, then the conversion should not lose
+        information.
+
+        :return: A new TimeSpan with the same number of ticks as this Duration.
+        """
+
+        return _datetime.timedelta(
+            days=self.__days, microseconds=self.__nano_of_day / PyodaConstants.NANOSECONDS_PER_MICROSECOND
+        )
 
     def to_nanoseconds(self) -> int:
         # TODO: This covers implementations for:
@@ -1178,16 +1780,33 @@ class Duration(metaclass=_DurationMeta):
         #  public BigInteger ToBigIntegerNanoseconds()
         return self.__days * PyodaConstants.NANOSECONDS_PER_DAY + self.__nano_of_day
 
-    @property
-    def bcl_compatible_ticks(self) -> int:
-        """Gets the total number of ticks in the duration as a 64-bit integer, truncating towards zero where
-        necessary."""
-        ticks = _TickArithmetic.days_and_tick_of_day_to_ticks(
-            self.__days, _towards_zero_division(self.__nano_of_day, PyodaConstants.NANOSECONDS_PER_TICK)
-        )
-        if self.__days < 0 and self.__nano_of_day % PyodaConstants.NANOSECONDS_PER_TICK != 0:
-            ticks += 1
-        return ticks
+    @staticmethod
+    def max(x: Duration, y: Duration) -> Duration:
+        """Returns the larger duration of the given two.
+
+        A "larger" duration is one that advances time by more than a "smaller" one. This means
+        that a positive duration is always larger than a negative one, for example. (This is the same
+        comparison used by the binary comparison operators.)
+
+        :param x: The first duration to compare.
+        :param y: The second duration to compare.
+        :return: The larger duration of ``x`` or ``y``.
+        """
+        return max(x, y)
+
+    @staticmethod
+    def min(x: Duration, y: Duration) -> Duration:
+        """Returns the smaller duration of the given two.
+
+        A "larger" duration is one that advances time by more than a "smaller" one. This means
+        that a positive duration is always larger than a negative one, for example. (This is the same
+        comparison used by the binary comparison operators.)
+
+        :param x: The first duration to compare.
+        :param y: The second duration to compare.
+        :return: The smaller duration of ``x`` or ``y``.
+        """
+        return min(x, y)
 
 
 @_sealed
@@ -1617,7 +2236,7 @@ class Offset(metaclass=_OffsetMeta):
         """Converts the given ``timedelta`` to an offset, with fractional seconds truncated.
 
         :param timedelta: The timedelta to convert
-        :returns: An offset for the same time as the given time span. :exception ValueError: The given timedelta falls
+        :returns: An offset for the same time as the given timedelta. :exception ValueError: The given timedelta falls
             outside the range of +/- 18 hours.
         """
         # TODO: Consider introducing a "from_microseconds" constructor?

--- a/pyoda_time/utility.py
+++ b/pyoda_time/utility.py
@@ -7,6 +7,7 @@ from __future__ import annotations as _annotations
 __all__: list[str] = []
 
 import datetime as _datetime
+import decimal as _decimal
 import typing as _typing
 
 _T = _typing.TypeVar("_T")
@@ -27,7 +28,9 @@ class _Preconditions:
         return argument
 
     @classmethod
-    def _check_argument_range(cls, param_name: str, value: int, min_inclusive: int, max_inclusive: int) -> None:
+    def _check_argument_range(
+        cls, param_name: str, value: int | float, min_inclusive: int | float, max_inclusive: int | float
+    ) -> None:
         if (value < min_inclusive) or (value > max_inclusive):
             cls._throw_argument_out_of_range_exception(param_name, value, min_inclusive, max_inclusive)
 
@@ -99,7 +102,7 @@ class _TickArithmetic:
         return days * PyodaConstants.TICKS_PER_DAY + tick_of_day
 
 
-def _towards_zero_division(x: int | float, y: int | float) -> int:
+def _towards_zero_division(x: int | float | _decimal.Decimal, y: int | float | _decimal.Decimal) -> int:
     """Divide two numbers using "towards zero" rounding.
 
     This ensures that integer division produces the same result as it would do in C#.

--- a/tests/test_duration.py
+++ b/tests/test_duration.py
@@ -2,12 +2,925 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 """https://github.com/nodatime/nodatime/blob/main/src/NodaTime.Test/DurationTest.cs"""
+import sys
+from datetime import timedelta
+from typing import Callable, Final, TypeVar
 
-from pyoda_time import Duration
+import pytest
+
+from pyoda_time import Duration, PyodaConstants
+from pyoda_time.utility import _CsharpConstants, _towards_zero_division
+from tests import helpers
+
+T = TypeVar("T")
 
 
 class TestDuration:
-    def test_default_initialiser(self) -> None:
+    def test_default_constructor(self) -> None:
         """Using the default constructor is equivalent to Duration.Zero."""
         actual = Duration()
         assert Duration.zero == actual
+
+    # TODO: def test_xml_serialization(self) -> None:
+    # TODO: def test_xml_serialization_invalid(self) -> None:
+
+    @pytest.mark.parametrize(
+        "int64_nanos",
+        [
+            _CsharpConstants.LONG_MIN_VALUE,
+            _CsharpConstants.LONG_MIN_VALUE + 1,
+            -PyodaConstants.NANOSECONDS_PER_DAY - 1,
+            -PyodaConstants.NANOSECONDS_PER_DAY,
+            -PyodaConstants.NANOSECONDS_PER_DAY + 1,
+            -1,
+            0,
+            1,
+            PyodaConstants.NANOSECONDS_PER_DAY - 1,
+            PyodaConstants.NANOSECONDS_PER_DAY,
+            PyodaConstants.NANOSECONDS_PER_DAY + 1,
+            _CsharpConstants.LONG_MAX_VALUE - 1,
+            _CsharpConstants.LONG_MAX_VALUE,
+        ],
+    )
+    def test_int64_conversions(self, int64_nanos: int) -> None:
+        # Note: There is no Duration.ToInt64Nanoseconds() in Pyoda Time.
+        nanoseconds = Duration.from_nanoseconds(int64_nanos)
+        assert nanoseconds.to_nanoseconds() == int64_nanos
+
+    @pytest.mark.parametrize(
+        "int64_nanos",
+        [
+            _CsharpConstants.LONG_MIN_VALUE,
+            _CsharpConstants.LONG_MIN_VALUE + 1,
+            -PyodaConstants.NANOSECONDS_PER_DAY - 1,
+            -PyodaConstants.NANOSECONDS_PER_DAY,
+            -PyodaConstants.NANOSECONDS_PER_DAY + 1,
+            -1,
+            0,
+            1,
+            PyodaConstants.NANOSECONDS_PER_DAY - 1,
+            PyodaConstants.NANOSECONDS_PER_DAY,
+            PyodaConstants.NANOSECONDS_PER_DAY + 1,
+            _CsharpConstants.LONG_MAX_VALUE - 1,
+            _CsharpConstants.LONG_MAX_VALUE,
+        ],
+    )
+    def test_big_integer_conversions(self, int64_nanos: int) -> None:
+        # Note: There is no Duration.ToBigIntegerNanoseconds() in Pyoda Time.
+        big_integer_nanos = int64_nanos * 100
+        nanoseconds = Duration.from_nanoseconds(big_integer_nanos)
+        assert nanoseconds.to_nanoseconds() == big_integer_nanos
+
+    def test_constituent_parts_positive(self) -> None:
+        nanos = Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY * 5 + 100)
+        assert nanos._floor_days == 5
+        assert nanos._nanosecond_of_floor_day == 100
+
+    def test_constituent_parts_negative(self) -> None:
+        nanos = Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY * -5 + 100)
+        assert nanos._floor_days == -5
+        assert nanos._nanosecond_of_floor_day == 100
+
+    def test_constituent_parts_large(self) -> None:
+        nanos = Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY * 365000 + 500)
+        assert nanos._floor_days == 365000
+        assert nanos._nanosecond_of_floor_day == 500
+
+    @pytest.mark.parametrize(
+        "left_days,left_nanos,right_days,right_nanos,result_days,result_nanos",
+        [
+            (1, 100, 2, 200, 3, 300),
+            (1, PyodaConstants.NANOSECONDS_PER_DAY - 5, 3, 100, 5, 95),
+            (1, 10, -1, PyodaConstants.NANOSECONDS_PER_DAY - 100, 0, PyodaConstants.NANOSECONDS_PER_DAY - 90),
+        ],
+    )
+    def test_addition_subtraction(
+        self, left_days: int, left_nanos: int, right_days: int, right_nanos: int, result_days: int, result_nanos: int
+    ) -> None:
+        left = Duration._ctor(days=left_days, nano_of_day=left_nanos)
+        right = Duration._ctor(days=right_days, nano_of_day=right_nanos)
+        result = Duration._ctor(days=result_days, nano_of_day=result_nanos)
+
+        assert left + right == result
+        assert left.plus(right) == result
+        assert Duration.add(left, right) == result
+
+        assert result - right == left
+        assert result.minus(right) == left
+        assert Duration.subtract(result, right) == left
+
+    def test_equality(self) -> None:
+        equal1 = Duration._ctor(days=1, nano_of_day=PyodaConstants.NANOSECONDS_PER_HOUR)
+        equal2 = Duration.from_ticks(PyodaConstants.TICKS_PER_HOUR * 25)
+        different1 = Duration._ctor(days=1, nano_of_day=200)
+        different2 = Duration._ctor(days=2, nano_of_day=PyodaConstants.TICKS_PER_HOUR)
+
+        helpers.test_equals(equal1, equal2, different1)
+        helpers.test_operator_equality(equal1, equal2, different1)
+
+        helpers.test_equals(equal1, equal2, different2)
+        helpers.test_operator_equality(equal1, equal2, different2)
+
+    def test_comparison(self) -> None:
+        equal1 = Duration._ctor(days=1, nano_of_day=PyodaConstants.NANOSECONDS_PER_HOUR)
+        equal2 = Duration.from_ticks(PyodaConstants.TICKS_PER_HOUR * 25)
+        greater1 = Duration._ctor(days=1, nano_of_day=PyodaConstants.NANOSECONDS_PER_HOUR + 1)
+        greater2 = Duration._ctor(days=2, nano_of_day=0)
+
+        helpers.test_compare_to(equal1, equal2, greater1)
+        helpers.test_operator_comparison_equality(equal1, equal2, greater1, greater2)
+
+    @pytest.mark.parametrize(
+        "start_days,start_nano_of_day,scalar,expected_days,expected_nano_of_day",
+        [
+            (1, 5, 2, 2, 10),
+            (-1, PyodaConstants.NANOSECONDS_PER_DAY - 10, 2, -1, PyodaConstants.NANOSECONDS_PER_DAY - 20),
+            (365000, 1, 2, 365000 * 2, 2),
+            (1000, 1, 365, 365000, 365),
+            (1000, 1, -365, -365001, PyodaConstants.NANOSECONDS_PER_DAY - 365),
+            (0, 1, PyodaConstants.NANOSECONDS_PER_DAY, 1, 0),
+        ],
+        ids=[
+            "Small, positive",
+            "Small, negative",
+            "More than 2^63 nanos before multiplication",
+            "More than 2^63 nanos after multiplication",
+            "Less than -2^63 nanos after multiplication",
+            "Large scalar",
+        ],
+    )
+    def test_multiplication(
+        self, start_days: int, start_nano_of_day: int, scalar: int, expected_days: int, expected_nano_of_day: int
+    ) -> None:
+        start = Duration._ctor(days=start_days, nano_of_day=start_nano_of_day)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert start * scalar == expected
+
+    @pytest.mark.parametrize(
+        "start_days,start_nano_of_day,expected_days,expected_nano_of_day",
+        [
+            (0, 0, 0, 0),
+            (1, 0, -1, 0),
+            (0, 500, -1, PyodaConstants.NANOSECONDS_PER_DAY - 500),
+            (365000, 500, -365001, PyodaConstants.NANOSECONDS_PER_DAY - 500),
+        ],
+    )
+    def test_unary_negation(
+        self, start_days: int, start_nano_of_day: int, expected_days: int, expected_nano_of_day: int
+    ) -> None:
+        start = Duration._ctor(days=start_days, nano_of_day=start_nano_of_day)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert -start == expected
+        # Test it the other way round as well
+        assert start == -expected
+
+    @pytest.mark.parametrize(
+        "start_days,start_nano_of_day,divisor,expected_days,expected_nano_of_day",
+        [
+            # Test cases around 0
+            (-1, PyodaConstants.NANOSECONDS_PER_DAY - 1, PyodaConstants.NANOSECONDS_PER_DAY, 0, 0),
+            (0, 0, PyodaConstants.NANOSECONDS_PER_DAY, 0, 0),
+            (0, 1, PyodaConstants.NANOSECONDS_PER_DAY, 0, 0),
+            # Test cases around dividing -1 day by "nanos per day"
+            (
+                -2,
+                PyodaConstants.NANOSECONDS_PER_DAY - 1,
+                PyodaConstants.NANOSECONDS_PER_DAY,
+                -1,
+                PyodaConstants.NANOSECONDS_PER_DAY - 1,
+            ),
+            (-1, 0, PyodaConstants.NANOSECONDS_PER_DAY, -1, PyodaConstants.NANOSECONDS_PER_DAY - 1),
+            (-1, 1, PyodaConstants.NANOSECONDS_PER_DAY, 0, 0),
+            # Test cases around dividing 1 day by "nanos per day"
+            (0, PyodaConstants.NANOSECONDS_PER_DAY - 1, PyodaConstants.NANOSECONDS_PER_DAY, 0, 0),
+            (1, 0, PyodaConstants.NANOSECONDS_PER_DAY, 0, 1),
+            (1, PyodaConstants.NANOSECONDS_PER_DAY - 1, PyodaConstants.NANOSECONDS_PER_DAY, 0, 1),
+            (10, 20, 5, 2, 4),
+            # Large value, which will use decimal arithmetic
+            (365000, 3000, 1000, 365, 3),
+        ],
+    )
+    def test_division(
+        self, start_days: int, start_nano_of_day: int, divisor: int, expected_days: int, expected_nano_of_day: int
+    ) -> None:
+        start = Duration._ctor(days=start_days, nano_of_day=start_nano_of_day)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert start / divisor == expected
+
+    def test_bcl_compatible_ticks_zero(self) -> None:
+        assert Duration.from_ticks(0).bcl_compatible_ticks == 0
+        assert Duration.from_nanoseconds(99).bcl_compatible_ticks == 0
+        assert Duration.from_nanoseconds(-99).bcl_compatible_ticks == 0
+
+    @pytest.mark.parametrize(
+        "ticks",
+        [
+            5,
+            PyodaConstants.TICKS_PER_DAY * 2,
+            PyodaConstants.TICKS_PER_DAY * 365000,
+        ],
+    )
+    def test_bcl_compatible_ticks_positive(self, ticks: int) -> None:
+        assert ticks > 0
+        start = Duration.from_ticks(ticks)
+        assert start.bcl_compatible_ticks == ticks
+
+        # We truncate towards zero... so subtracting 1 nanosecond should
+        # reduce the number of ticks, and adding 99 nanoseconds should not change it
+        assert start._minus_small_nanoseconds(1).bcl_compatible_ticks == ticks - 1
+        assert start._plus_small_nanoseconds(99).bcl_compatible_ticks == ticks
+
+    @pytest.mark.parametrize(
+        "ticks",
+        [
+            -5,
+            -PyodaConstants.TICKS_PER_DAY * 2,
+            -PyodaConstants.TICKS_PER_DAY * 365000,
+        ],
+    )
+    def test_bcl_compatible_ticks_negative(self, ticks: int) -> None:
+        assert ticks < 0
+        start = Duration.from_ticks(ticks)
+        assert start.bcl_compatible_ticks == ticks
+
+        # We truncate towards zero... so subtracting 99 nanoseconds should
+        # have no effect, and adding 1 should increase the number of ticks
+        assert start._minus_small_nanoseconds(99).bcl_compatible_ticks == ticks
+        assert start._plus_small_nanoseconds(1).bcl_compatible_ticks == ticks + 1
+
+    @pytest.mark.xfail(reason="Python's dynamic integer size prevents Overflow")
+    def test_bcl_compatible_ticks_min_value(self) -> None:
+        with pytest.raises(OverflowError):
+            str(Duration.min_value.bcl_compatible_ticks)
+
+    def test_validation(self) -> None:
+        # Different to Noda Time:
+        # We use different min/max days in Pyoda Time, with a larger range.
+        # The aim is to increase the range sufficiently to accommodate the range of
+        # `datetime.timedelta`, which is greater than that of `TimeSpan` in dotnet.
+        helpers.assert_valid(Duration.from_days, (1 << 30) - 1)
+        helpers.assert_out_of_range(Duration.from_days, 1 << 30)
+        helpers.assert_valid(Duration.from_days, -(1 << 30))
+        helpers.assert_out_of_range(Duration.from_days, -(1 << 30) - 1)
+
+    @pytest.mark.xfail(reason="Python's dynamic integer size prevents Overflow")
+    def test_bcl_compatbile_ticks_overflow(self) -> None:
+        max_ticks = Duration.from_ticks(_CsharpConstants.LONG_MAX_VALUE) + Duration.from_ticks(1)
+        with pytest.raises(OverflowError):
+            str(max_ticks.bcl_compatible_ticks)
+
+    def test_positive_components(self) -> None:
+        duration = Duration.from_nanoseconds(1234567890123456)
+        assert duration.days == 14
+        assert duration.nanosecond_of_day == 24967890123456
+        assert duration.hours == 6
+        assert duration.minutes == 56
+        assert duration.seconds == 7
+        assert duration.milliseconds == 890
+        assert duration.microseconds == 890123
+        assert duration.subsecond_ticks == 8901234
+        assert duration.subsecond_nanoseconds == 890123456
+
+    def test_negative_components(self) -> None:
+        duration = Duration.from_nanoseconds(-1234567890123456)
+        assert duration.days == -14
+        assert duration.nanosecond_of_day == -24967890123456
+        assert duration.hours == -6
+        assert duration.minutes == -56
+        assert duration.seconds == -7
+        assert duration.milliseconds == -890
+        assert duration.microseconds == -890123
+        assert duration.subsecond_ticks == -8901234
+        assert duration.subsecond_nanoseconds == -890123456
+
+    def test_positive_totals(self) -> None:
+        duration = (
+            Duration.from_days(4)
+            + Duration.from_hours(3)
+            + Duration.from_minutes(2)
+            + Duration.from_seconds(1)
+            + Duration.from_nanoseconds(123456789)
+        )
+        assert duration.total_days == pytest.approx(4.1264, abs=0.0001)
+        assert duration.total_hours == pytest.approx(99.0336, abs=0.0001)
+        assert duration.total_minutes == pytest.approx(5942.0187, abs=0.0001)
+        assert duration.total_seconds == pytest.approx(356521.123456789, abs=0.000000001)
+        assert duration.total_milliseconds == pytest.approx(356521123.456789, abs=0.000001)
+        assert duration.total_ticks == pytest.approx(3565211234567.89, abs=0.01)
+        assert duration.total_nanoseconds == pytest.approx(356521123456789, abs=1)
+
+    def test_negative_totals(self) -> None:
+        duration = (
+            Duration.from_days(-4)
+            + Duration.from_hours(-3)
+            + Duration.from_minutes(-2)
+            + Duration.from_seconds(-1)
+            + Duration.from_nanoseconds(-123456789)
+        )
+        assert duration.total_days == pytest.approx(-4.1264, abs=0.0001)
+        assert duration.total_hours == pytest.approx(-99.0336, abs=0.0001)
+        assert duration.total_minutes == pytest.approx(-5942.0187, abs=0.0001)
+        assert duration.total_seconds == pytest.approx(-356521.123456789, abs=0.000000001)
+        assert duration.total_milliseconds == pytest.approx(-356521123.456789, abs=0.000001)
+        assert duration.total_ticks == pytest.approx(-3565211234567.89, abs=0.01)
+        assert duration.total_nanoseconds == pytest.approx(-356521123456789, abs=1)
+
+    def test_max_min_relationship(self) -> None:
+        # Max and Min work like they do for other signed types - basically the max value is one less than the absolute
+        # of the min value.
+        assert -Duration.max_value - Duration.epsilon == Duration.min_value
+
+    def test_max(self) -> None:
+        x = Duration.from_nanoseconds(100)
+        y = Duration.from_nanoseconds(200)
+        assert Duration.max(x, y) == y
+        assert Duration.max(y, x) == y
+        assert Duration.max(x, Duration.min_value) == x
+        assert Duration.max(Duration.min_value, x) == x
+        assert Duration.max(Duration.max_value, x) == Duration.max_value
+        assert Duration.max(x, Duration.max_value) == Duration.max_value
+
+    def test_min(self) -> None:
+        x = Duration.from_nanoseconds(100)
+        y = Duration.from_nanoseconds(200)
+        assert Duration.min(x, y) == x
+        assert Duration.min(y, x) == x
+        assert Duration.min(x, Duration.min_value) == Duration.min_value
+        assert Duration.min(Duration.min_value, x) == Duration.min_value
+        assert Duration.min(Duration.max_value, x) == x
+        assert Duration.min(x, Duration.max_value) == x
+
+
+class TestDurationConstruction:
+    """Test cases for factory methods.
+
+    In general, we want to check the limits, very small, very large and medium values, with a mixture of positive and
+    negative, "on and off" day boundaries.
+    """
+
+    DAY_CASES: Final[list[int]] = [Duration._MIN_DAYS, -3000 * 365, -100, -1, 0, 1, 100, 3000 * 365, Duration._MAX_DAYS]
+
+    HOUR_CASES: Final[list[int]] = [
+        Duration._MIN_DAYS * PyodaConstants.HOURS_PER_DAY,
+        -3000 * 365 * PyodaConstants.HOURS_PER_DAY,
+        -100,
+        -48,
+        -1,
+        0,
+        1,
+        48,
+        100,
+        3000 * 365 * PyodaConstants.HOURS_PER_DAY,
+        ((Duration._MAX_DAYS + 1) * PyodaConstants.HOURS_PER_DAY) - 1,
+    ]
+
+    @staticmethod
+    def generate_cases(units_per_day: int) -> list[int]:
+        return [
+            Duration._MIN_DAYS * units_per_day,
+            -3000 * 365 * units_per_day - 1,
+            -3000 * 365 * units_per_day,
+            _towards_zero_division(-5 * units_per_day, 2),
+            -2 * units_per_day - 1,
+            0,
+            1,
+            2 * units_per_day,
+            _towards_zero_division(5 * units_per_day, 2),
+            3000 * 365 * units_per_day,
+            3000 * 365 * units_per_day + 1,
+            ((Duration._MAX_DAYS + 1) * units_per_day) - 1,
+        ]
+
+    MINUTE_CASES = generate_cases(PyodaConstants.MINUTES_PER_DAY)
+
+    SECOND_CASES = generate_cases(PyodaConstants.SECONDS_PER_DAY)
+
+    MILLISECOND_CASES = generate_cases(PyodaConstants.MILLISECONDS_PER_DAY)
+
+    # Different to Noda Time:
+    MICROSECOND_CASES = generate_cases(PyodaConstants.MICROSECONDS_PER_DAY)
+
+    # TODO: Look into this Noda Time comment:
+    #  No boundary versions as Int64 doesn't have enough ticks to exceed our limits.
+    TICK_CASES = generate_cases(PyodaConstants.TICKS_PER_DAY)[1:-2]
+
+    def test_zero(self) -> None:
+        test: Duration = Duration.zero
+        assert test.bcl_compatible_ticks == 0
+        assert test._nanosecond_of_floor_day == 0
+        assert test._floor_days == 0
+
+    @staticmethod
+    def __test_factory_method(
+        method: Callable[[int], Duration] | Callable[[float], Duration], value: int, nanoseconds_per_unit: int
+    ) -> None:
+        duration = method(value)
+        expected_nanoseconds = value * nanoseconds_per_unit
+        assert duration.to_nanoseconds() == expected_nanoseconds
+
+    @pytest.mark.parametrize("days", DAY_CASES)
+    def test_from_days_int32(self, days: int) -> None:
+        self.__test_factory_method(Duration.from_days, days, PyodaConstants.NANOSECONDS_PER_DAY)
+
+    @pytest.mark.parametrize("hours", HOUR_CASES)
+    def test_from_hours_int32(self, hours: int) -> None:
+        self.__test_factory_method(Duration.from_hours, hours, PyodaConstants.NANOSECONDS_PER_HOUR)
+
+    @pytest.mark.parametrize("minutes", MINUTE_CASES)
+    def test_from_minutes_int64(self, minutes: int) -> None:
+        self.__test_factory_method(Duration.from_minutes, minutes, PyodaConstants.NANOSECONDS_PER_MINUTE)
+
+    @pytest.mark.parametrize("seconds", SECOND_CASES)
+    def test_from_seconds_int64(self, seconds: int) -> None:
+        self.__test_factory_method(Duration.from_seconds, seconds, PyodaConstants.NANOSECONDS_PER_SECOND)
+
+    @pytest.mark.parametrize("milliseconds", MILLISECOND_CASES)
+    def test_from_milliseconds_int64(self, milliseconds: int) -> None:
+        self.__test_factory_method(Duration.from_milliseconds, milliseconds, PyodaConstants.NANOSECONDS_PER_MILLISECOND)
+
+    @pytest.mark.parametrize("microseconds", MICROSECOND_CASES)
+    def test_from_microseconds_int64(self, microseconds: int) -> None:
+        self.__test_factory_method(Duration.from_microseconds, microseconds, PyodaConstants.NANOSECONDS_PER_MICROSECOND)
+
+    @pytest.mark.parametrize("ticks", TICK_CASES)
+    def test_from_ticks(self, ticks: int) -> None:
+        nanoseconds = Duration.from_ticks(ticks)
+        assert nanoseconds.to_nanoseconds() == ticks * PyodaConstants.NANOSECONDS_PER_TICK
+
+        # Just another sanity check, although Ticks is covered in more detail later.
+        assert nanoseconds.bcl_compatible_ticks == ticks
+
+    @pytest.mark.parametrize(
+        "days,expected_days,expected_nano_of_day",
+        [
+            (1.5, 1, PyodaConstants.NANOSECONDS_PER_DAY / 2),
+            (-0.25, -1, 3 * PyodaConstants.NANOSECONDS_PER_DAY / 4),
+            (100000.5, 100000, PyodaConstants.NANOSECONDS_PER_DAY / 2),
+            (-5000, -5000, 0),
+        ],
+    )
+    def test_from_days_double(self, days: float, expected_days: int, expected_nano_of_day: int) -> None:
+        actual = Duration.from_days(days)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "hours,expected_days,expected_nano_of_day",
+        [
+            (36.5, 1, PyodaConstants.NANOSECONDS_PER_DAY / 2 + PyodaConstants.NANOSECONDS_PER_HOUR / 2),
+            (-0.25, -1, PyodaConstants.NANOSECONDS_PER_DAY - PyodaConstants.NANOSECONDS_PER_HOUR / 4),
+            (24000.5, 1000, PyodaConstants.NANOSECONDS_PER_HOUR / 2),
+        ],
+    )
+    def test_from_hours_double(self, hours: float, expected_days: int, expected_nano_of_day: int) -> None:
+        actual = Duration.from_hours(hours)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "minutes,expected_days,expected_nano_of_day",
+        [
+            (
+                PyodaConstants.MINUTES_PER_DAY + PyodaConstants.MINUTES_PER_DAY / 2,
+                1,
+                PyodaConstants.NANOSECONDS_PER_DAY / 2,
+            ),
+            (1.5, 0, PyodaConstants.NANOSECONDS_PER_SECOND * 90),
+            (-PyodaConstants.MINUTES_PER_DAY + 1.5, -1, PyodaConstants.NANOSECONDS_PER_SECOND * 90),
+        ],
+    )
+    def test_from_minutes_double(self, minutes: float, expected_days: int, expected_nano_of_day: int) -> None:
+        actual = Duration.from_minutes(minutes)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "seconds,expected_days,expected_nano_of_day",
+        [
+            (
+                PyodaConstants.SECONDS_PER_DAY + PyodaConstants.SECONDS_PER_DAY / 2,
+                1,
+                PyodaConstants.NANOSECONDS_PER_DAY / 2,
+            ),
+            (1.5, 0, PyodaConstants.NANOSECONDS_PER_MILLISECOND * 1500),
+            (-PyodaConstants.SECONDS_PER_DAY + 1.5, -1, PyodaConstants.NANOSECONDS_PER_MILLISECOND * 1500),
+        ],
+    )
+    def test_from_seconds_double(self, seconds: float, expected_days: int, expected_nano_of_day: int) -> None:
+        actual = Duration.from_seconds(seconds)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "milliseconds,expected_days,expected_nano_of_day",
+        [
+            (
+                PyodaConstants.MILLISECONDS_PER_DAY + PyodaConstants.MILLISECONDS_PER_DAY / 2,
+                1,
+                PyodaConstants.NANOSECONDS_PER_DAY / 2,
+            ),
+            (1.5, 0, 1500000),
+            (-PyodaConstants.MILLISECONDS_PER_DAY + 1.5, -1, 1500000),
+        ],
+    )
+    def test_from_milliseconds_double(self, milliseconds: float, expected_days: int, expected_nano_of_day: int) -> None:
+        actual = Duration.from_milliseconds(milliseconds)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "microseconds,expected_days,expected_nano_of_day",
+        [
+            (
+                PyodaConstants.MICROSECONDS_PER_DAY + PyodaConstants.MICROSECONDS_PER_DAY / 2,
+                1,
+                PyodaConstants.NANOSECONDS_PER_DAY / 2,
+            ),
+            (1.5, 0, 1500),
+            (-PyodaConstants.MICROSECONDS_PER_DAY + 1.5, -1, 1500),
+        ],
+    )
+    def test_from_microseconds_double(self, microseconds: float, expected_days: int, expected_nano_of_day: int) -> None:
+        actual = Duration.from_microseconds(microseconds)
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert actual == expected
+
+    def test_from_and_to_timedelta(self) -> None:
+        """Test conversion to and from ``datetime.timedelta``.
+
+        This is more or less equivalent to the Noda Time test:
+
+        ```
+            [Test]
+            public void FromAndToTimeSpan() {...}
+        ```
+
+        Differences between ``timedelta`` and ``TimeSpan``:
+
+        * ``TimeSpan`` has 100-nanosecond tick precision, whereas ``timedelta`` has microsecond precision.
+        * ``timedelta`` can represent a larger range of time than ``TimeSpan``.
+
+        Differences between ``Duration`` implementations in Pyoda Time and Noda Time:
+
+        * Noda Time has a smaller valid range of ``Duration`` than the equivalent class in Pyoda Time.
+        * Conversion from e.g ``timedelta.max`` would be impossible with Noda Time's min/max constraints.
+        * Pyoda Time's ``Duration`` implementation supports microseconds, Noda Time's does not.
+        """
+
+        td = timedelta(hours=3, seconds=2, microseconds=1)
+        duration = Duration.from_hours(3) + Duration.from_seconds(2) + Duration.from_microseconds(1)
+        assert Duration.from_timedelta(td) == duration
+        assert duration.to_timedelta() == td
+        assert duration.total_seconds == td.total_seconds()
+
+        max_td_duration = (
+            Duration.from_days(timedelta.max.days)
+            + Duration.from_seconds(timedelta.max.seconds)
+            + Duration.from_microseconds(timedelta.max.microseconds)
+        )
+        assert Duration.from_timedelta(timedelta.max) == max_td_duration
+        assert max_td_duration.to_timedelta() == timedelta.max
+        assert (
+            max_td_duration.total_microseconds == timedelta.max.total_seconds() * PyodaConstants.MICROSECONDS_PER_SECOND
+        )
+
+        min_td_duration = (
+            Duration.from_days(timedelta.min.days)
+            + Duration.from_seconds(timedelta.min.seconds)
+            + Duration.from_microseconds(timedelta.min.microseconds)
+        )
+        assert Duration.from_timedelta(timedelta.min) == min_td_duration
+        assert (
+            min_td_duration.total_microseconds == timedelta.min.total_seconds() * PyodaConstants.MICROSECONDS_PER_SECOND
+        )
+        assert min_td_duration.to_timedelta() == timedelta.min
+
+        # The rest of the test documents how using timedelta.total_seconds() is slightly inaccurate.
+        assert timedelta.max.total_seconds() * PyodaConstants.MICROSECONDS_PER_SECOND != (
+            timedelta.max.days * PyodaConstants.MICROSECONDS_PER_DAY
+            + timedelta.max.seconds * PyodaConstants.MICROSECONDS_PER_SECOND
+            + timedelta.max.microseconds
+        )
+        assert timedelta.min.total_seconds() * PyodaConstants.MICROSECONDS_PER_SECOND != (
+            timedelta.min.days * PyodaConstants.MICROSECONDS_PER_DAY
+            + timedelta.min.seconds * PyodaConstants.MICROSECONDS_PER_SECOND
+            + timedelta.min.microseconds
+        )
+        assert duration.from_seconds(timedelta.max.total_seconds()) != max_td_duration
+        assert duration.from_seconds(timedelta.min.total_seconds()) != min_td_duration
+
+    def test_from_nanoseconds_int64(self) -> None:
+        assert Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY - 1) == Duration.one_day - Duration.epsilon
+        assert Duration.one_day == Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY)
+        assert Duration.one_day + Duration.epsilon == Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY + 1)
+
+        assert -Duration.one_day - Duration.epsilon == Duration.from_nanoseconds(
+            -PyodaConstants.NANOSECONDS_PER_DAY - 1
+        )
+        assert -Duration.one_day == Duration.from_nanoseconds(-PyodaConstants.NANOSECONDS_PER_DAY)
+        assert -Duration.one_day + Duration.epsilon == Duration.from_nanoseconds(
+            -PyodaConstants.NANOSECONDS_PER_DAY + 1
+        )
+
+    def test_from_nanoseconds_decimal_limits(self) -> None:
+        assert Duration.min_value == Duration._from_nanoseconds(Duration._MIN_DECIMAL_NANOSECONDS)
+        assert Duration.max_value == Duration._from_nanoseconds(Duration._MAX_DECIMAL_NANOSECONDS)
+        with pytest.raises(ValueError):
+            Duration._from_nanoseconds(Duration._MIN_DECIMAL_NANOSECONDS - 1)
+        with pytest.raises(ValueError):
+            Duration._from_nanoseconds(Duration._MAX_DECIMAL_NANOSECONDS + 1)
+
+    def test_from_nanoseconds_big_integer(self) -> None:
+        assert Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY - 1) == Duration.one_day - Duration.epsilon
+        assert Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY - 0) == Duration.one_day
+        assert Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY + 1) == Duration.one_day + Duration.epsilon
+
+        assert (
+            Duration.from_nanoseconds(-PyodaConstants.NANOSECONDS_PER_DAY - 1) == -Duration.one_day - Duration.epsilon
+        )
+        assert Duration.from_nanoseconds(-PyodaConstants.NANOSECONDS_PER_DAY - 0) == -Duration.one_day
+        assert (
+            Duration.from_nanoseconds(-PyodaConstants.NANOSECONDS_PER_DAY + 1) == -Duration.one_day + Duration.epsilon
+        )
+
+    def test_from_nanoseconds_double(self) -> None:
+        assert (
+            Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY - 1.0) == Duration.one_day - Duration.epsilon
+        )
+        assert Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY + 0.0) == Duration.one_day
+        assert (
+            Duration.from_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY + 1.0) == Duration.one_day + Duration.epsilon
+        )
+
+        assert (
+            Duration.from_nanoseconds(-PyodaConstants.NANOSECONDS_PER_DAY - 1.0) == -Duration.one_day - Duration.epsilon
+        )
+        assert Duration.from_nanoseconds(-PyodaConstants.NANOSECONDS_PER_DAY + 0.0) == -Duration.one_day
+        assert (
+            Duration.from_nanoseconds(-PyodaConstants.NANOSECONDS_PER_DAY + 1.0) == -Duration.one_day + Duration.epsilon
+        )
+
+        # Checks for values outside the range of long...
+        # Find a value which is pretty big, but will definitely still convert back to a positive long.
+        large_double_value = (_CsharpConstants.LONG_MAX_VALUE / 16) * 15
+        large_int64_value = int(large_double_value)  # This won't be exactly long.MaxValue
+        assert Duration.from_nanoseconds(large_double_value + 8.0) == Duration.from_nanoseconds(large_int64_value)
+
+    def test_factory_methods_out_of_range(self) -> None:
+        def assert_out_of_range(factory_method: Callable[[T], Duration], *values: T) -> None:
+            for value in values:
+                with pytest.raises(ValueError):  # TODO ArgumentOutOfRangeException
+                    factory_method(value)
+
+        def assert_limits_int32(factory_method: Callable[[int], Duration], all_cases: list[int]) -> None:
+            assert_out_of_range(factory_method, all_cases[0] - 1, all_cases[-1] + 1)
+
+        def assert_limits_int64(factory_method: Callable[[int], Duration], all_cases: list[int]) -> None:
+            assert_out_of_range(factory_method, all_cases[0] - 1, all_cases[-1] + 1)
+
+        # Each set of cases starts with the minimum and ends with the
+        # maximum, so we can test just beyond the limits easily.
+        assert_limits_int32(Duration.from_days, self.DAY_CASES)
+        assert_limits_int32(Duration.from_hours, self.HOUR_CASES)
+        assert_limits_int64(Duration.from_minutes, self.MINUTE_CASES)
+        assert_limits_int64(Duration.from_seconds, self.SECOND_CASES)
+        assert_limits_int64(Duration.from_milliseconds, self.MILLISECOND_CASES)
+        assert_limits_int64(Duration.from_microseconds, self.MICROSECOND_CASES)
+        # TODO: Duration.from_ticks(long) doesn't throw in C#, but in Python it probably *should* raise.
+        # from_ticks(long) never throws
+
+        big_bad_doubles = [
+            float("-inf"),  # double.NegativeInfinity
+            # The lowest possible non-infinite float is not `sys.float_info.min`.
+            # That merely gives you the "smallest" possible *positive* float.
+            # The *lowest* float is actually the negation of the maximum float.
+            -sys.float_info.max,  # double.MinValue
+            sys.float_info.max,  # double.MaxValue
+            float("inf"),  # double.PositiveInfinity
+            float("nan"),  # double.NaN
+        ]
+        assert_out_of_range(Duration.from_days, *big_bad_doubles)
+        assert_out_of_range(Duration.from_hours, *big_bad_doubles)
+        assert_out_of_range(Duration.from_minutes, *big_bad_doubles)
+        assert_out_of_range(Duration.from_seconds, *big_bad_doubles)
+        assert_out_of_range(Duration.from_milliseconds, *big_bad_doubles)
+        assert_out_of_range(Duration.from_ticks, *big_bad_doubles)
+        assert_out_of_range(Duration.from_nanoseconds, *big_bad_doubles)
+
+        # Noda Time has the following comment:
+        # No such concept as BigInteger.Min/MaxValue, so use the values we know to be just outside valid bounds.
+        assert_out_of_range(Duration.from_nanoseconds, Duration._MIN_NANOSECONDS - 1, Duration._MAX_NANOSECONDS + 1)
+
+
+class TestDurationOperators:
+    THREE_MILLION = Duration.from_nanoseconds(3000000)
+    NEGATIVE_FIFTY_MILLION = Duration.from_nanoseconds(-50000000)
+
+    # region operator +
+
+    def test_operator_plus_zero_is_neutral_element(self) -> None:
+        assert (Duration.zero + Duration.zero).to_nanoseconds() == 0, "0 + 0"
+        assert (Duration.epsilon + Duration.zero).to_nanoseconds() == 1, "1 + 0"
+        assert (Duration.zero + Duration.epsilon).to_nanoseconds() == 1, "0 + 1"
+
+    def test_operator_plus_non_zero(self) -> None:
+        assert (self.THREE_MILLION + Duration.epsilon).to_nanoseconds() == 3000001, "3,000,000 + 1"
+        assert (Duration.epsilon + Duration.from_nanoseconds(-1)).to_nanoseconds() == 0, "1 + (-1)"
+        assert (self.NEGATIVE_FIFTY_MILLION + Duration.epsilon).to_nanoseconds() == -49999999, "-50,000,000 + 1"
+
+    def test_operator_plus_method_equivalents(self) -> None:
+        x = Duration.from_nanoseconds(100)
+        y = Duration.from_nanoseconds(200)
+        assert Duration.add(x, y) == x + y
+        assert x.plus(y) == x + y
+
+    # endregion
+
+    # region operator -
+
+    def test_operator_minus_zero_is_neutral_element(self) -> None:
+        assert (Duration.zero - Duration.zero).to_nanoseconds() == 0, "0 - 0"
+        assert (Duration.epsilon - Duration.zero).to_nanoseconds() == 1, "1 - 0"
+        assert (Duration.zero - Duration.epsilon).to_nanoseconds() == -1, "0 - 1"
+
+    def test_operator_minus_non_zero(self) -> None:
+        negativeEpsilon = Duration.from_nanoseconds(-1)
+        assert (self.THREE_MILLION - Duration.epsilon).to_nanoseconds() == 2999999, "3,000,000 - 1"
+        assert (Duration.epsilon - negativeEpsilon).to_nanoseconds() == 2, "1 - (-1)"
+        assert (self.NEGATIVE_FIFTY_MILLION - Duration.epsilon).to_nanoseconds() == -50000001, "-50,000,000 - 1"
+
+    def test_operator_minus_method_equivalents(self) -> None:
+        x = Duration.from_nanoseconds(100)
+        y = Duration.from_nanoseconds(200)
+        assert Duration.subtract(x, y) == x - y
+        assert x.minus(y) == x - y
+
+    # endregion
+
+    # region operator /
+
+    @pytest.mark.parametrize(
+        "days,nano_of_day,divisor,expected_days,expected_nano_of_day",
+        [
+            (1, 0, 2, 0, PyodaConstants.NANOSECONDS_PER_DAY / 2),
+            (0, 3000000, 3000, 0, 1000),
+            (0, 3000000, 2000000, 0, 1),
+            (0, 3000000, -2000000, -1, PyodaConstants.NANOSECONDS_PER_DAY - 1),
+        ],
+    )
+    def test_operator_division_int64(
+        self, days: int, nano_of_day: int, divisor: int, expected_days: int, expected_nano_of_day: int
+    ) -> None:
+        duration = Duration._ctor(days=days, nano_of_day=nano_of_day)
+        actual = duration / divisor
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "days,nano_of_day,divisor,expected_days,expected_nano_of_day",
+        [
+            (2, 100, 2.0, 1, 50),
+            (2, PyodaConstants.NANOSECONDS_PER_DAY / 2, -0.5, -5, 0),
+            (1, 0, 2, 0, PyodaConstants.NANOSECONDS_PER_DAY / 2),
+        ],
+    )
+    def test_operator_division_double(
+        self, days: int, nano_of_day: int, divisor: float, expected_days: int, expected_nano_of_day: int
+    ) -> None:
+        duration = Duration._ctor(days=days, nano_of_day=nano_of_day)
+        actual = duration / divisor
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nano_of_day)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "dividend_days,dividend_nano_of_day,divisor_days,divisor_nano_of_day,expected",
+        [
+            (1, 0, 2, 0, 0.5),
+            (1, 0, 0, PyodaConstants.NANOSECONDS_PER_DAY / 2, 2.0),
+            (-1, 0, 3, 0, -1 / 3.0),
+        ],
+    )
+    def test_operator_division_duration(
+        self,
+        dividend_days: int,
+        dividend_nano_of_day: int,
+        divisor_days: int,
+        divisor_nano_of_day: int,
+        expected: float,
+    ) -> None:
+        dividend = Duration._ctor(days=dividend_days, nano_of_day=dividend_nano_of_day)
+        divisor = Duration._ctor(days=divisor_days, nano_of_day=divisor_nano_of_day)
+        actual = dividend / divisor
+        assert actual == expected
+
+    def test_operator_division_by_zero_throws(self) -> None:
+        with pytest.raises(ZeroDivisionError):
+            str(self.THREE_MILLION / 0.0), "3000000 / 0"
+        with pytest.raises(ZeroDivisionError):
+            str(self.THREE_MILLION / 0), "3000000 / 0"
+        with pytest.raises(ZeroDivisionError):
+            str(self.THREE_MILLION / Duration.zero), "3000000 / 0"
+
+    def test_operator_division_method_equivalent(self) -> None:
+        assert Duration.divide(self.THREE_MILLION, 2000000) == self.THREE_MILLION / 2000000
+        assert Duration.divide(self.THREE_MILLION, 2000000.0) == self.THREE_MILLION / 2000000.0
+        assert (
+            Duration.divide(self.NEGATIVE_FIFTY_MILLION, self.THREE_MILLION)
+            == self.NEGATIVE_FIFTY_MILLION / self.THREE_MILLION
+        )
+
+    # endregion
+
+    # region operator *
+
+    @pytest.mark.parametrize(
+        "days,nanos,right_operand",
+        [
+            # "Old" non-zero non-one test cases for posterity's sake.
+            (0, 3000, 1000),
+            (0, 50000, -1000),
+            (0, -50000, 1000),
+            (0, -3000, -1000),
+            # Zero
+            (0, 0, 0),
+            (0, 1, 0),
+            (0, 3000000, 0),
+            (0, -50000000, 0),
+            (1, 1, 0),
+            (0, 0, 10),
+            (0, 0, -10),
+            # One
+            (0, 3000000, 1),
+            (0, 0, 1),
+            (0, -5000000, 1),
+            # More interesting cases - explore the boundaries of the fast path.
+            # This currently assumes that we're optimizing on multiplying "less than 100 days"
+            # by less than "about a thousand". There's a comment in the code near that constant
+            # to indicate that these tests would need to change if that constant changes.
+            (-99, 10000, 800),
+            (-101, 10000, 800),
+            (-99, 10000, 1234),
+            (-101, 10000, 1234),
+            (-99, 10000, -800),
+            (-101, 10000, -800),
+            (-99, 10000, -1234),
+            (-101, 10000, -1234),
+            (99, 10000, 800),
+            (101, 10000, 800),
+            (99, 10000, 1234),
+            (101, 10000, 1234),
+            (99, 10000, -800),
+            (101, 10000, -800),
+            (99, 10000, -1234),
+            (101, 10000, -1234),
+        ],
+    )
+    def test_operator_multiplication_int64(self, days: int, nanos: int, right_operand: int) -> None:
+        # Rather than expressing an expected answer, just do a "long-hand" version
+        # using ToBigIntegerNanoseconds and FromNanoseconds, trusting those two operations
+        # to be correct.
+        duration = Duration.from_days(days) + Duration.from_nanoseconds(nanos)
+        actual = duration * right_operand
+
+        expected = Duration.from_nanoseconds(duration.to_nanoseconds()) * right_operand
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "days,nanos,right_operand,expected_days,expected_nanos",
+        [
+            (1, 0, 0.5, 0, PyodaConstants.NANOSECONDS_PER_DAY / 2),
+            (1, 200, 2.5, 2, PyodaConstants.NANOSECONDS_PER_DAY / 2 + 500),
+            (-2, PyodaConstants.NANOSECONDS_PER_DAY / 2, 2.0, -3, 0),
+        ],
+    )
+    def test_operator_multiplication_double(
+        self, days: int, nanos: int, right_operand: int, expected_days: int, expected_nanos: int
+    ) -> None:
+        start = Duration._ctor(days=days, nano_of_day=nanos)
+        actual = start * right_operand
+        expected = Duration._ctor(days=expected_days, nano_of_day=expected_nanos)
+        assert actual == expected
+        actual = right_operand * start
+        assert actual == expected
+
+    def test_commutation(self) -> None:
+        assert 5 * self.THREE_MILLION == self.THREE_MILLION * 5
+        assert 5.5 * self.THREE_MILLION == self.THREE_MILLION * 5.5
+
+    def test_operator_multiplication_method_equivalents(self) -> None:
+        assert Duration.from_nanoseconds(-50000) * 1000 == Duration.multiply(Duration.from_nanoseconds(-50000), 1000)
+        assert 1000 * Duration.from_nanoseconds(-50000) == Duration.multiply(1000, Duration.from_nanoseconds(-50000))
+        assert Duration.from_nanoseconds(-50000) * 1000.0 == Duration.multiply(
+            Duration.from_nanoseconds(-50000), 1000.0
+        )
+        assert 1000.0 * Duration.from_nanoseconds(-50000) == Duration.multiply(
+            1000.0, Duration.from_nanoseconds(-50000)
+        )
+
+    # endregion
+
+    def test_unary_minus_and_negate(self) -> None:
+        start = Duration.from_nanoseconds(5000)
+        expected = Duration.from_nanoseconds(-5000)
+        assert -start == expected
+        assert Duration.negate(start) == expected

--- a/tests/test_instant.py
+++ b/tests/test_instant.py
@@ -104,7 +104,7 @@ class TestInstant:
         assert instant.to_unix_time_milliseconds() == expected_milliseconds
 
     def test_unix_conversions_extreme_values(self) -> None:
-        max_ = Instant.max_value - Duration.from_seconds(1) + Duration.epsilon()
+        max_ = Instant.max_value - Duration.from_seconds(1) + Duration.epsilon
         assert Instant.from_unix_time_seconds(max_.to_unix_time_seconds()) == max_
         assert Instant.from_unix_time_milliseconds(max_.to_unix_time_milliseconds()) == max_
         assert Instant.from_unix_time_ticks(max_.to_unix_time_ticks()) == max_
@@ -203,9 +203,9 @@ class TestInstant:
 
     def test_plus_duration_overflow(self) -> None:
         with pytest.raises(OverflowError):
-            Instant.min_value.plus(-Duration.epsilon())
+            Instant.min_value.plus(-Duration.epsilon)
         with pytest.raises(OverflowError):
-            Instant.max_value.plus(Duration.epsilon())
+            Instant.max_value.plus(Duration.epsilon)
 
     def test_extreme_arithmetic(self) -> None:
         huge_and_positive = Instant.max_value - Instant.min_value


### PR DESCRIPTION
Implements the `Duration` class.

Besides porting the corresponding Noda Time struct, there are a few differences/additions:
- `Duration.FromTimeSpan()`/`Duration.ToTimeSpan()` has been implemented as `Duration.to_timedelta()` and `Duration.from_timedelta()`
- Added initial support for microseconds, as this is probably a more common resolution for Python developers than ticks or nanoseconds. This includes:
  - Additions to `PyodaConstants`
  - Additional properties/methods such as `Duration.microseconds`, `Duration.from_microseconds`...
