### PR TITLE
feat: Implement `OffsetPattern`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -137,13 +137,13 @@ files = [
 
 [[package]]
 name = "commitizen"
-version = "3.14.0"
+version = "3.15.0"
 description = "Python commitizen client tool"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "commitizen-3.14.0-py3-none-any.whl", hash = "sha256:5345a118f2a0b2b8fcfc5fcfea7945f8c984803836a1735199d469e865be4efb"},
-    {file = "commitizen-3.14.0.tar.gz", hash = "sha256:3c799dc0ffb2c99d021edd32de55ddce182635bf6129ac6abf223696ccbdd1a7"},
+    {file = "commitizen-3.15.0-py3-none-any.whl", hash = "sha256:5f9f9097f1f14c943982fe159905b1e895f4686f15b7aaa62a1e913fa89f2d6f"},
+    {file = "commitizen-3.15.0.tar.gz", hash = "sha256:10b9cc1013a87aaca30562f9f5ac6ddaad47c336f7eee6fbfd11e92b820eee39"},
 ]
 
 [package.dependencies]
@@ -161,63 +161,63 @@ tomlkit = ">=0.5.3,<1.0.0"
 
 [[package]]
 name = "coverage"
-version = "7.4.1"
+version = "7.4.2"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:077d366e724f24fc02dbfe9d946534357fda71af9764ff99d73c3c596001bbd7"},
-    {file = "coverage-7.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0193657651f5399d433c92f8ae264aff31fc1d066deee4b831549526433f3f61"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d17bbc946f52ca67adf72a5ee783cd7cd3477f8f8796f59b4974a9b59cacc9ee"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3277f5fa7483c927fe3a7b017b39351610265308f5267ac6d4c2b64cc1d8d25"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dceb61d40cbfcf45f51e59933c784a50846dc03211054bd76b421a713dcdf19"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6008adeca04a445ea6ef31b2cbaf1d01d02986047606f7da266629afee982630"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c61f66d93d712f6e03369b6a7769233bfda880b12f417eefdd4f16d1deb2fc4c"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9bb62fac84d5f2ff523304e59e5c439955fb3b7f44e3d7b2085184db74d733b"},
-    {file = "coverage-7.4.1-cp310-cp310-win32.whl", hash = "sha256:f86f368e1c7ce897bf2457b9eb61169a44e2ef797099fb5728482b8d69f3f016"},
-    {file = "coverage-7.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:869b5046d41abfea3e381dd143407b0d29b8282a904a19cb908fa24d090cc018"},
-    {file = "coverage-7.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8ffb498a83d7e0305968289441914154fb0ef5d8b3157df02a90c6695978295"},
-    {file = "coverage-7.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3cacfaefe6089d477264001f90f55b7881ba615953414999c46cc9713ff93c8c"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d6850e6e36e332d5511a48a251790ddc545e16e8beaf046c03985c69ccb2676"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18e961aa13b6d47f758cc5879383d27b5b3f3dcd9ce8cdbfdc2571fe86feb4dd"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dfd1e1b9f0898817babf840b77ce9fe655ecbe8b1b327983df485b30df8cc011"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6b00e21f86598b6330f0019b40fb397e705135040dbedc2ca9a93c7441178e74"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:536d609c6963c50055bab766d9951b6c394759190d03311f3e9fcf194ca909e1"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7ac8f8eb153724f84885a1374999b7e45734bf93a87d8df1e7ce2146860edef6"},
-    {file = "coverage-7.4.1-cp311-cp311-win32.whl", hash = "sha256:f3771b23bb3675a06f5d885c3630b1d01ea6cac9e84a01aaf5508706dba546c5"},
-    {file = "coverage-7.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:9d2f9d4cc2a53b38cabc2d6d80f7f9b7e3da26b2f53d48f05876fef7956b6968"},
-    {file = "coverage-7.4.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f68ef3660677e6624c8cace943e4765545f8191313a07288a53d3da188bd8581"},
-    {file = "coverage-7.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23b27b8a698e749b61809fb637eb98ebf0e505710ec46a8aa6f1be7dc0dc43a6"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e3424c554391dc9ef4a92ad28665756566a28fecf47308f91841f6c49288e66"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0860a348bf7004c812c8368d1fc7f77fe8e4c095d661a579196a9533778e156"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe558371c1bdf3b8fa03e097c523fb9645b8730399c14fe7721ee9c9e2a545d3"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3468cc8720402af37b6c6e7e2a9cdb9f6c16c728638a2ebc768ba1ef6f26c3a1"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:02f2edb575d62172aa28fe00efe821ae31f25dc3d589055b3fb64d51e52e4ab1"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ca6e61dc52f601d1d224526360cdeab0d0712ec104a2ce6cc5ccef6ed9a233bc"},
-    {file = "coverage-7.4.1-cp312-cp312-win32.whl", hash = "sha256:ca7b26a5e456a843b9b6683eada193fc1f65c761b3a473941efe5a291f604c74"},
-    {file = "coverage-7.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:85ccc5fa54c2ed64bd91ed3b4a627b9cce04646a659512a051fa82a92c04a448"},
-    {file = "coverage-7.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8bdb0285a0202888d19ec6b6d23d5990410decb932b709f2b0dfe216d031d218"},
-    {file = "coverage-7.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:918440dea04521f499721c039863ef95433314b1db00ff826a02580c1f503e45"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:379d4c7abad5afbe9d88cc31ea8ca262296480a86af945b08214eb1a556a3e4d"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b094116f0b6155e36a304ff912f89bbb5067157aff5f94060ff20bbabdc8da06"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2f5968608b1fe2a1d00d01ad1017ee27efd99b3437e08b83ded9b7af3f6f766"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:10e88e7f41e6197ea0429ae18f21ff521d4f4490aa33048f6c6f94c6045a6a75"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a4a3907011d39dbc3e37bdc5df0a8c93853c369039b59efa33a7b6669de04c60"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6d224f0c4c9c98290a6990259073f496fcec1b5cc613eecbd22786d398ded3ad"},
-    {file = "coverage-7.4.1-cp38-cp38-win32.whl", hash = "sha256:23f5881362dcb0e1a92b84b3c2809bdc90db892332daab81ad8f642d8ed55042"},
-    {file = "coverage-7.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:a07f61fc452c43cd5328b392e52555f7d1952400a1ad09086c4a8addccbd138d"},
-    {file = "coverage-7.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8e738a492b6221f8dcf281b67129510835461132b03024830ac0e554311a5c54"},
-    {file = "coverage-7.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46342fed0fff72efcda77040b14728049200cbba1279e0bf1188f1f2078c1d70"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9641e21670c68c7e57d2053ddf6c443e4f0a6e18e547e86af3fad0795414a628"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aeb2c2688ed93b027eb0d26aa188ada34acb22dceea256d76390eea135083950"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d12c923757de24e4e2110cf8832d83a886a4cf215c6e61ed506006872b43a6d1"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0491275c3b9971cdbd28a4595c2cb5838f08036bca31765bad5e17edf900b2c7"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8dfc5e195bbef80aabd81596ef52a1277ee7143fe419efc3c4d8ba2754671756"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1a78b656a4d12b0490ca72651fe4d9f5e07e3c6461063a9b6265ee45eb2bdd35"},
-    {file = "coverage-7.4.1-cp39-cp39-win32.whl", hash = "sha256:f90515974b39f4dea2f27c0959688621b46d96d5a626cf9c53dbc653a895c05c"},
-    {file = "coverage-7.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:64e723ca82a84053dd7bfcc986bdb34af8d9da83c521c19d6b472bc6880e191a"},
-    {file = "coverage-7.4.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:32a8d985462e37cfdab611a6f95b09d7c091d07668fdc26e47a725ee575fe166"},
-    {file = "coverage-7.4.1.tar.gz", hash = "sha256:1ed4b95480952b1a26d863e546fa5094564aa0065e1e5f0d4d0041f293251d04"},
+    {file = "coverage-7.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bf54c3e089179d9d23900e3efc86d46e4431188d9a657f345410eecdd0151f50"},
+    {file = "coverage-7.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fe6e43c8b510719b48af7db9631b5fbac910ade4bd90e6378c85ac5ac706382c"},
+    {file = "coverage-7.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b98c89db1b150d851a7840142d60d01d07677a18f0f46836e691c38134ed18b"},
+    {file = "coverage-7.4.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5f9683be6a5b19cd776ee4e2f2ffb411424819c69afab6b2db3a0a364ec6642"},
+    {file = "coverage-7.4.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78cdcbf7b9cb83fe047ee09298e25b1cd1636824067166dc97ad0543b079d22f"},
+    {file = "coverage-7.4.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2599972b21911111114100d362aea9e70a88b258400672626efa2b9e2179609c"},
+    {file = "coverage-7.4.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ef00d31b7569ed3cb2036f26565f1984b9fc08541731ce01012b02a4c238bf03"},
+    {file = "coverage-7.4.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:20a875bfd8c282985c4720c32aa05056f77a68e6d8bbc5fe8632c5860ee0b49b"},
+    {file = "coverage-7.4.2-cp310-cp310-win32.whl", hash = "sha256:b3f2b1eb229f23c82898eedfc3296137cf1f16bb145ceab3edfd17cbde273fb7"},
+    {file = "coverage-7.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:7df95fdd1432a5d2675ce630fef5f239939e2b3610fe2f2b5bf21fa505256fa3"},
+    {file = "coverage-7.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a8ddbd158e069dded57738ea69b9744525181e99974c899b39f75b2b29a624e2"},
+    {file = "coverage-7.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81a5fb41b0d24447a47543b749adc34d45a2cf77b48ca74e5bf3de60a7bd9edc"},
+    {file = "coverage-7.4.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2412e98e70f16243be41d20836abd5f3f32edef07cbf8f407f1b6e1ceae783ac"},
+    {file = "coverage-7.4.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ddb79414c15c6f03f56cc68fa06994f047cf20207c31b5dad3f6bab54a0f66ef"},
+    {file = "coverage-7.4.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf89ab85027427d351f1de918aff4b43f4eb5f33aff6835ed30322a86ac29c9e"},
+    {file = "coverage-7.4.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a178b7b1ac0f1530bb28d2e51f88c0bab3e5949835851a60dda80bff6052510c"},
+    {file = "coverage-7.4.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:06fe398145a2e91edaf1ab4eee66149c6776c6b25b136f4a86fcbbb09512fd10"},
+    {file = "coverage-7.4.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:18cac867950943fe93d6cd56a67eb7dcd2d4a781a40f4c1e25d6f1ed98721a55"},
+    {file = "coverage-7.4.2-cp311-cp311-win32.whl", hash = "sha256:f72cdd2586f9a769570d4b5714a3837b3a59a53b096bb954f1811f6a0afad305"},
+    {file = "coverage-7.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:d779a48fac416387dd5673fc5b2d6bd903ed903faaa3247dc1865c65eaa5a93e"},
+    {file = "coverage-7.4.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:adbdfcda2469d188d79771d5696dc54fab98a16d2ef7e0875013b5f56a251047"},
+    {file = "coverage-7.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ac4bab32f396b03ebecfcf2971668da9275b3bb5f81b3b6ba96622f4ef3f6e17"},
+    {file = "coverage-7.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:006d220ba2e1a45f1de083d5022d4955abb0aedd78904cd5a779b955b019ec73"},
+    {file = "coverage-7.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3733545eb294e5ad274abe131d1e7e7de4ba17a144505c12feca48803fea5f64"},
+    {file = "coverage-7.4.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42a9e754aa250fe61f0f99986399cec086d7e7a01dd82fd863a20af34cbce962"},
+    {file = "coverage-7.4.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2ed37e16cf35c8d6e0b430254574b8edd242a367a1b1531bd1adc99c6a5e00fe"},
+    {file = "coverage-7.4.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b953275d4edfab6cc0ed7139fa773dfb89e81fee1569a932f6020ce7c6da0e8f"},
+    {file = "coverage-7.4.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32b4ab7e6c924f945cbae5392832e93e4ceb81483fd6dc4aa8fb1a97b9d3e0e1"},
+    {file = "coverage-7.4.2-cp312-cp312-win32.whl", hash = "sha256:f5df76c58977bc35a49515b2fbba84a1d952ff0ec784a4070334dfbec28a2def"},
+    {file = "coverage-7.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:34423abbaad70fea9d0164add189eabaea679068ebdf693baa5c02d03e7db244"},
+    {file = "coverage-7.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5b11f9c6587668e495cc7365f85c93bed34c3a81f9f08b0920b87a89acc13469"},
+    {file = "coverage-7.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:51593a1f05c39332f623d64d910445fdec3d2ac2d96b37ce7f331882d5678ddf"},
+    {file = "coverage-7.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69f1665165ba2fe7614e2f0c1aed71e14d83510bf67e2ee13df467d1c08bf1e8"},
+    {file = "coverage-7.4.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3c8bbb95a699c80a167478478efe5e09ad31680931ec280bf2087905e3b95ec"},
+    {file = "coverage-7.4.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:175f56572f25e1e1201d2b3e07b71ca4d201bf0b9cb8fad3f1dfae6a4188de86"},
+    {file = "coverage-7.4.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8562ca91e8c40864942615b1d0b12289d3e745e6b2da901d133f52f2d510a1e3"},
+    {file = "coverage-7.4.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d9a1ef0f173e1a19738f154fb3644f90d0ada56fe6c9b422f992b04266c55d5a"},
+    {file = "coverage-7.4.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f40ac873045db4fd98a6f40387d242bde2708a3f8167bd967ccd43ad46394ba2"},
+    {file = "coverage-7.4.2-cp38-cp38-win32.whl", hash = "sha256:d1b750a8409bec61caa7824bfd64a8074b6d2d420433f64c161a8335796c7c6b"},
+    {file = "coverage-7.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:b4ae777bebaed89e3a7e80c4a03fac434a98a8abb5251b2a957d38fe3fd30088"},
+    {file = "coverage-7.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3ff7f92ae5a456101ca8f48387fd3c56eb96353588e686286f50633a611afc95"},
+    {file = "coverage-7.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:861d75402269ffda0b33af94694b8e0703563116b04c681b1832903fac8fd647"},
+    {file = "coverage-7.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3507427d83fa961cbd73f11140f4a5ce84208d31756f7238d6257b2d3d868405"},
+    {file = "coverage-7.4.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bf711d517e21fb5bc429f5c4308fbc430a8585ff2a43e88540264ae87871e36a"},
+    {file = "coverage-7.4.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c00e54f0bd258ab25e7f731ca1d5144b0bf7bec0051abccd2bdcff65fa3262c9"},
+    {file = "coverage-7.4.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f8e845d894e39fb53834da826078f6dc1a933b32b1478cf437007367efaf6f6a"},
+    {file = "coverage-7.4.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:840456cb1067dc350af9080298c7c2cfdddcedc1cb1e0b30dceecdaf7be1a2d3"},
+    {file = "coverage-7.4.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c11ca2df2206a4e3e4c4567f52594637392ed05d7c7fb73b4ea1c658ba560265"},
+    {file = "coverage-7.4.2-cp39-cp39-win32.whl", hash = "sha256:3ff5bdb08d8938d336ce4088ca1a1e4b6c8cd3bef8bb3a4c0eb2f37406e49643"},
+    {file = "coverage-7.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:ac9e95cefcf044c98d4e2c829cd0669918585755dd9a92e28a1a7012322d0a95"},
+    {file = "coverage-7.4.2-pp38.pp39.pp310-none-any.whl", hash = "sha256:f593a4a90118d99014517c2679e04a4ef5aee2d81aa05c26c734d271065efcb6"},
+    {file = "coverage-7.4.2.tar.gz", hash = "sha256:1a5ee18e3a8d766075ce9314ed1cb695414bae67df6a4b0805f5137d93d6f1cb"},
 ]
 
 [package.extras]
@@ -263,13 +263,13 @@ typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
 name = "identify"
-version = "2.5.33"
+version = "2.5.35"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.5.33-py2.py3-none-any.whl", hash = "sha256:d40ce5fcd762817627670da8a7d8d8e65f24342d14539c59488dc603bf662e34"},
-    {file = "identify-2.5.33.tar.gz", hash = "sha256:161558f9fe4559e1557e1bff323e8631f6a0e4837f7497767c1782832f16b62d"},
+    {file = "identify-2.5.35-py2.py3-none-any.whl", hash = "sha256:c4de0081837b211594f8e877a6b4fad7ca32bbfc1a9307fdd61c28bfe923f13e"},
+    {file = "identify-2.5.35.tar.gz", hash = "sha256:10a7ca245cfcd756a554a7288159f72ff105ad233c7c4b9c6f0f4d108f5f6791"},
 ]
 
 [package.extras]
@@ -448,13 +448,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "3.6.0"
+version = "3.6.2"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pre_commit-3.6.0-py2.py3-none-any.whl", hash = "sha256:c255039ef399049a5544b6ce13d135caba8f2c28c3b4033277a788f434308376"},
-    {file = "pre_commit-3.6.0.tar.gz", hash = "sha256:d30bad9abf165f7785c15a21a1f46da7d0677cb00ee7ff4c579fd38922efe15d"},
+    {file = "pre_commit-3.6.2-py2.py3-none-any.whl", hash = "sha256:ba637c2d7a670c10daedc059f5c49b5bd0aadbccfcd7ec15592cf9665117532c"},
+    {file = "pre_commit-3.6.2.tar.gz", hash = "sha256:c3ef34f463045c88658c5b99f38c1e297abdcc0ff13f98d3370055fbbfabc67e"},
 ]
 
 [package.dependencies]
@@ -479,14 +479,24 @@ files = [
 wcwidth = "*"
 
 [[package]]
+name = "pyicu"
+version = "2.12"
+description = "Python extension wrapping the ICU C++ API"
+optional = false
+python-versions = "*"
+files = [
+    {file = "PyICU-2.12.tar.gz", hash = "sha256:bd7ab5efa93ad692e6daa29cd249364e521218329221726a113ca3cb281c8611"},
+]
+
+[[package]]
 name = "pytest"
-version = "8.0.0"
+version = "8.0.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.0.0-py3-none-any.whl", hash = "sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6"},
-    {file = "pytest-8.0.0.tar.gz", hash = "sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c"},
+    {file = "pytest-8.0.1-py3-none-any.whl", hash = "sha256:3e4f16fe1c0a9dc9d9389161c127c3edc5d810c38d6793042fb81d9f48a59fca"},
+    {file = "pytest-8.0.1.tar.gz", hash = "sha256:267f6563751877d772019b13aacbe4e860d73fe8f651f28112e9ac37de7513ae"},
 ]
 
 [package.dependencies]
@@ -584,18 +594,18 @@ prompt_toolkit = ">=2.0,<=3.0.36"
 
 [[package]]
 name = "setuptools"
-version = "69.0.3"
+version = "69.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.0.3-py3-none-any.whl", hash = "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
-    {file = "setuptools-69.0.3.tar.gz", hash = "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"},
+    {file = "setuptools-69.1.0-py3-none-any.whl", hash = "sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6"},
+    {file = "setuptools-69.1.0.tar.gz", hash = "sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -625,13 +635,13 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.25.0"
+version = "20.25.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.25.0-py3-none-any.whl", hash = "sha256:4238949c5ffe6876362d9c0180fc6c3a824a7b12b80604eeb8085f2ed7460de3"},
-    {file = "virtualenv-20.25.0.tar.gz", hash = "sha256:bf51c0d9c7dd63ea8e44086fa1e4fb1093a31e963b86959257378aef020e1f1b"},
+    {file = "virtualenv-20.25.1-py3-none-any.whl", hash = "sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a"},
+    {file = "virtualenv-20.25.1.tar.gz", hash = "sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"},
 ]
 
 [package.dependencies]
@@ -672,4 +682,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "db004e7dccb24feb079d458d75fb14f1c19850b8683b3b47fd93fcc3a3ac36bf"
+content-hash = "f81ad1a65a73f9c9ba108b5ced63b199fe6adb03dcf4104aa425209d9da1e27b"

--- a/pyoda_time/__init__.py
+++ b/pyoda_time/__init__.py
@@ -30,6 +30,8 @@ __all__: list[str] = [
 from . import (
     calendars,  # noqa: F401
     fields,  # noqa: F401
+    globalization,  # noqa: F401
+    text,  # noqa: F401
     time_zones,  # noqa: F401
     utility,  # noqa: F401
 )

--- a/pyoda_time/_compatibility/__init__.py
+++ b/pyoda_time/_compatibility/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+

--- a/pyoda_time/_compatibility/_calendar.py
+++ b/pyoda_time/_compatibility/_calendar.py
@@ -1,0 +1,14 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from abc import ABC
+
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class Calendar(ABC):  # TODO: ICloneable
+    """A bare-bones equivalent to the ``System.Globalization.Calendar`` abstract class in .NET."""
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.UNINITIALIZED_VALUE

--- a/pyoda_time/_compatibility/_calendar_id.py
+++ b/pyoda_time/_compatibility/_calendar_id.py
@@ -1,0 +1,37 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+
+from enum import Enum
+
+
+class _CalendarId(Enum):
+    """A port of the ``System.Globalization.CalendarId`` internal enum in .NET."""
+
+    UNINITIALIZED_VALUE = 0
+    GREGORIAN = 1  # Gregorian (localized) calendar
+    GREGORIAN_US = 2  # Gregorian (U.S.) calendar
+    JAPAN = 3  # Japanese Emperor Era calendar
+    TAIWAN = 4  # Taiwan Era calendar /* SSS_WARNINGS_ON */
+    KOREA = 5  # Korean Tangun Era calendar
+    HIJRI = 6  # Hijri (Arabic Lunar) calendar
+    THAI = 7  # Thai calendar
+    HEBREW = 8  # Hebrew (Lunar) calendar
+    GREGORIAN_ME_FRENCH = 9  # Gregorian Middle East French calendar
+    GREGORIAN_ARABIC = 10  # Gregorian Arabic calendar
+    GREGORIAN_XLIT_ENGLISH = 11  # Gregorian Transliterated English calendar
+    GREGORIAN_XLIT_FRENCH = 12
+    # Note that all calendars after this point are MANAGED ONLY for now.
+    JULIAN = 13
+    JAPANESELUNISOLAR = 14
+    CHINESELUNISOLAR = 15
+    SAKA = 16  # reserved to match Office but not implemented in our code
+    LUNAR_ETO_CHN = 17  # reserved to match Office but not implemented in our code
+    LUNAR_ETO_KOR = 18  # reserved to match Office but not implemented in our code
+    LUNAR_ETO_ROKUYOU = 19  # reserved to match Office but not implemented in our code
+    KOREANLUNISOLAR = 20
+    TAIWANLUNISOLAR = 21
+    PERSIAN = 22
+    UMALQURA = 23
+    LAST_CALENDAR = 23  # Last calendar ID

--- a/pyoda_time/_compatibility/_culture_data.py
+++ b/pyoda_time/_compatibility/_culture_data.py
@@ -1,0 +1,306 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+import copy
+import typing
+from typing import Iterable
+
+import icu
+
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._gregorian_calendar import GregorianCalendar
+from pyoda_time._compatibility._string_builder import StringBuilder
+
+if typing.TYPE_CHECKING:
+    from pyoda_time._compatibility._number_format_info import NumberFormatInfo
+
+
+class _CultureDataMeta(type):
+    """Metaclass for CultureData static properties."""
+
+    @property
+    def invariant(self) -> _CultureData:
+        """Equivalent to CultureData.Invariant in .NET.
+
+        The invariant culture independent of any particular real-world locale.
+
+        Whereas in .NET it is a set of hard-coded definitions within the CultureData
+        class itself, here we are creating a PyICU.Locale with an empty name.
+
+        PyICU accepts this name and gives us back a Locale with default (i.e. invariant)
+        defaults.
+
+        Whether the values which that Locale gives us are the same as those of the invariant culture
+        in .NET remains to be seen, but so far it does...
+        """
+        return _CultureData("C")
+
+
+class _CultureData(metaclass=_CultureDataMeta):
+    """A bare-bones port of the ``System.Globalization.CultureData`` internal class in .NET.
+
+    In .NET this is a partial class with four source files.
+
+    * CultureData.cs
+    * CultureData.Icu.cs
+    * CultureData.Nls.cs
+    * CultureData.Unix.cs
+
+    In .NET, culture (locale) data is typically gleaned from ICU (International Components for Unicode).
+
+    https://unicode-org.github.io/icu-docs/
+
+    .NET interacts with ICU's C/C++ API via a dotnet runtime interop layer within System.Globalization.Native:
+
+    https://github.com/dotnet/runtime/blob/cc89d7db095028948afde863114b3ca04147477d/src/native/libs/System.Globalization.Native/pal_locale.c
+
+    In .NET Framework, CultureData is an internal C# abstraction over those interop layer calls to ICU's C++ API.
+
+    This Python implementation relies on the PyICU library, which is python bindings for ICU's C++ API,
+    to emulate the functionality of ``CultureData`` in .NET.
+
+    Unlike the .NET CultureData, there is no support for NLS, which is Microsoft's own localisation information.
+
+    (That is unlikely to change; As of dotnet 5, the globalization mode defaults to ICU over NLS.)
+    """
+
+    def __init__(self, name: str = "") -> None:
+        name = name.strip()
+
+        if name in ("", "C", "c"):
+            # Using this as roughly equivalent to the "Invariant" CultureInfo name
+            icu_compatible_name = ""
+        else:
+            # ICU uses underscores (en_US), whereas dotnet typically uses hyphens (en-US),
+            # although internally dotnet allows for locale names to be formatted either way.
+            # Let's be kind to folks coming to the library who are familiar with .NET.
+            icu_compatible_name = name.replace("-", "_")
+
+            if not self.__is_valid_culture_name(icu_compatible_name):
+                raise ValueError(f"{name} is not a valid culture name.")
+
+            available_locales: Iterable[str] = icu.Locale.getAvailableLocales().keys()
+
+            # TODO: Should this be case-insensitive?
+            #  My gut says no, because we don't own the data.
+            #  Better to be strict at first then more lenient
+            #  later than the other way around.
+            if icu_compatible_name not in available_locales:
+                # PyICU doesn't do this validation for us.
+                # If we don't do this check ourselves, it will
+                # happily just return a locale with our name
+                # with the default values for locale data.
+                raise ValueError(f"Unknown locale: {name}")
+
+        self.__raw_name: str = name
+        self.__locale: icu.Locale = icu.Locale(icu_compatible_name)
+
+    @property
+    def _culture_name(self) -> str:
+        """The real name used to construct the locale (ie: de-DE_phoneb)."""
+        return self.__raw_name
+
+    @property
+    def name(self) -> str:
+        """Locale name (ie: de-DE, NO sort information)"""
+        return str(self.__locale.getName())  # Wrapped in str() for mypy reasons
+
+    @staticmethod
+    def __is_valid_culture_name(subject: str) -> tuple[bool, int, int]:
+        """Port of the private static ``CultueData.IsValidCultureName()`` method in .NET.
+
+        In .NET this method is 'a fast approximate implementation based on the BCP47 spec'.
+
+        https://en.wikipedia.org/wiki/IETF_language_tag
+
+        When it returns False, the input is definitely wrong. However, it may return True in some
+        cases where the name contains characters which aren't strictly allowed by the spec.
+
+        It accommodates the input length of zero for invariant culture purposes.
+        """
+
+        index_of_underscore = -1
+        index_of_extensions = -1
+        if len(subject) == 0:
+            return True, index_of_underscore, index_of_extensions
+        if len(subject) == 1 or len(subject) > 85:
+            return False, index_of_underscore, index_of_extensions
+
+        flag = False
+        for index, ch in enumerate(subject):
+            if not ("A" <= ch <= "Z" or "a" <= ch <= "z" or ch in "0123456789" or ch in ["-", "_"]):
+                return False, index_of_underscore, index_of_extensions
+
+            if ch in ["-", "_"]:
+                if index == 0 or index == len(subject) - 1 or subject[index - 1] in ["_", "-"]:
+                    return False, index_of_underscore, index_of_extensions
+                if ch == "_":
+                    if flag:
+                        return False, index_of_underscore, index_of_extensions
+                    flag = True
+                    index_of_underscore = index
+                elif ch == "-" and index_of_extensions < 0 and index < len(subject) - 2:
+                    if subject[index + 1] in ["t", "u"]:
+                        if subject[index + 2] == "-" and (
+                            subject[index + 1] == "t"
+                            or index >= len(subject) - 6
+                            or subject[index + 3 : index + 6] != "co-"
+                        ):
+                            index_of_extensions = index
+        return True, index_of_underscore, index_of_extensions
+
+    @property
+    def _default_calendar(self) -> Calendar:
+        """Port of the internal ``CultureData.DefaultCalendar`` property.
+
+        This returns an instance of the default ``System.Globalization.Calendar`` for the locale.
+        """
+        # TODO: Only the invariant culture is supported.
+        if True:  # if (GlobalizationMode.Invariant) {...}
+            return GregorianCalendar()
+
+    @property
+    def _time_separator(self) -> str:
+        """Port of the internal ``CultureData.TimeSeparator`` property.
+
+        As in .NET, the time separator is determined by parsing the locale's long time format.
+        """
+        # TODO: Check/test this is actually the case
+        #  As in .NET, fr-CA is special cased to force the colon separator.
+        #  The pattern there is "HH 'h' mm 'min' ss 's'", from which the
+        #  separator cannot be derived.
+        if self.name == "fr-CA":
+            return ":"
+
+        long_time_format: str = icu.SimpleDateFormat(style=icu.DateFormat.kLong, locale=self.__locale).toPattern()
+
+        return self.__get_time_separator(long_time_format)
+
+    @classmethod
+    def __get_time_separator(cls, pattern: str) -> str:
+        """Port of the private static ``GetTimeSeparator`` method.
+
+        This is used to derive the locale's time separator (e.g. ':' in '12:39:00') from the locale's long time pattern.
+        """
+        return cls.__get_separator(pattern, "Hhms")
+
+    @classmethod
+    def __get_date_separator(cls, pattern: str) -> str:
+        """Port of the private static ``GetDateSeparator`` method.
+
+        This is used to derive the locale's date separator (e.g. '/' in '9/1/03') from the locale's short date format.
+        """
+        return cls.__get_separator(pattern, "dyM")
+
+    @classmethod
+    def __get_separator(cls, pattern: str, time_parts: str) -> str:
+        """Finds the separator between time_parts in the given pattern.
+
+        This is used to derive the locale's date or time separator from its date/time patterns.
+        """
+        index = cls.__index_of_time_part(pattern, 0, time_parts)
+        if index != -1:
+            # Found a time part, find out when it changes
+            c_time_part = pattern[index]
+
+            index += 1
+
+            while index < len(pattern) and pattern[index] == c_time_part:
+                index += 1
+
+            separator_start = index
+
+            # Now we need to find the end of the separator
+            if separator_start < len(pattern):
+                separator_end = cls.__index_of_time_part(pattern, separator_start, time_parts)
+                if separator_end != -1:
+                    return cls.__unescape_nls_string(pattern, separator_start, separator_end - 1)
+
+        return ""
+
+    @classmethod
+    def __index_of_time_part(cls, pattern: str, start_index: int, time_parts: str) -> int:
+        """Return the index of the time part in the given pattern.
+
+        Python implementation of ``CultureData.IndexOfTimePart()``.
+        """
+        # TODO: can this be replaced with str.index() in Python?
+        assert start_index >= 0, "start_index cannot be negative"
+        assert not any(char in time_parts for char in "'\\"), "time_parts cannot include quote characters"
+        in_quote = False
+        i = start_index
+        while i < len(pattern):
+            char = pattern[i]
+            if not in_quote and char in time_parts:
+                return i
+            if char == "\\":
+                if i + 1 < len(pattern):
+                    i += 1
+                    if pattern[i] not in ["'", "\\"]:
+                        i -= 1  # backup since we will move over this next
+            elif char == "'":
+                in_quote = not in_quote
+            i += 1
+        return -1
+
+    @classmethod
+    def __unescape_nls_string(cls, s: str, start: int, end: int) -> str:
+        """Used to unescape NLS strings in .NET Framework.
+
+        Probably not needed here, but for the sake of completeness...
+        """
+        # TODO: Do we actually need this method if we don't support NLS?
+        assert s is not None
+        assert start >= 0
+        assert end >= 0
+        result = None
+
+        i = start
+        while i < len(s) and i <= end:
+            char = s[i]
+            if char == "'":
+                if result is None:
+                    result = StringBuilder(s[start:i])
+            elif char == "\\":
+                if result is None:
+                    result = StringBuilder(s[start:i])
+                i += 1
+                if i < len(s):
+                    if result is not None:
+                        result.append(s[i])
+            else:
+                if result is not None:
+                    result.append(char)
+            i += 1
+
+        if result is None:
+            return s[start : end + 1]
+        else:
+            return result.to_string()
+
+    def __deepcopy__(self, memo: dict) -> _CultureData:
+        """Implementation to support CultureInfo.clone(), so we can copy.deepcopy(some_culture_info)
+
+        icu.Locale is not pickleable, so we need to handle it manually.
+        """
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if not isinstance(v, icu.Locale):
+                setattr(result, k, copy.deepcopy(v, memo))
+        result.__locale = icu.Locale(self.__locale.getName())
+        return result
+
+    def _get_nfi_values(self, nfi: NumberFormatInfo) -> None:
+        """Populate the provided ``NumberFormatInfo`` with locale-specific values from ICU."""
+        # TODO: This is a bare-bones port; just as much as we needed at the time and no more.
+        number_format: icu.DecimalFormatSymbols = icu.DecimalFormatSymbols(self.__locale)
+        nfi.positive_sign = number_format.getSymbol(icu.DecimalFormatSymbols.kPlusSignSymbol)
+
+    @property
+    def _is_invariant_culture(self) -> bool:
+        return not self.name  # string.IsNullOrEmpty(this.Name)

--- a/pyoda_time/_compatibility/_culture_info.py
+++ b/pyoda_time/_compatibility/_culture_info.py
@@ -1,0 +1,188 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+import copy
+import threading
+from typing import Any, Final, _ProtocolMeta
+
+import icu
+
+from ._calendar import Calendar
+from ._culture_data import _CultureData
+from ._date_time_format_info import DateTimeFormatInfo
+from ._i_format_provider import IFormatProvider
+from ._number_format_info import NumberFormatInfo
+
+
+class __CultureInfoMeta(type):
+    """Metaclass for CultureInfo."""
+
+    __CURRENT_CULTURE_ATTR_NAME: Final[str] = "s_currentThreadCulture"
+    __THREAD_LOCAL_STORAGE: Final[threading.local] = threading.local()
+
+    __s_InvariantCultureInfo: CultureInfo | None = None
+    __s_user_default_culture: CultureInfo | None = None
+    __s_default_thread_current_culture: CultureInfo | None = None
+
+    @property
+    def invariant_culture(cls) -> CultureInfo:
+        """An instance of ``CultureInfo`` which is independent of system/user settings."""
+        if not cls.__s_InvariantCultureInfo:
+            cls.__s_InvariantCultureInfo = CultureInfo._ctor(_CultureData.invariant, is_read_only=True)
+        return cls.__s_InvariantCultureInfo
+
+    @property
+    def current_culture(self) -> CultureInfo:
+        """Gets or sets the locale information for the current thread."""
+        return getattr(
+            self.__THREAD_LOCAL_STORAGE,
+            self.__CURRENT_CULTURE_ATTR_NAME,
+            CultureInfo.default_thread_current_culture
+            or self.__s_user_default_culture
+            or self.__initialize_user_default_culture(),
+        )
+
+    @current_culture.setter
+    def current_culture(self, value: CultureInfo) -> None:
+        setattr(self.__THREAD_LOCAL_STORAGE, self.__CURRENT_CULTURE_ATTR_NAME, value)
+        assert getattr(self.__THREAD_LOCAL_STORAGE, self.__CURRENT_CULTURE_ATTR_NAME) == value
+
+    @property
+    def default_thread_current_culture(self) -> CultureInfo | None:
+        """Gets or sets the default culture for threads."""
+        return self.__s_default_thread_current_culture
+
+    @default_thread_current_culture.setter
+    def default_thread_current_culture(self, value: CultureInfo) -> None:
+        self.__s_default_thread_current_culture = value
+
+    def __initialize_user_default_culture(self) -> CultureInfo:
+        self.__s_user_default_culture = self._get_user_default_culture()
+        return self.__s_user_default_culture
+
+    @staticmethod
+    def _get_default_locale_name() -> str | None:
+        """Return the name of the default ICU Locale."""
+        # Much like .NET defers to their ICU interop layer.
+        locale: icu.Locale = icu.Locale.getDefault()
+        if locale is None:
+            return None
+        return str(locale.getName())
+
+    @staticmethod
+    def __get_culture_by_name(name: str) -> CultureInfo:
+        """Return the CultureInfo for the given name if it exists.
+
+        Otherwise, return the invariant CultureInfo.
+        """
+        # TODO: Not keen on this try/except, but this is how .NET does it
+        try:
+            return CultureInfo(name)
+        except:  # noqa
+            return CultureInfo.invariant_culture
+
+    def _get_user_default_culture(self) -> CultureInfo:
+        # TODO: if GlobalizationMode.Invariant:
+        #      return CultureInfo.Invariant
+        if (default_locale_name := CultureInfo._get_default_locale_name()) is None:
+            return CultureInfo.invariant_culture
+        return self.__get_culture_by_name(default_locale_name)
+
+
+class __CombinedMeta(_ProtocolMeta, __CultureInfoMeta):
+    """Intermediary class which prevents a metaclass conflict in CultureInfo."""
+
+
+class CultureInfo(IFormatProvider, metaclass=__CombinedMeta):  # TODO: ICloneable
+    """Provides information about a specific culture (aka locale).
+
+    The information includes the names for the culture, the writing system, the calendar used, the sort order of
+    strings, and formatting for dates and numbers.
+    """
+
+    def __init__(self, name: str, use_user_override: bool = True) -> None:
+        self._culture_data: _CultureData = _CultureData(name)
+        self._name = self._culture_data._culture_name
+        self._is_inherited = isinstance(self, CultureInfo)  # TODO: issubclass?
+        self._is_read_only = False
+
+        # Cached attributes exposed via lazy-initialisation properties
+        self._date_time_info: DateTimeFormatInfo | None = None
+        self._num_info: NumberFormatInfo | None = None
+
+    def __repr__(self) -> str:
+        return self._name
+
+    def __str__(self) -> str:
+        return self._name
+
+    @classmethod
+    def _ctor(cls, culture_data: _CultureData, is_read_only: bool = False) -> CultureInfo:
+        self = cls.__new__(cls)
+        self._culture_data = culture_data
+        self._name = culture_data.name
+        self._is_inherited = cls != CultureInfo
+        self._is_read_only = is_read_only
+
+        # Cached attributes exposed via lazy-initialisation properties
+        self._date_time_info = None
+        self._num_info = None
+
+        return self
+
+    @property
+    def calendar(self) -> Calendar:
+        """Gets the default calendar used by the culture."""
+        return self._culture_data._default_calendar
+
+    @property
+    def date_time_format(self) -> DateTimeFormatInfo:
+        """Gets or sets a ``DateTimeFormatInfo`` that defines the culturally appropriate format of displaying dates and
+        times."""
+        if self._date_time_info is None:
+            self._date_time_info = DateTimeFormatInfo._ctor(self._culture_data, self.calendar)
+        return self._date_time_info
+
+    @date_time_format.setter
+    def date_time_format(self, value: DateTimeFormatInfo | None) -> None:
+        if value is None:
+            raise ValueError("date_time_format cannot be None")
+        if not isinstance(value, DateTimeFormatInfo):
+            raise TypeError("date_time_format must be an instance of DateTimeFormatInfo")
+        self.__verify_writable()
+        self._date_time_info = value
+
+    @property
+    def number_format(self) -> NumberFormatInfo:
+        """Gets or sets a ``NumberFormatInfo`` that defines the culturally appropriate format of displaying numbers,
+        currency, and percentage."""
+        if self._num_info is None:
+            self._num_info = NumberFormatInfo._ctor(self._culture_data)
+        return self._num_info
+
+    @number_format.setter
+    def number_format(self, value: NumberFormatInfo) -> None:
+        if value is None:
+            raise ValueError("number_format cannot be None")
+        if not isinstance(value, NumberFormatInfo):
+            raise TypeError("number_format must be an instance of NumberFormatInfo")
+        self.__verify_writable()
+        self._num_info = value
+
+    def __verify_writable(self) -> None:
+        if self._is_read_only:
+            raise RuntimeError("Cannot write read-only CultureInfo")
+
+    def clone(self) -> CultureInfo:  # TODO: ICloneable
+        """Creates a copy of this ``CultureInfo``."""
+        # TODO: This might be good enough for our purposes, but
+        #  it isn't anything like the behaviour in .NET.
+        # Refer to CultureData.__deepcopy__() implementation
+        return copy.deepcopy(self)
+
+    def get_format(self, format_type: type) -> Any | None:
+        """Gets an object that defines how to format the specified type."""
+        raise NotImplementedError

--- a/pyoda_time/_compatibility/_date_time_format_info.py
+++ b/pyoda_time/_compatibility/_date_time_format_info.py
@@ -1,0 +1,72 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+from pyoda_time._compatibility._culture_data import _CultureData
+from pyoda_time._compatibility._i_format_provider import IFormatProvider
+
+
+# TODO: ICloneable
+class DateTimeFormatInfo(IFormatProvider):
+    """Provides culture-specific information about the format of date and time values."""
+
+    def __init__(self) -> None:
+        from ._culture_info import CultureInfo
+        from ._gregorian_calendar import GregorianCalendar
+
+        self._culture_data: _CultureData = CultureInfo.invariant_culture._culture_data
+        self._calendar: Calendar = GregorianCalendar()
+
+        self._is_read_only: bool = False
+
+        # Cached values exposed via lazy-initialising properties
+        self.__time_separator: str | None = None
+
+    @classmethod
+    def _ctor(cls, culture_data: _CultureData, cal: Calendar) -> DateTimeFormatInfo:
+        self = cls.__new__(cls)
+        self._culture_data = culture_data
+        self._calendar = cal
+        self._is_read_only = False
+        self.__initialize_overridable_properties(culture_data, cal._id)
+
+        # Cached values exposed via lazy-initialising properties
+        self.__time_separator = None
+
+        return self
+
+    @property
+    def time_separator(self) -> str:
+        """Gets or sets the string that separates the components of time, that is, the hour, minutes, and seconds."""
+        if self.__time_separator is None:
+            self.__time_separator = self._culture_data._time_separator
+        return self.__time_separator
+
+    @time_separator.setter
+    def time_separator(self, value: str) -> None:
+        self.__verify_writable()
+        if value is None:
+            raise ValueError("DateTimeFormatInfo.value cannot be None")
+        # TODO: this.ClearTokenHashTable();
+        self.__time_separator = value
+
+    def __verify_writable(self) -> None:
+        if self._is_read_only:
+            raise RuntimeError("Cannot write read-only DateFormatInfo")
+
+    @property
+    def is_read_only(self) -> bool:
+        return self._is_read_only
+
+    def __initialize_overridable_properties(self, culture_data: _CultureData, calendar_id: _CalendarId) -> None:
+        # TODO: implement __initialize_overridable_properties()
+        pass
+
+    def get_format(self, format_type: type) -> Any | None:
+        raise NotImplementedError

--- a/pyoda_time/_compatibility/_gregorian_calendar.py
+++ b/pyoda_time/_compatibility/_gregorian_calendar.py
@@ -1,0 +1,17 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+from pyoda_time._compatibility._gregorian_calendar_types import GregorianCalendarTypes
+
+
+class GregorianCalendar(Calendar):
+    """Represents the Gregorian calendar."""
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId(self._type.value)
+
+    def __init__(self, type_: GregorianCalendarTypes = GregorianCalendarTypes.Localized) -> None:
+        self._type = type_

--- a/pyoda_time/_compatibility/_gregorian_calendar_types.py
+++ b/pyoda_time/_compatibility/_gregorian_calendar_types.py
@@ -1,0 +1,18 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from enum import Enum
+
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class GregorianCalendarTypes(Enum):
+    """Defines the different language versions of the Gregorian calendar."""
+
+    Localized = _CalendarId.GREGORIAN
+    USEnglish = _CalendarId.GREGORIAN_US
+    MiddleEastFrench = _CalendarId.GREGORIAN_ME_FRENCH
+    Arabic = _CalendarId.GREGORIAN_ARABIC
+    TransliteratedEnglish = _CalendarId.GREGORIAN_XLIT_ENGLISH
+    TransliteratedFrench = _CalendarId.GREGORIAN_XLIT_FRENCH

--- a/pyoda_time/_compatibility/_i_format_provider.py
+++ b/pyoda_time/_compatibility/_i_format_provider.py
@@ -1,0 +1,25 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from abc import abstractmethod
+from typing import Any, Protocol
+
+
+class IFormatProvider(Protocol):
+    """Provides a mechanism for retrieving an object to control formatting.
+
+    https://learn.microsoft.com/en-us/dotnet/api/system.iformatprovider
+    """
+
+    @abstractmethod
+    def get_format(self, format_type: type) -> Any | None:
+        """Returns an object that provides formatting services for the specified type.
+
+        https://learn.microsoft.com/en-us/dotnet/api/system.iformatprovider.getformat
+
+        :param format_type: An object that specifies the type of format object to return.
+        :return: An instance of the object specified by ``format_type``, if the
+            ``IFormatProvider`` implementation can supply that type of object; otherwise,
+            ``None``.
+        """
+        ...

--- a/pyoda_time/_compatibility/_number_format_info.py
+++ b/pyoda_time/_compatibility/_number_format_info.py
@@ -1,0 +1,49 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from pyoda_time._compatibility._culture_data import _CultureData
+
+
+class NumberFormatInfo:
+    """Provides culture-specific information for formatting and parsing numeric values."""
+
+    def __init__(self) -> None:
+        self._positive_sign = "+"
+        self._negative_sign = "-"
+        self._is_read_only: bool = False
+
+    @classmethod
+    def _ctor(cls, culture_data: _CultureData) -> NumberFormatInfo:
+        instance = NumberFormatInfo()
+        culture_data._get_nfi_values(instance)
+        instance.__initialize_invariant_and_negative_sign_flags()
+        return instance
+
+    def __initialize_invariant_and_negative_sign_flags(self) -> None:
+        # TODO: implement whatever this is
+        pass
+
+    @property
+    def positive_sign(self) -> str:
+        """Gets or sets the string that denotes that the associated number is positive."""
+        return self._positive_sign
+
+    @positive_sign.setter
+    def positive_sign(self, value: str) -> None:
+        self._positive_sign = value
+
+    @property
+    def negative_sign(self) -> str:
+        """Gets or sets the string that denotes that the associated number is negative."""
+        return self._negative_sign
+
+    @negative_sign.setter
+    def negative_sign(self, value: str) -> None:
+        self.__verify_writable()
+        self._negative_sign = value
+
+    def __verify_writable(self) -> None:
+        if self._is_read_only:
+            raise RuntimeError("Cannot write read-only CultureInfo")

--- a/pyoda_time/_compatibility/_string_builder.py
+++ b/pyoda_time/_compatibility/_string_builder.py
@@ -1,0 +1,38 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from typing import Self
+
+
+class StringBuilder:
+    """A bare-bones implementation of .NET's ``System.Text.StringBuilder``.
+
+    Represents a mutable sequence of characters.
+    """
+
+    __slots__ = ("__string",)
+
+    def __init__(
+        self,
+        string: str = "",
+        start_index: int = 0,
+        length: int = 0,
+        capacity: int = 16,
+    ) -> None:
+        self.__string = string
+
+    @property
+    def length(self) -> int:
+        return len(self.__string)
+
+    def append(self, string: str) -> Self:
+        self.__string += string
+        return self
+
+    def append_line(self, string: str = "") -> Self:
+        self.append(string + "\n")
+        return self
+
+    def to_string(self) -> str:
+        return self.__string

--- a/pyoda_time/_offset.py
+++ b/pyoda_time/_offset.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import datetime as _datetime
 import typing as _typing
 
+from ._compatibility._culture_info import CultureInfo
 from ._pyoda_constants import PyodaConstants
 from .utility import _Preconditions, _sealed, _towards_zero_division
 
@@ -428,6 +429,6 @@ class Offset(metaclass=_OffsetMeta):
     # endregion
 
     def __str__(self) -> str:
-        hours = int(self.seconds / PyodaConstants.SECONDS_PER_HOUR)
-        symbol = "+" if hours >= 0 else "-"
-        return "Z" if self == Offset.zero else f"{symbol}{hours:0>2}"
+        from .text._offset_pattern import OffsetPattern
+
+        return OffsetPattern._bcl_support.format(self, None, CultureInfo.current_culture)

--- a/pyoda_time/globalization/__init__.py
+++ b/pyoda_time/globalization/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from ._pyoda_format_info import _PyodaFormatInfo  # noqa: F401

--- a/pyoda_time/globalization/_pattern_resources.py
+++ b/pyoda_time/globalization/_pattern_resources.py
@@ -1,0 +1,25 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Final
+
+
+class _PatternResources:
+    """Constants for patterns.
+
+    In Noda Time, this is a wrapper around a ResourceManager and the eponymous .resx.
+    """
+
+    ERAS_ANNO_HEGIRAE: Final[str] = "A.H.|AH"
+    ERAS_ANNO_MARTYRUM: Final[str] = "A.M.|AM"
+    ERAS_ANNO_MUNDI: Final[str] = "A.M.|AM"
+    ERAS_ANNO_PERSICO: Final[str] = "A.P.|AP"
+    ERAS_BAHAI: Final[str] = "B.E.|BE"
+    ERAS_BEFORE_COMMON: Final[str] = "B.C.|B.C.E.|BC|BCE"
+    ERAS_COMMON: Final[str] = "A.D.|AD|C.E.|CE"
+    OFFSET_PATTERN_LONG: Final[str] = "+HH:mm:ss"
+    OFFSET_PATTERN_LONG_NO_PUNCTUATION: Final[str] = "+HHmmss"
+    OFFSET_PATTERN_MEDIUM: Final[str] = "+HH:mm"
+    OFFSET_PATTERN_MEDIUM_NO_PUNCTUATION: Final[str] = "+HHmm"
+    OFFSET_PATTERN_SHORT: Final[str] = "+HH"
+    OFFSET_PATTERN_SHORT_NO_PUNCTUATION: Final[str] = "+HH"

--- a/pyoda_time/globalization/_pyoda_format_info.py
+++ b/pyoda_time/globalization/_pyoda_format_info.py
@@ -1,0 +1,129 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+import typing
+from typing import final
+
+from .._compatibility._culture_info import CultureInfo
+from .._compatibility._date_time_format_info import DateTimeFormatInfo
+from .._compatibility._i_format_provider import IFormatProvider
+from .._offset import Offset
+from ..calendars import Era
+
+if typing.TYPE_CHECKING:
+    from ..text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
+from ..utility import _Preconditions
+from ..utility._csharp_compatibility import _sealed
+from ._pattern_resources import _PatternResources
+
+
+class _PyodaFormatInfoMeta(type):
+    @property
+    def invariant_info(self) -> _PyodaFormatInfo:
+        """A ``_PyodaFormatInfo`` wrapping the invariant culture."""
+        return _PyodaFormatInfo(CultureInfo.invariant_culture)
+
+    @property
+    def current_info(cls) -> _PyodaFormatInfo:
+        """Gets the ``_PyodaFormatInfo`` object for the current thread."""
+        return _PyodaFormatInfo.get_instance(CultureInfo.current_culture)
+
+
+@final
+@_sealed
+class _PyodaFormatInfo(metaclass=_PyodaFormatInfoMeta):
+    def __init__(self, culture_info: CultureInfo, date_time_format: DateTimeFormatInfo | None = None) -> None:
+        _Preconditions._check_not_null(culture_info, "culture_info")
+        # _Preconditions._check_not_null(date_time_format, "date_time_format")
+        self.__culture_info: CultureInfo = culture_info
+        self.__date_time_format: DateTimeFormatInfo = (
+            culture_info.date_time_format if date_time_format is None else date_time_format
+        )
+        self.__era_descriptions: dict[Era, _EraDescription] = dict()
+
+    @property
+    def culture_info(self) -> CultureInfo:
+        """Gets the culture info associated with this format provider."""
+        return self.__culture_info
+
+    @property
+    def time_separator(self) -> str:
+        """Gets the time separator."""
+        return self.__date_time_format.time_separator
+
+    @classmethod
+    def get_instance(cls, provider: IFormatProvider | None) -> _PyodaFormatInfo:
+        """Gets the ``_PyodaFormatInfo`` for the given ``IFormatProvider``.
+
+        If the
+        /// format provider is null then the format object for the current thread is returned. If it's
+        /// a CultureInfo, that's used for everything. If it's a DateTimeFormatInfo, that's used for
+        /// format strings, day names etc but the invariant culture is used for text comparisons and
+        /// resource lookups. Otherwise, ``ValueError`` is thrown.
+        """
+        if provider is None:
+            return cls.get_format_info(cls.current_info.culture_info)
+        if isinstance(provider, CultureInfo):
+            return cls.get_format_info(provider)
+        if isinstance(provider, DateTimeFormatInfo):
+            return _PyodaFormatInfo(CultureInfo.invariant_culture, provider)
+        raise ValueError(f"Cannot use provider of type {type(provider).__name__} in Pyoda Time")
+
+    def __str__(self) -> str:
+        return f"PyodaFormatInfo[{self.__culture_info._name}]"
+
+    @property
+    def offset_pattern_parser(self) -> _FixedFormatInfoPatternParser[Offset]:
+        from ..text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
+        from ..text._offset_pattern_parser import _OffsetPatternParser
+
+        return _FixedFormatInfoPatternParser[Offset](_OffsetPatternParser(), self)
+
+    @property
+    def offset_pattern_long(self) -> str:
+        """Gets the ``Offset`` 'l' pattern."""
+        return _PatternResources.OFFSET_PATTERN_LONG
+
+    @property
+    def offset_pattern_medium(self) -> str:
+        """Gets the ``Offset`` 'm' pattern."""
+        return _PatternResources.OFFSET_PATTERN_MEDIUM
+
+    @property
+    def offset_pattern_short(self) -> str:
+        """Gets the ``Offset`` 's' pattern."""
+        return _PatternResources.OFFSET_PATTERN_SHORT
+
+    @property
+    def offset_pattern_long_no_punctuation(self) -> str:
+        """Gets the ``Offset`` 'L' pattern."""
+        return _PatternResources.OFFSET_PATTERN_LONG_NO_PUNCTUATION
+
+    @property
+    def offset_pattern_medium_no_punctuation(self) -> str:
+        """Gets the ``Offset`` 'M' pattern."""
+        return _PatternResources.OFFSET_PATTERN_MEDIUM_NO_PUNCTUATION
+
+    @property
+    def offset_pattern_short_no_punctuation(self) -> str:
+        """Gets the ``Offset`` 'S' pattern."""
+        return _PatternResources.OFFSET_PATTERN_SHORT_NO_PUNCTUATION
+
+    @classmethod
+    def get_format_info(cls, culture_info: CultureInfo) -> _PyodaFormatInfo:
+        """Gets the ``_PyodaFormatInfo`` for the given ``CultureInfo``."""
+        _Preconditions._check_not_null(culture_info, "culture_info")
+        if culture_info == CultureInfo.invariant_culture:
+            return _PyodaFormatInfo.invariant_info
+        # TODO: This is simplified to ignore caching and read-only cultures for now...
+        return _PyodaFormatInfo(culture_info)
+
+
+class _EraDescription:
+    """The description for an era: the primary name and all possible names."""
+
+    # TODO: EraDescription
+    pass

--- a/pyoda_time/text/__init__.py
+++ b/pyoda_time/text/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+__all__: list[str] = [
+    "InvalidPatternError",
+    "ParseResult",
+    "UnparsableValueError",
+]
+
+from . import patterns  # noqa: F401
+from ._invalid_pattern_exception import InvalidPatternError
+from ._parse_bucket import _ParseBucket  # noqa: F401
+from ._parse_result import ParseResult
+from ._text_cursor import _TextCursor  # noqa: F401
+from ._unparsable_value_error import UnparsableValueError
+from ._value_cursor import _ValueCursor  # noqa: F401

--- a/pyoda_time/text/_composite_pattern_builder.py
+++ b/pyoda_time/text/_composite_pattern_builder.py
@@ -1,0 +1,93 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Callable, Final, Generic, Sequence, TypeVar, cast, final
+
+from pyoda_time._compatibility._string_builder import StringBuilder
+from pyoda_time.text import ParseResult, _ValueCursor
+from pyoda_time.text._i_partial_pattern import _IPartialPattern
+from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.utility import _Preconditions, _sealed
+
+T = TypeVar("T")
+
+
+@final
+@_sealed
+class CompositePatternBuilder(Generic[T]):  # TODO: IEnumerable<Pattern<T>>
+    """A builder for composite patterns.
+
+    A composite pattern is a combination of multiple patterns. When parsing, these are checked
+    in the order in which they are added to the builder with the ``add(IPattern[T], Callable[[T], bool])``
+    method, by trying to parse and seeing if the result is a successful one. When formatting,
+    the patterns are checked in the reverse order, using the predicate provided along with the pattern
+    when calling ``add``. The intention is that patterns are added in "most precise first" order,
+    and the predicate should indicate whether it can fully represent the given value - so the "less precise"
+    (and therefore usually shorter) pattern can be used first.
+    """
+
+    def __init__(
+        self,
+        patterns: Sequence[IPattern[T]] | None = None,
+        format_predicates: Sequence[Callable[[T], bool]] | None = None,
+    ) -> None:
+        self.__patterns: Final[list[IPattern[T]]] = list(patterns) if patterns else []
+        self.__format_predicates: Final[list[Callable[[T], bool]]] = (
+            list(format_predicates) if format_predicates else []
+        )
+
+    def add(self, pattern: IPattern[T], format_predicates: Callable[[T], bool]) -> None:
+        """Adds a component pattern to this builder.
+
+        :param pattern: The component pattern to use as part of the eventual composite pattern.
+        :param format_predicates: A predicate to determine whether this pattern is suitable for formatting the given
+            value
+        :return:
+        """
+        self.__patterns.append(_Preconditions._check_not_null(pattern, "pattern"))
+        self.__format_predicates.append(_Preconditions._check_not_null(format_predicates, "format_predicates"))
+
+    def build(self) -> IPattern[T]:
+        _Preconditions._check_state(
+            len(self.__patterns) != 0, "A composite pattern must have at least one component pattern."
+        )
+        return self._build_as_partial()
+
+    def _build_as_partial(self) -> _IPartialPattern[T]:
+        # TODO: Preconditions.DebugCheckState
+        return self.__CompositePattern(self.__patterns, self.__format_predicates)
+
+    class __CompositePattern(_IPartialPattern[T]):
+        def __init__(self, patterns: list[IPattern[T]], format_predicates: list[Callable[[T], bool]]) -> None:
+            self.__patterns: Final[list[IPattern[T]]] = patterns
+            self.__format_predicates: Final[list[Callable[[T], bool]]] = format_predicates
+
+        def parse(self, text: str) -> ParseResult[T]:
+            for pattern in self.__patterns:
+                result: ParseResult[T] = pattern.parse(text)
+                if result.success or not result._continue_after_error_with_multiple_formats:
+                    return result
+            return ParseResult[T]._no_matching_format(_ValueCursor(text))
+
+        def parse_partial(self, cursor: _ValueCursor) -> ParseResult[T]:
+            index = cursor.index
+            for pattern in self.__patterns:
+                cursor.move(index)
+                result: ParseResult[T] = cast(_IPartialPattern[T], pattern).parse_partial(cursor)
+                if result.success or not result._continue_after_error_with_multiple_formats:
+                    return result
+            cursor.move(index)
+            return ParseResult[T]._no_matching_format(cursor)
+
+        def format(self, value: T) -> str:
+            return self.__find_format_pattern(value).format(value)
+
+        def append_format(self, value: T, builder: StringBuilder) -> StringBuilder:
+            return self.__find_format_pattern(value).append_format(value, builder)
+
+        def __find_format_pattern(self, value: T) -> IPattern[T]:
+            for format_predicate in reversed(self.__format_predicates):
+                if format_predicate(value):
+                    return self.__patterns[self.__format_predicates.index(format_predicate)]
+            # TODO: FormatException equivalent?
+            raise RuntimeError("Composite pattern was unable to format value using any of the provided patterns.")

--- a/pyoda_time/text/_fixed_format_info_pattern_parser.py
+++ b/pyoda_time/text/_fixed_format_info_pattern_parser.py
@@ -1,0 +1,30 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from typing import Final, Generic, TypeVar, final
+
+from ..globalization import _PyodaFormatInfo
+from ..utility import _sealed
+from ._i_pattern import IPattern
+from .patterns._i_pattern_parser import _IPatternParser
+
+T = TypeVar("T")
+
+
+@_sealed
+@final
+class _FixedFormatInfoPatternParser(Generic[T]):
+    """A pattern parser for a single format info, which caches patterns by text/style."""
+
+    # TODO: This is dramatically simplified compared to Noda Time
+
+    def __init__(self, pattern_parser: _IPatternParser[T], format_info: _PyodaFormatInfo) -> None:
+        self.__pattern_parser = pattern_parser
+        self.__format_info = format_info
+        self.__cache: Final[dict[str, IPattern[T]]] = dict()
+
+    def _parse_pattern(self, pattern: str) -> IPattern[T]:
+        if not (ret := self.__cache.get(pattern)):
+            ret = self.__cache[pattern] = self.__pattern_parser.parse_pattern(pattern, self.__format_info)
+        return ret

--- a/pyoda_time/text/_format_helper.py
+++ b/pyoda_time/text/_format_helper.py
@@ -1,0 +1,76 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._string_builder import StringBuilder
+
+
+class FormatHelper:
+    """Provides helper methods for formatting values using pattern strings."""
+
+    @staticmethod
+    def format_2_digits_non_negative(value: int, output_buffer: StringBuilder) -> None:
+        """Formats the given value to two digits, left-padding with '0' if necessary.
+
+        It is assumed that the value is in the range [0, 100). This is usually used for month, day-of-month, hour,
+        minute, second and year-of-century values.
+        """
+        # TODO: Preconditions.DebugCheckArgumentRange
+        # TODO: unchecked
+        # TODO: This is pretty different (but more idiomatic Python) compared to Noda Time.
+        output_buffer.append(f"{value:02}")
+
+    @staticmethod
+    def format_4_digits_value_fits(value: int, output_buffer: StringBuilder) -> None:
+        """Formats the given value to two digits, left-padding with '0' if necessary.
+
+        It is assumed that the value is in the range [-9999, 10000). This is usually used for year values. If the value
+        is negative, a '-' character is prepended.
+        """
+        # TODO: Preconditions.DebugCheckArgumentRange
+        # TODO: unchecked
+        # TODO: This is pretty different (but more idiomatic Python) compared to Noda Time.
+        if value < 0:
+            value = -value
+            output_buffer.append("-")
+        output_buffer.append(f"{value:04}")
+
+    @staticmethod
+    def left_pad(value: int, length: int, output_buffer: StringBuilder) -> None:
+        """Formats the given value left padded with zeros.
+
+        Left pads with zeros the value into a field of ``length`` characters. If the value
+        is longer than ``length``, the entire value is formatted. If the value is negative,
+        it is preceded by "-" but this does not count against the length.
+
+        :param value: The value to format.
+        :param length: The length to fill.
+        :param output_buffer: The output buffer to add the digits to.
+        :return:
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def left_pad_non_negative(value: int, length: int, output_buffer: StringBuilder) -> None:
+        """Formats the given value left padded with zeros. The value is assumed to be non-negative.
+
+        Left pads with zeros the value into a field of ``length`` characters. If the value
+        is longer than ``length``, the entire value is formatted. If the value is negative,
+        it is preceded by "-" but this does not count against the length.
+
+        :param value: The value to format.
+        :param length: The length to fill.
+        :param output_buffer: The output buffer to add the digits to.
+        :return:
+        """
+        # TODO: Preconditions.DebugCheckArgumentRange, something like:
+        #  assert if value > 0 and length > 1, "Value must be non-negative and length must be at least 1")
+
+        # TODO: unchecked
+
+        # TODO: This is dramatically more simple than the Noda Time implementation,
+        #  which optimizes common cases to prevent heap allocations.
+
+        # Using an f-string for formatting
+        formatted_value = f"{value:0>{length}}"
+
+        output_buffer.append(formatted_value)

--- a/pyoda_time/text/_i_partial_pattern.py
+++ b/pyoda_time/text/_i_partial_pattern.py
@@ -1,0 +1,25 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from abc import abstractmethod
+
+from pyoda_time.text import ParseResult, _ValueCursor
+from pyoda_time.text._i_pattern import IPattern, T
+
+
+class _IPartialPattern(IPattern[T]):
+    """Internal interface supporting partial parsing and formatting.
+
+    This is used when one pattern is embedded within another.
+    """
+
+    @abstractmethod
+    def parse_partial(self, cursor: _ValueCursor) -> ParseResult[T]:
+        """Parses a value from the current position in the cursor. This will
+        not fail if the pattern ends before the cursor does - that's expected
+        in most cases.
+
+        :param cursor: The cursor to parse from.
+        :return: The result of parsing from the cursor.
+        """
+        ...

--- a/pyoda_time/text/_i_pattern.py
+++ b/pyoda_time/text/_i_pattern.py
@@ -1,0 +1,51 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from abc import abstractmethod
+from typing import Protocol, TypeVar
+
+from .._compatibility._string_builder import StringBuilder
+from ._parse_result import ParseResult
+
+T = TypeVar("T")
+
+
+class IPattern(Protocol[T]):
+    """Generic interface supporting parsing and formatting.
+
+    Parsing always results in a ``ParseResult[T]`` which can represent success or failure.
+
+    Idiomatic text handling in Pyoda Time involves creating a pattern once and reusing it multiple
+    times, rather than specifying the pattern text repeatedly.
+    """
+
+    @abstractmethod
+    def parse(self, text: str) -> ParseResult[T]:
+        """Parses the given text value according to the rules of this pattern.
+
+        This method never raises an Exception (barring a bug in Pyoda Time itself).
+
+        :param text: The text value to parse.
+        :return: The result of parsing, which may be successful or unsuccessful.
+        """
+        ...
+
+    @abstractmethod
+    def format(self, value: T) -> str:
+        """Formats the given value as text according to the rules of this pattern.
+
+        :param value: The value to format.
+        :return: The value formatted according to this pattern.
+        """
+        ...
+
+    @abstractmethod
+    def append_format(self, value: T, builder: StringBuilder) -> StringBuilder:
+        """Formats the given value as text according to the rules of this pattern, appending to the given
+        ``StringBuilder``.
+
+        :param value: The value to format.
+        :param builder: The ``StringBuilder`` to append to.
+        :return: The builder passed in as ``builder``.
+        """
+        ...

--- a/pyoda_time/text/_invalid_pattern_exception.py
+++ b/pyoda_time/text/_invalid_pattern_exception.py
@@ -1,0 +1,23 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from typing import Any, final
+
+from ..utility import _sealed
+
+
+@final
+@_sealed
+class InvalidPatternError(ValueError):
+    """Exception thrown to indicate that the format pattern provided for either formatting or parsing is invalid."""
+
+    def __init__(self, message: str, *args: Any) -> None:
+        """Creates a new InvalidPatternException by formatting the given format string with the specified parameters.
+
+        :param message: Format string to use in order to create the final message
+        :param args: Format string parameters
+        """
+        if args:
+            message = message.format(*args)
+        super().__init__(message)

--- a/pyoda_time/text/_offset_pattern.py
+++ b/pyoda_time/text/_offset_pattern.py
@@ -1,0 +1,168 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from functools import cache
+from typing import Final, _ProtocolMeta, cast, final
+
+from pyoda_time import Offset
+from pyoda_time._compatibility._culture_info import CultureInfo
+from pyoda_time._compatibility._string_builder import StringBuilder
+from pyoda_time.globalization import _PyodaFormatInfo
+from pyoda_time.text import ParseResult
+from pyoda_time.text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
+from pyoda_time.text._i_partial_pattern import _IPartialPattern
+from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.text.patterns import _PatternBclSupport
+from pyoda_time.utility import _Preconditions, _sealed
+
+
+class _OffsetPatternMeta(type):
+    @property
+    @cache
+    def _bcl_support(self) -> _PatternBclSupport[Offset]:
+        def pattern_parser(format_info: _PyodaFormatInfo) -> _FixedFormatInfoPatternParser[Offset]:
+            return format_info.offset_pattern_parser
+
+        return _PatternBclSupport(
+            OffsetPattern._DEFAULT_FORMAT_PATTERN,
+            pattern_parser,
+        )
+
+    @property
+    @cache
+    def general_invariant(self) -> OffsetPattern:
+        """The "general" offset pattern (e.g. +HH, +HH:mm, +HH:mm:ss, +HH:mm:ss.fff) for the invariant culture."""
+        return OffsetPattern.create_with_invariant_culture("g")
+
+    @property
+    @cache
+    def general_invariant_with_z(self) -> OffsetPattern:
+        """The "general" offset pattern (e.g. +HH, +HH:mm, +HH:mm:ss, +HH:mm:ss.fff) for the invariant culture, but
+        producing (and allowing) Z as a value for a zero offset."""
+        return OffsetPattern.create_with_invariant_culture("G")
+
+
+class _CombinedMeta(_ProtocolMeta, _OffsetPatternMeta):
+    """Intermediary class which prevents a metaclass conflict."""
+
+
+@_sealed
+@final
+class OffsetPattern(IPattern[Offset], metaclass=_CombinedMeta):
+    """Represents a pattern for parsing and formatting ``Offset`` values."""
+
+    _DEFAULT_FORMAT_PATTERN: Final[str] = "g"
+
+    def __init__(self, pattern_text: str, pattern: _IPartialPattern[Offset]):
+        self.__pattern_text: Final[str] = pattern_text
+        self.__underlying_pattern: Final[_IPartialPattern[Offset]] = pattern
+
+    @property
+    def pattern_text(self) -> str:
+        """Gets the pattern text for this pattern, as supplied on creation."""
+        return self.__pattern_text
+
+    @property
+    def _underlying_pattern(self) -> _IPartialPattern[Offset]:
+        """Returns the pattern that this object delegates to.
+
+        Mostly useful to avoid this public class implementing an internal interface.
+        """
+        return self.__underlying_pattern
+
+    def parse(self, text: str) -> ParseResult[Offset]:
+        """Parses the given text value according to the rules of this pattern.
+
+        This method never throws an exception (barring a bug in Pyoda Time itself). Even errors such as the argument
+        being null are wrapped in a parse result.
+
+        :param text: The text value to parse.
+        :return: The result of parsing, which may be successful or unsuccessful.
+        """
+        return self._underlying_pattern.parse(text)
+
+    def format(self, value: Offset) -> str:
+        """Formats the given offset as text according to the rules of this pattern.
+
+        :param value: The offset to format.
+        :return: The offset formatted according to this pattern.
+        """
+        return self._underlying_pattern.format(value)
+
+    def append_format(self, value: Offset, builder: StringBuilder) -> StringBuilder:
+        """Formats the given value as text according to the rules of this pattern, appending to the given
+        ``StringBuilder``.
+
+        :param value: The value to format.
+        :param builder: The ``StringBuilder`` to append to.
+        :return: The builder passed in as ``builder``.
+        """
+        return self._underlying_pattern.append_format(value, builder)
+
+    @classmethod
+    def _create(cls, pattern_text: str, format_info: _PyodaFormatInfo) -> OffsetPattern:
+        """Creates a pattern for the given pattern text and format info.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :param format_info: Localization information
+        :return: A pattern for parsing and formatting offsets.
+        :raises InvalidPatternException: The pattern text was invalid.
+        """
+        _Preconditions._check_not_null(pattern_text, "pattern_text")
+        _Preconditions._check_not_null(format_info, "format_info")
+        if isinstance(format_info, CultureInfo):
+            format_info = _PyodaFormatInfo.get_format_info(format_info)
+        pattern = cast(_IPartialPattern[Offset], format_info.offset_pattern_parser._parse_pattern(pattern_text))
+        return OffsetPattern(pattern_text, pattern)
+
+    @classmethod
+    def create(cls, pattern_text: str, culture_info: CultureInfo) -> OffsetPattern:
+        """Creates a pattern for the given pattern text and culture.
+
+        See the user guide for the available pattern text options.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :param culture_info: The culture to use in the pattern
+        :return: A pattern for parsing and formatting offsets.
+        :raises InvalidPatternException: The pattern text was invalid.
+        """
+        return cls._create(pattern_text, _PyodaFormatInfo.get_instance(culture_info))
+
+    @classmethod
+    def create_with_current_culture(cls, pattern_text: str) -> OffsetPattern:
+        """Creates a pattern for the given pattern text in the current thread's current culture.
+
+        See the user guide for the available pattern text options. Note that the current culture
+        is captured at the time this method is called - it is not captured at the point of parsing
+        or formatting values.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :return: A pattern for parsing and formatting offsets.
+        :raises InvalidPatternException: The pattern text was invalid.
+        """
+        return cls._create(pattern_text, _PyodaFormatInfo.current_info)
+
+    @classmethod
+    def create_with_invariant_culture(cls, pattern_text: str) -> OffsetPattern:
+        """Creates a pattern for the given pattern text in the invariant culture.
+
+        See the user guide for the available pattern text options. Note that the current culture
+        is captured at the time this method is called - it is not captured at the point of parsing
+        or formatting values.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :return: A pattern for parsing and formatting offsets.
+        :raises InvalidPatternException: The pattern text was invalid.
+        """
+        return cls._create(pattern_text, _PyodaFormatInfo.invariant_info)
+
+    def with_culture(self, culture_info: CultureInfo) -> OffsetPattern:
+        """Creates a pattern for the same original pattern text as this pattern, but with the specified culture.
+
+        :param culture_info: The culture to use in the new pattern.
+        :return: A new pattern with the given culture.
+        """
+        return self._create(self.pattern_text, _PyodaFormatInfo.get_format_info(culture_info))

--- a/pyoda_time/text/_offset_pattern_parser.py
+++ b/pyoda_time/text/_offset_pattern_parser.py
@@ -1,0 +1,253 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import Callable, Final, Mapping, final
+
+from pyoda_time import PyodaConstants
+from pyoda_time._compatibility._string_builder import StringBuilder
+from pyoda_time._offset import Offset
+from pyoda_time.globalization import _PyodaFormatInfo
+from pyoda_time.text import InvalidPatternError, ParseResult, _ValueCursor
+from pyoda_time.text._composite_pattern_builder import CompositePatternBuilder
+from pyoda_time.text._i_partial_pattern import _IPartialPattern
+from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.text._parse_bucket import _ParseBucket
+from pyoda_time.text._text_error_messages import TextErrorMessages
+from pyoda_time.text.patterns import _PatternCursor, _PatternFields
+from pyoda_time.text.patterns._i_pattern_parser import _IPatternParser
+from pyoda_time.text.patterns._stepped_pattern_builder import _SteppedPatternBuilder
+from pyoda_time.utility import _csharp_modulo, _Preconditions, _sealed, _towards_zero_division
+
+
+@_sealed
+@final
+class _OffsetParseBucket(_ParseBucket[Offset]):
+    """Provides a container for the interim parsed pieces of an ``Offset`` value."""
+
+    def __init__(self, hours: int = 0, minutes: int = 0, seconds: int = 0, is_negative: bool = False) -> None:
+        # The hours in the range [0, 23].
+        self._hours = hours
+        # The minutes in the range [0, 59].
+        self._minutes = minutes
+        # The seconds in the range [0, 59].
+        self._seconds = seconds
+        # ``True`` if this instance is negative; otherwise, ``False``.
+        self._is_negative = is_negative
+
+    def calculate_value(self, used_fields: _PatternFields, value: str) -> ParseResult[Offset]:
+        """Calculates the value from the parsed pieces."""
+        seconds: int = (
+            self._hours * PyodaConstants.SECONDS_PER_HOUR
+            + self._minutes * PyodaConstants.SECONDS_PER_MINUTE
+            + self._seconds
+        )
+        if self._is_negative:
+            seconds = -seconds
+        return ParseResult[Offset].for_value(Offset.from_seconds(seconds))
+
+
+@_sealed
+@final
+class _OffsetPatternParser(_IPatternParser[Offset]):
+    @staticmethod
+    def __get_positive_hours(offset: Offset) -> int:
+        return _towards_zero_division(abs(offset.milliseconds), PyodaConstants.MILLISECONDS_PER_HOUR)
+
+    @staticmethod
+    def __H_setter(bucket: _OffsetParseBucket, value: int) -> None:
+        bucket._hours = value
+
+    @staticmethod
+    def __get_positive_minutes(offset: Offset) -> int:
+        return _towards_zero_division(
+            _csharp_modulo(abs(offset.milliseconds), PyodaConstants.MILLISECONDS_PER_HOUR),
+            PyodaConstants.MILLISECONDS_PER_MINUTE,
+        )
+
+    @staticmethod
+    def __m_setter(bucket: _OffsetParseBucket, value: int) -> None:
+        bucket._minutes = value
+
+    @staticmethod
+    def __get_positive_seconds(offset: Offset) -> int:
+        return _towards_zero_division(
+            _csharp_modulo(abs(offset.milliseconds), PyodaConstants.MILLISECONDS_PER_MINUTE),
+            PyodaConstants.MILLISECONDS_PER_SECOND,
+        )
+
+    @staticmethod
+    def __s_setter(bucket: _OffsetParseBucket, value: int) -> None:
+        bucket._seconds = value
+
+    @staticmethod
+    def __handle_colon(_: _PatternCursor, builder: _SteppedPatternBuilder[Offset, _OffsetParseBucket]) -> None:
+        builder._add_literal(builder._format_info.time_separator, ParseResult[Offset]._time_separator_mismatch)
+
+    @staticmethod
+    def __handle_h(pattern: _PatternCursor, builder: _SteppedPatternBuilder[Offset, _OffsetParseBucket]) -> None:
+        raise InvalidPatternError(TextErrorMessages.HOUR12_PATTERN_NOT_SUPPORTED, Offset.__name__)
+
+    @staticmethod
+    def __handle_Z(_: _PatternCursor, __: _SteppedPatternBuilder[Offset, _OffsetParseBucket]) -> None:
+        raise InvalidPatternError(TextErrorMessages.ZPREFIX_NOT_AT_START_OF_PATTERN)
+
+    @staticmethod
+    def __handle_plus(pattern: _PatternCursor, builder: _SteppedPatternBuilder[Offset, _OffsetParseBucket]) -> None:
+        def sign_setter(bucket: _OffsetParseBucket, positive: bool) -> None:
+            bucket._is_negative = not positive
+
+        def non_negative_predicate(offset: Offset) -> bool:
+            return offset.milliseconds >= 0
+
+        builder._add_field(_PatternFields.SIGN, pattern.current)
+        builder.add_required_sign(sign_setter, non_negative_predicate)
+
+    @staticmethod
+    def __handle_minus(pattern: _PatternCursor, builder: _SteppedPatternBuilder[Offset, _OffsetParseBucket]) -> None:
+        def sign_setter(bucket: _OffsetParseBucket, positive: bool) -> None:
+            bucket._is_negative = not positive
+
+        def non_negative_predicate(offset: Offset) -> bool:
+            return offset.milliseconds >= 0
+
+        builder._add_field(_PatternFields.SIGN, pattern.current)
+        builder.add_negative_only_sign(sign_setter, non_negative_predicate)
+
+    __PATTERN_CHARACTER_HANDLERS: Mapping[
+        str, Callable[[_PatternCursor, _SteppedPatternBuilder[Offset, _OffsetParseBucket]], None]
+    ] = {
+        "%": _SteppedPatternBuilder[Offset, _OffsetParseBucket]._handle_percent,
+        "'": _SteppedPatternBuilder[Offset, _OffsetParseBucket]._handle_quote,
+        '"': _SteppedPatternBuilder[Offset, _OffsetParseBucket]._handle_quote,
+        "\\": _SteppedPatternBuilder[Offset, _OffsetParseBucket]._handle_backslash,
+        ":": __handle_colon,
+        "h": __handle_h,
+        "H": _SteppedPatternBuilder[Offset, _OffsetParseBucket]._handle_padded_field(
+            2, _PatternFields.HOURS_24, 0, 23, __get_positive_hours, __H_setter, Offset
+        ),
+        "m": _SteppedPatternBuilder[Offset, _OffsetParseBucket]._handle_padded_field(
+            2, _PatternFields.MINUTES, 0, 59, __get_positive_minutes, __m_setter, Offset
+        ),
+        "s": _SteppedPatternBuilder[Offset, _OffsetParseBucket]._handle_padded_field(
+            2, _PatternFields.SECONDS, 0, 59, __get_positive_seconds, __s_setter, Offset
+        ),
+        "+": __handle_plus,
+        "-": __handle_minus,
+        "Z": __handle_Z,
+        # TODO: Add missing character handlers
+    }
+
+    def parse_pattern(self, pattern: str, format_info: _PyodaFormatInfo) -> IPattern[Offset]:
+        return self.__parse_partial_pattern(pattern, format_info)
+
+    def __parse_partial_pattern(self, pattern_text: str, format_info: _PyodaFormatInfo) -> _IPartialPattern[Offset]:
+        # Nullity check is performed in OffsetPattern.
+        if len(pattern_text) == 0:
+            raise InvalidPatternError(TextErrorMessages.FORMAT_STRING_EMPTY)
+
+        if len(pattern_text) == 1:
+            match pattern_text[0]:
+                case "g":
+                    return CompositePatternBuilder(
+                        patterns=[
+                            self.__parse_partial_pattern(format_info.offset_pattern_long, format_info),
+                            self.__parse_partial_pattern(format_info.offset_pattern_medium, format_info),
+                            self.__parse_partial_pattern(format_info.offset_pattern_short, format_info),
+                        ],
+                        format_predicates=[
+                            lambda offset: True,
+                            self.__has_zero_seconds,
+                            self.__has_zero_seconds_and_minutes,
+                        ],
+                    )._build_as_partial()
+                case "G":
+                    return self.__ZPrefixPattern(self.__parse_partial_pattern("g", format_info))
+                case "i":
+                    return CompositePatternBuilder(
+                        patterns=[
+                            self.__parse_partial_pattern(format_info.offset_pattern_long_no_punctuation, format_info),
+                            self.__parse_partial_pattern(format_info.offset_pattern_medium_no_punctuation, format_info),
+                            self.__parse_partial_pattern(format_info.offset_pattern_short_no_punctuation, format_info),
+                        ],
+                        format_predicates=[
+                            lambda offset: True,
+                            self.__has_zero_seconds,
+                            self.__has_zero_seconds_and_minutes,
+                        ],
+                    )._build_as_partial()
+                case "I":
+                    return self.__ZPrefixPattern(self.__parse_partial_pattern("i", format_info))
+                case "l":
+                    pattern_text = format_info.offset_pattern_long
+                case "m":
+                    pattern_text = format_info.offset_pattern_medium
+                case "s":
+                    pattern_text = format_info.offset_pattern_short
+                case "L":
+                    pattern_text = format_info.offset_pattern_long_no_punctuation
+                case "M":
+                    pattern_text = format_info.offset_pattern_medium_no_punctuation
+                case "S":
+                    pattern_text = format_info.offset_pattern_short_no_punctuation
+                case _:
+                    raise InvalidPatternError(TextErrorMessages.UNKNOWN_STANDARD_FORMAT, pattern_text, Offset.__name__)
+
+        # This is the only way we'd normally end up in custom parsing land for Z on its own.
+        if pattern_text == "%Z":
+            raise InvalidPatternError(TextErrorMessages.EMPTY_ZPREFIXED_OFFSET_PATTERN)
+
+        # Handle Z-prefix by stripping it, parsing the rest as a normal pattern, then building a special pattern
+        # which decides whether or not to delegate.
+        # Note that patternText is guaranteed not to be empty due to the check at the start.
+        # (And assuming we don't add any standard => custom pattern expansions that result in an empty pattern.)
+        z_prefix: bool = pattern_text[0] == "Z"
+
+        pattern_builder = _SteppedPatternBuilder[Offset, _OffsetParseBucket](format_info, _OffsetParseBucket)
+        pattern_builder._parse_custom_pattern(
+            pattern_text[1:] if z_prefix else pattern_text, self.__PATTERN_CHARACTER_HANDLERS
+        )
+        # No need to validate field combinations here, but we do need to do something a bit special
+        # for Z-handling.
+        pattern: _IPartialPattern[Offset] = pattern_builder._build(Offset.from_hours_and_minutes(5, 30))
+        return self.__ZPrefixPattern(pattern) if z_prefix else pattern
+
+    @staticmethod
+    def __has_zero_seconds(offset: Offset) -> bool:
+        """Returns true if the offset is representable just in hours and minutes (no seconds)."""
+        return _csharp_modulo(offset.seconds, PyodaConstants.SECONDS_PER_MINUTE) == 0
+
+    @staticmethod
+    def __has_zero_seconds_and_minutes(offset: Offset) -> bool:
+        """Returns true if the offset is representable just in hours (no minutes or seconds)."""
+        return _csharp_modulo(offset.seconds, PyodaConstants.SECONDS_PER_HOUR) == 0
+
+    class __ZPrefixPattern(_IPartialPattern[Offset]):
+        """Pattern which optionally delegates to another, but both parses and formats Offset.Zero as "Z"."""
+
+        def __init__(self, full_pattern: _IPartialPattern[Offset]) -> None:
+            self.__full_pattern: Final[_IPartialPattern[Offset]] = full_pattern
+
+        def parse(self, text: str) -> ParseResult[Offset]:
+            if text == "Z":
+                return ParseResult[Offset].for_value(Offset.zero)
+            return self.__full_pattern.parse(text)
+
+        def format(self, value: Offset) -> str:
+            if value == Offset.zero:
+                return "Z"
+            return self.__full_pattern.format(value)
+
+        def parse_partial(self, cursor: _ValueCursor) -> ParseResult[Offset]:
+            if cursor.current == "Z":
+                cursor.move_next()
+                return ParseResult[Offset].for_value(Offset.zero)
+            return self.__full_pattern.parse_partial(cursor)
+
+        def append_format(self, value: Offset, builder: StringBuilder) -> StringBuilder:
+            _Preconditions._check_not_null(builder, "builder")
+            if value == Offset.zero:
+                return builder.append("Z")
+            return self.__full_pattern.append_format(value, builder)

--- a/pyoda_time/text/_parse_bucket.py
+++ b/pyoda_time/text/_parse_bucket.py
@@ -1,0 +1,27 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+from ._parse_result import ParseResult
+from .patterns._pattern_fields import _PatternFields
+
+T = TypeVar("T")
+
+
+class _ParseBucket(ABC, Generic[T]):
+    """Base class for "buckets" of parse data - as field values are parsed, they are stored in a bucket,
+    then the final value is calculated at the end.
+    """
+
+    @abstractmethod
+    def calculate_value(self, used_fields: _PatternFields, value: str) -> ParseResult[T]:
+        """Performs the final conversion from fields to a value. The parse can still fail here, if there are
+        incompatible field values.
+
+        :param used_fields: Indicates which fields were part of the original text pattern.
+        :param value: Complete value being parsed
+        :return: The result of the parse operation.
+        """
+        raise NotImplementedError

--- a/pyoda_time/text/_parse_result.py
+++ b/pyoda_time/text/_parse_result.py
@@ -1,0 +1,416 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, final, overload
+
+from .._calendar_system import CalendarSystem
+from ..calendars._era import Era
+from ..utility import _Preconditions, _private, _sealed
+from ._text_error_messages import TextErrorMessages
+from ._unparsable_value_error import UnparsableValueError
+
+if TYPE_CHECKING:
+    from . import _ValueCursor
+
+
+T = TypeVar("T")
+TTarget = TypeVar("TTarget")
+
+
+class _ParseResultMeta(type):
+    @property
+    @functools.cache
+    def _format_only_pattern(cls) -> ParseResult:
+        """This isn't really an issue with the value so much as the pattern...
+
+        but the result is the same.
+        """
+        # Pyoda Time implementation note:
+        # This is a field on ParseResult in Noda Time.
+        # To make this property possible without a complete hack,
+        # I've made ported the private constructor as an internal one.
+        # So `_ctor` rather than `__ctor`.
+        # This is also cached so that the same instance is returned
+        # eache time the getter is accessed.
+        # We need that for `assert ==` in tests, because the equality
+        # operator is not implemented for ParseResult, and equality
+        # checks fall back to default object.__eq__() behaviour.
+        return ParseResult._ctor(
+            exception_provider=functools.partial(UnparsableValueError, TextErrorMessages.FORMAT_ONLY_PATTERN),
+            continue_with_multiple=True,
+        )
+
+
+@_private
+@final
+@_sealed
+class ParseResult(Generic[T], metaclass=_ParseResultMeta):
+    """The result of a parse operation."""
+
+    # Invariant: exactly one of value or exceptionProvider is null.
+    __value: T | None = None
+    __exception_provider: Callable[[], Exception] | None = None
+
+    __continue_after_error_with_multiple_formats: bool = False
+
+    @property
+    def _continue_after_error_with_multiple_formats(self) -> bool:
+        return self.__continue_after_error_with_multiple_formats
+
+    @classmethod
+    def _ctor(
+        cls,
+        value: T | None = None,
+        exception_provider: Callable[[], Exception] | None = None,
+        continue_with_multiple: bool = False,
+    ) -> ParseResult[T]:
+        # Implementation Note:
+        # In Noda Time this is a private constructor.
+        # Normally we'd port those to a `__ctor` classmethod,
+        # but we need this one to be accessible to the metaclass
+        # for @property usage.
+
+        if (value and exception_provider) or (value is None and exception_provider is None):
+            raise RuntimeError("Exactly one of value and exception_provider can be specified")
+
+        self = super().__new__(cls)
+
+        if value:
+            self.__value = value
+        elif exception_provider:
+            self.__exception_provider = exception_provider
+            self.__continue_after_error_with_multiple_formats = continue_with_multiple
+
+        return self
+
+    @property
+    def value(self) -> T:
+        """Gets the value from the parse operation if it was successful, or throws an exception indicating the parse
+        failure otherwise.
+
+        This method is exactly equivalent to calling the ``get_value_or_throw()`` method, but is terser if the code is
+        already clear that it will throw if the parse failed.
+
+        :return: The result of the parsing operation if it was successful.
+        """
+        return self.get_value_or_throw()
+
+    @property
+    def exception(self) -> Exception:
+        """Gets an exception indicating the cause of the parse failure.
+
+        This property is typically used to wrap parse failures in higher level exceptions.
+
+        :return: The exception indicating the cause of the parse failure.
+        :raises RuntimeError: The parse operation succeeded.
+        """
+        if self.__exception_provider:
+            return self.__exception_provider()
+        raise RuntimeError("Parse operation succeeded, so no exception is available")
+
+    def get_value_or_throw(self) -> T:
+        """Gets the value from the parse operation if it was successful, or throws an exception indicating the parse
+        failure otherwise.
+
+        This method is exactly equivalent to fetching the ``value`` property, but more explicit in terms of throwing
+        an exception on failure.
+
+        :return: The result of the parsing operation if it was successful.
+        """
+        if self.__value is not None:
+            return self.__value
+        raise self.exception
+
+    def try_get_value(self, failure_value: T) -> tuple[bool, T]:
+        """Returns a two-tuple of the success value, and either the default ``failure_value`` of T or the successful
+        parse result value.
+
+        :param failure_value: The "default" value to set in ``result`` if parsing failed.
+        :return: A two-tuple of a boolean representing success, and either the parsed value or the default value.
+        """
+        return (self.success, self.value) if self.success else (self.success, failure_value)
+
+    @property
+    def success(self) -> bool:
+        """Indicates whether the parse operation was successful.
+
+        :return: ``True`` if the parse operation was successful; otherwise ``False``.
+        """
+        return self.__exception_provider is None
+
+    def convert(self, projection: Callable[[T], TTarget]) -> ParseResult[TTarget]:
+        """Converts this result to a new target type, either by executing the given projection for a success result, or
+        propagating the exception provider for failure.
+
+        :param projection: The projection to apply for the value of this result, if it's a success result.
+        :return: A ParseResult for the target type, either with a value obtained by applying the specified projection to
+            the value in this result, or with the same error as this result.
+        """
+        _Preconditions._check_not_null(projection, "projection")
+        return (
+            ParseResult[TTarget].for_value(projection(self.value))
+            if self.success
+            else ParseResult[TTarget]._ctor(
+                exception_provider=self.__exception_provider,
+                continue_with_multiple=self._continue_after_error_with_multiple_formats,
+            )
+        )
+
+    def convert_error(self: ParseResult[T], target_type: type[TTarget]) -> ParseResult[TTarget]:
+        # TODO: docstring
+        if self.success:
+            raise RuntimeError("convert_error should not be called on a successful parse result")
+        return ParseResult[TTarget]._ctor(
+            exception_provider=self.__exception_provider,
+            continue_with_multiple=self.__continue_after_error_with_multiple_formats,
+        )
+
+    # region Factory methods and readonly static fields
+
+    @classmethod
+    def for_value(cls: type[ParseResult[T]], value: T) -> ParseResult[T]:
+        """Produces a ParseResult which represents a successful parse operation.
+
+        :param value: The successfully parsed value.
+        :return: A ParseResult representing a successful parsing operation.
+        """
+        return cls._ctor(value)
+
+    @classmethod
+    def for_exception(cls: type[ParseResult[T]], exception_provider: Callable[[], Exception]) -> ParseResult[T]:
+        """Produces a ``ParseResult`` which represents a failed parsing operation.
+
+        This method accepts a ``Callable`` rather than the exception itself because
+        if the client doesn't need the actual exception - just the information
+        that the parse failed - there's no point in creating the exception.
+
+        :param exception_provider: A ``Callable`` which produces the exception
+            representing the error that caused the parse to fail.
+        :return: A ``ParseResult`` representing a failed parsing operation.
+        """
+        return cls._ctor(
+            exception_provider=_Preconditions._check_not_null(exception_provider, "exception_provider"),
+            continue_with_multiple=False,
+        )
+
+    @classmethod
+    def _for_invalid_value_post_parse(cls, text: str, format_string: str, *args: Any) -> ParseResult[T]:
+        def expection_provider() -> Exception:
+            detail_message = format_string.format(*args)
+            overall_message = TextErrorMessages.UNPARSABLE_VALUE_POST_PARSE.format(detail_message, text)
+            return UnparsableValueError(overall_message)
+
+        return cls._for_invalid_value(expection_provider)
+
+    @classmethod
+    @overload
+    def _for_invalid_value(cls, exception_provider: Callable[[], Exception], /) -> ParseResult[T]:
+        ...
+
+    @classmethod
+    @overload
+    def _for_invalid_value(cls, cursor: _ValueCursor, format_string: str, /, *parameters: Any) -> ParseResult[T]:
+        ...
+
+    @classmethod
+    def _for_invalid_value(
+        cls, cursor_or_exception_provider: _ValueCursor | Callable[[], Exception], *args: Any
+    ) -> ParseResult[T]:
+        from . import _ValueCursor
+
+        exception_provider: Callable[[], Exception]
+
+        if isinstance(cursor_or_exception_provider, _ValueCursor):
+            cursor: _ValueCursor = cursor_or_exception_provider
+            format_string: str = args[0]
+            parameters = args[1:]
+            detail_message = format_string.format(*parameters)
+            overall_message = TextErrorMessages.UNPARSABLE_VALUE.format(detail_message, cursor)
+
+            def exception_provider() -> Exception:
+                return UnparsableValueError(overall_message)
+
+        elif callable(cursor_or_exception_provider):
+            exception_provider = cursor_or_exception_provider
+        else:
+            raise TypeError(f"Expected cursor or exception_provider, got {type(cursor_or_exception_provider)}")
+
+        return cls._ctor(exception_provider=exception_provider, continue_with_multiple=True)
+
+    @classmethod
+    def _argument_null(cls, parameter: str) -> ParseResult[T]:
+        def exception_provider() -> Exception:
+            # TODO: ArgumentNullException
+            return ValueError(parameter)
+
+        return cls._ctor(exception_provider=exception_provider, continue_with_multiple=False)
+
+    @classmethod
+    def _positive_sign_invalid(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.POSITIVE_SIGN_INVALID)
+
+    @classmethod
+    def _value_string_empty(cls) -> ParseResult[T]:
+        """Special case: it's a fault with the value, but we still don't want to continue with multiple patterns.
+        Also, there's no point in including the text.
+        """
+
+        def exception_provider() -> Exception:
+            return UnparsableValueError(TextErrorMessages.VALUE_STRING_EMPTY)
+
+        return cls._ctor(exception_provider=exception_provider, continue_with_multiple=False)
+
+    @classmethod
+    def _extra_value_characters(cls, cursor: _ValueCursor, remainder: str) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.EXTRA_VALUE_CHARACTERS, remainder)
+
+    @classmethod
+    def _quoted_string_mismatch(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.QUOTED_STRING_MISMATCH)
+
+    @classmethod
+    def _escaped_character_missmatch(cls, cursor: _ValueCursor, pattern_character: str) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.ESCAPED_CHARACTER_MISMATCH, pattern_character)
+
+    @classmethod
+    def _end_of_string(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.END_OF_STRING)
+
+    @classmethod
+    def _time_separator_mismatch(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.TIME_SEPARATOR_MISMATCH)
+
+    @classmethod
+    def _date_separator_mismatch(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.DATE_SEPARATOR_MISMATCH)
+
+    @classmethod
+    def _missing_number(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.MISSING_NUMBER)
+
+    @classmethod
+    def _unexpected_negative(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.UNEXPECTED_NEGATIVE)
+
+    @classmethod
+    def _mismatched_number(cls, cursor: _ValueCursor, pattern: str) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.MISMATCHED_NUMBER, pattern)
+
+    @classmethod
+    def _mismatched_character(cls, cursor: _ValueCursor, pattern_character: str) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.MISMATCHED_CHARACTER, pattern_character)
+
+    @classmethod
+    def _mismatched_text(cls, cursor: _ValueCursor, field: str) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.MISMATCHED_TEXT, field)
+
+    @classmethod
+    def _no_matching_format(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.NO_MATCHING_FORMAT)
+
+    @classmethod
+    def _value_out_of_range(cls, value_cursor: _ValueCursor, value: T) -> ParseResult[T]:
+        return cls._for_invalid_value(value_cursor, TextErrorMessages.VALUE_OUT_OF_RANGE, value, type(value))
+
+    @classmethod
+    def _missing_sign(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.MISSING_SIGN)
+
+    @classmethod
+    def _missing_am_pm_designator(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.MISSING_AM_PM_DESIGNATOR)
+
+    @classmethod
+    def _no_matching_calendar_system(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.NO_MATCHING_CALENDAR_SYSTEM)
+
+    @classmethod
+    def _no_matching_zone_id(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.NO_MATCHING_ZONE_ID)
+
+    @classmethod
+    def _invalid_hour_24(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        return cls._for_invalid_value(cursor, TextErrorMessages.INVALID_HOUR_24)
+
+    @classmethod
+    def _field_value_out_of_range(cls, cursor: _ValueCursor, value: int, field: str, type_: type[T]) -> ParseResult[T]:
+        # TODO: This differs from Noda Time insofar as we can't do `typeof(T)` for the
+        #  final argument. This means that we've had to pass the actual type at runtime
+        #  which required several method signature changes. (Wherever this method is used.)
+        return cls._for_invalid_value(cursor, TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE, value, field, type_.__name__)
+
+    @classmethod
+    def _field_value_out_of_range_post_parse(
+        cls, text: str, value: int, field: str, eventual_result_type: type
+    ) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(
+            text, TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE, value, field, eventual_result_type
+        )
+
+    @classmethod
+    def _inconsistent_values(cls, text: str, field_1: str, field_2: str, eventual_result_type: type) -> ParseResult[T]:
+        """Two fields (e.g. "hour of day" and "hour of half day") were mutually inconsistent."""
+        return cls._for_invalid_value_post_parse(
+            text, TextErrorMessages.INCONSISTENT_VALUES_2, field_1, field_2, eventual_result_type
+        )
+
+    @classmethod
+    def _inconsistent_month_values(cls, text: str) -> ParseResult[T]:
+        """The month of year is inconsistent between the text and numeric specifications.
+
+        We can't use InconsistentValues for this as the pattern character is the same in both cases.
+        """
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.INCONSISTENT_MONTH_TEXT_VALUE)
+
+    @classmethod
+    def _inconsistent_day_of_week_text_value(cls, text: str) -> ParseResult[T]:
+        """The day of month is inconsistent with the day of week value.
+
+        We can't use InconsistentValues for this as the pattern character is the same in both cases.
+        """
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.INCONSISTENT_DAY_OF_WEEK_TEXT_VALUE)
+
+    @classmethod
+    def _expected_end_of_string(cls, cursor: _ValueCursor) -> ParseResult[T]:
+        """We'd expected to get to the end of the string now, but we haven't."""
+        return cls._for_invalid_value(cursor, TextErrorMessages.EXPECTED_END_OF_STRING)
+
+    @classmethod
+    def _year_era_out_of_range(cls, text: str, value: int, era: Era, calendar: CalendarSystem) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(
+            text, TextErrorMessages.YEAR_OF_ERA_OUT_OF_RANGE, value, era.name, calendar.name
+        )
+
+    @classmethod
+    def _month_out_of_range(cls, text: str, month: int, year: int) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.MONTH_OUT_OF_RANGE, month, year)
+
+    @classmethod
+    def _iso_month_out_of_range(cls, text: str, month: int) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.ISO_MONTH_OUT_OF_RANGE, month)
+
+    @classmethod
+    def _day_of_month_out_of_range(cls, text: str, day: int, month: int, year: int) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.DAY_OF_MONTH_OUT_OF_RANGE, day, month, year)
+
+    @classmethod
+    def _day_of_month_out_of_range_no_year(cls, text: str, day: int, month: int) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.DAY_OF_MONTH_OUT_OF_RANGE_NO_YEAR, day, month)
+
+    @classmethod
+    def _invalid_offset(cls, text: str) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.INVALID_OFFSET)
+
+    @classmethod
+    def _skipped_local_time(cls, text: str) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.SKIPPED_LOCAL_TIME)
+
+    @classmethod
+    def _ambiguous_local_time(cls, text: str) -> ParseResult[T]:
+        return cls._for_invalid_value_post_parse(text, TextErrorMessages.AMBIGUOUS_LOCAL_TIME)
+
+    # endregion

--- a/pyoda_time/text/_text_cursor.py
+++ b/pyoda_time/text/_text_cursor.py
@@ -1,0 +1,101 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from abc import ABC
+
+
+class _TextCursor(ABC):
+    """Provides a cursor over text being parsed.
+
+    None of the methods in this class throw exceptions (unless there is a bug in Pyoda Time, in which case an exception
+    is appropriate) and none of the methods have ref parameters indicating failures, unlike subclasses. This class is
+    used as the basis for both value and pattern parsing, so can make no judgement about what's wrong (i.e. it wouldn't
+    know what type of failure to indicate). Instead, methods return Boolean values to indicate success or failure.
+    """
+
+    @property
+    def length(self) -> int:
+        """Gets the length of the string being parsed."""
+        return self.__length
+
+    @property
+    def value(self) -> str:
+        """Gets the string being parsed."""
+        return self.__value
+
+    # A nul character. This character is not allowed in any parsable string and is used to
+    # indicate that the current character is not set.
+    _NUL: str = "\0"
+
+    def __init__(self, value: str) -> None:
+        self.__value = value
+        self.__length = len(value)
+        self.__current = self._NUL
+        self.__index = self.length
+        self.move(-1)
+
+    @property
+    def current(self) -> str:
+        """Gets the current character."""
+        return self.__current
+
+    @property
+    def has_more_characters(self) -> bool:
+        """Gets a value indicating whether this instance has more characters."""
+        return (self.index + 1) < self.length
+
+    @property
+    def index(self) -> int:
+        """Gets the current index into the string being parsed."""
+        return self.__index
+
+    @property
+    def remainder(self) -> str:
+        """Gets the remainder the string that has not been parsed yet."""
+        return self.value[self.index :]
+
+    def __str__(self) -> str:
+        if self.index <= 0:
+            return f"^{self.value}"
+        if self.index >= self.length:
+            return f"{self.value}^"
+        return self.value[: self.index] + "^" + self.value[self.index :]
+
+    def peek_next(self) -> str:
+        """Eturns the next character if there is one or `_NUL` if there isn't."""
+        return self.value[self.index + 1] if self.has_more_characters else self._NUL
+
+    def move(self, target_index: int) -> bool:
+        """Moves the specified target index. If the new index is out of range of the valid indices for this string then
+        the index is set to the beginning or the end of the string whichever is nearest the requested index.
+
+        :param target_index: Index of the target.
+        :return: ``True`` if the requested index is in range.
+        """
+        if target_index >= 0:
+            if target_index < self.length:
+                self.__index = target_index
+                self.__current = self.value[self.index]
+                return True
+            else:
+                self.__current = self._NUL
+                self.__index = self.length
+                return False
+        self.__current = self._NUL
+        self.__index = -1
+        return False
+
+    def move_next(self) -> bool:
+        """Moves to the next character.
+
+        :return: ``True`` if the requested index is in range.
+        """
+        return self.move(self.index + 1)
+
+    def move_previous(self) -> bool:
+        """Moves to the previous character.
+
+        :return: ``True`` if the requested index is in range.
+        """
+        return self.move(self.index - 1)

--- a/pyoda_time/text/_text_error_messages.py
+++ b/pyoda_time/text/_text_error_messages.py
@@ -1,0 +1,120 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from typing import Final, final
+
+from ..utility import _private, _sealed
+
+
+@final
+@_sealed
+@_private
+class TextErrorMessages:
+    """Centralized location for error messages around text handling."""
+
+    AMBIGUOUS_LOCAL_TIME: Final[str] = "The local date/time is ambiguous in the target time zone."
+    CALENDAR_AND_ERA: Final[
+        str
+    ] = "The era specifier cannot be specified in the same pattern as the calendar specifier."
+    DATE_FIELD_AND_EMBEDDED_DATE: Final[
+        str
+    ] = "Custom date specifiers cannot be specified in the same pattern as an embedded date specifier"
+    DATE_SEPARATOR_MISMATCH: Final[str] = "The value string does not match a date separator in the format string."
+    DAY_OF_MONTH_OUT_OF_RANGE: Final[str] = "The day {0} is out of range in month {1} of year {2}."
+    DAY_OF_MONTH_OUT_OF_RANGE_NO_YEAR: Final[str] = "The day {0} is out of range in month {1}."
+    EMPTY_PERIOD: Final[str] = "The specified period was empty."
+    EMPTY_ZPREFIXED_OFFSET_PATTERN: Final[
+        str
+    ] = "The Z prefix for an Offset pattern must be followed by a custom pattern."
+    END_OF_STRING: Final[str] = "Input string ended unexpectedly early."
+    ERA_WITHOUT_YEAR_OF_ERA: Final[str] = 'The era specifier cannot be used without the "year of era" specifier.'
+    ESCAPE_AT_END_OF_STRING: Final[
+        str
+    ] = "The format string has an escape character (backslash '\\') at the end of the string."
+    ESCAPED_CHARACTER_MISMATCH: Final[
+        str
+    ] = 'The value string does not match an escaped character in the format string: "{0}"'
+    EXPECTED_END_OF_STRING: Final[str] = "Expected end of input, but more data remains."
+    EXTRA_VALUE_CHARACTERS: Final[
+        str
+    ] = 'The format matches a prefix of the value string but not the entire string. Part not matching: "{0}".'
+    FIELD_VALUE_OUT_OF_RANGE: Final[str] = "The value {0} is out of range for the field '{1}' in the {2} type."
+    FORMAT_ONLY_PATTERN: Final[str] = "This pattern is only capable of formatting, not parsing."
+    FORMAT_STRING_EMPTY: Final[str] = "The format string is empty."
+    HOUR12_PATTERN_NOT_SUPPORTED: Final[str] = "The 'h' pattern flag (12 hour format) is not supported by the {0} type."
+    INCONSISTENT_DAY_OF_WEEK_TEXT_VALUE: Final[
+        str
+    ] = "The specified day of the week does not matched the computed value."
+    INCONSISTENT_MONTH_TEXT_VALUE: Final[str] = "The month values specified as text and numbers are inconsistent."
+    INCONSISTENT_VALUES_2: Final[
+        str
+    ] = "The individual values for the fields '{0}' and '{1}' created an inconsistency in the {2} type."
+    INVALID_EMBEDDED_PATTERN_TYPE: Final[str] = "The type of embedded pattern is not supported for this type."
+    INVALID_HOUR_24: Final[str] = "24 is only valid as an hour number when the units smaller than hours are all 0."
+    INVALID_OFFSET: Final[str] = "The specified offset is invalid for the given date/time."
+    INVALID_REPEAT_COUNT: Final[
+        str
+    ] = 'The number of consecutive copies of the pattern character "{0}" in the format string ({1}) is invalid.'
+    INVALID_UNIT_SPECIFIER: Final[str] = "The period unit specifier '{0}' is invalid."
+    ISO_MONTH_OUT_OF_RANGE: Final[str] = "The month {0} is out of range in the ISO calendar."
+    MISMATCHED_CHARACTER: Final[str] = 'The value string does not match a simple character in the format string "{0}".'
+    MISMATCHED_NUMBER: Final[str] = 'The value string does not match the required number from the format string "{0}".'
+    MISMATCHED_TEXT: Final[str] = "The value string does not match the text-based field '{0}'."
+    MISPLACED_UNIT_SPECIFIER: Final[
+        str
+    ] = "The period unit specifier '{0}' appears at the wrong place in the input string."
+    MISSING_AM_PM_DESIGNATOR: Final[
+        str
+    ] = "The value string does not match the AM or PM designator for the culture at the required place."
+    MISSING_EMBEDDED_PATTERN_END: Final[
+        str
+    ] = "The pattern has an embedded pattern which is missing its closing character ('{0}')."
+    MISSING_EMBEDDED_PATTERN_START: Final[
+        str
+    ] = "The pattern has an embedded pattern which is missing its opening character ('{0}')."
+    MISSING_END_QUOTE: Final[str] = 'The format string is missing the end quote character "{0}".'
+    MISSING_NUMBER: Final[str] = "The value string does not include a number in the expected position."
+    MISSING_SIGN: Final[str] = "The required value sign is missing."
+    MONTH_OUT_OF_RANGE: Final[str] = "The month {0} is out of range in year {1}."
+    MULTIPLE_CAPITAL_DURATION_FIELDS: Final[
+        str
+    ] = 'Only one of "D", "H", "M" or "S" can occur in a duration format string.'
+    NO_MATCHING_CALENDAR_SYSTEM: Final[str] = "The specified calendar id is not recognized."
+    NO_MATCHING_FORMAT: Final[str] = "None of the specified formats matches the given value string."
+    NO_MATCHING_ZONE_ID: Final[str] = "The specified time zone identifier is not recognized."
+    OVERALL_VALUE_OUT_OF_RANGE: Final[str] = "Value is out of the legal range for the {0} type."
+    PERCENT_AT_END_OF_STRING: Final[str] = "A percent sign (%) appears at the end of the format string."
+    PERCENT_DOUBLED: Final[str] = "A percent sign (%) is followed by another percent sign in the format string."
+    POSITIVE_SIGN_INVALID: Final[str] = "A positive value sign is not valid at this point."
+    QUOTED_STRING_MISMATCH: Final[str] = "The value string does not match a quoted string in the pattern."
+    REPEAT_COUNT_EXCEEDED: Final[str] = (
+        'There were more consecutive copies of the pattern character "{0}" than the maximum allowed ({1}) '
+        "in the format string."
+    )
+    REPEATED_FIELD_IN_PATTERN: Final[str] = 'The field "{0}" is specified multiple times in the pattern.'
+    REPEATED_UNIT_SPECIFIER: Final[str] = "The period unit specifier '{0}' appears multiple times in the input string."
+    SKIPPED_LOCAL_TIME: Final[str] = "The local date/time is skipped in the target time zone."
+    TIME_FIELD_AND_EMBEDDED_TIME: Final[
+        str
+    ] = "Custom time specifiers cannot be specified in the same pattern as an embedded time specifier"
+    TIME_SEPARATOR_MISMATCH: Final[str] = "The value string does not match a time separator in the format string."
+    UNEXPECTED_NEGATIVE: Final[
+        str
+    ] = "The value string includes a negative value where only a non-negative one is allowed."
+    UNKNOWN_STANDARD_FORMAT: Final[str] = (
+        'The standard format "{0}" is not valid for the {1} type. '
+        'If the pattern was intended to be a custom format, escape it with a percent sign: "%{0}".'
+    )
+    UNPARSABLE_VALUE: Final[str] = "{0} Value being parsed: '{1}'. (^ indicates error position.)"
+    UNPARSABLE_VALUE_POST_PARSE: Final[str] = "{0} Value being parsed: '{1}'."
+    UNQUOTED_LITERAL: Final[str] = (
+        "The character {0} is not a format specifier for this pattern type, and should be quoted to "
+        "act as a literal. Note that each type of pattern has its own set of valid format specifiers."
+    )
+    VALUE_OUT_OF_RANGE: Final[str] = "The value {0} is out of the legal range for the {1} type."
+    VALUE_STRING_EMPTY: Final[str] = "The value string is empty."
+    YEAR_OF_ERA_OUT_OF_RANGE: Final[str] = "The year {0} is out of range for the {1} era in the {2} calendar."
+    ZPREFIX_NOT_AT_START_OF_PATTERN: Final[
+        str
+    ] = "The Z prefix for an Offset pattern must occur at the beginning of the pattern."

--- a/pyoda_time/text/_unparsable_value_error.py
+++ b/pyoda_time/text/_unparsable_value_error.py
@@ -1,0 +1,15 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from typing import final
+
+from pyoda_time.utility import _sealed
+
+
+@_sealed
+@final
+class UnparsableValueError(Exception):
+    """Exception thrown to indicate that the specified value could not be parsed."""
+
+    pass

--- a/pyoda_time/text/_value_cursor.py
+++ b/pyoda_time/text/_value_cursor.py
@@ -1,0 +1,206 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import math
+from typing import final
+
+from ..utility import _CsharpConstants, _sealed
+from ._parse_result import ParseResult
+from ._text_cursor import _TextCursor
+
+
+@final
+@_sealed
+class _ValueCursor(_TextCursor):
+    def _match(self, match: str) -> bool:
+        """Attempts to match the specified string with the current point in the string. If the character matches then
+        the index is moved past the string.
+
+        :param match: The string to match.
+        :return: ``True`` if the string matches.
+        """
+        target_index = self.index + len(match)
+        if self.value[self.index : target_index] == match:
+            self.move(target_index)
+            return True
+        return False
+
+    # TODO: We don't have CompareInfo.Compare() in Python
+    #  internal bool MatchCaseInsensitive(string match, CompareInfo compareInfo, bool moveOnSuccess)
+    def _match_case_insensitive(self, match: str, move_on_success: bool) -> bool:
+        """Attempts to match the specified string with the current point in the string in a case-insensitive manner,
+        according to the given comparison info.
+
+        The cursor is optionally updated to the end of the match.
+        """
+
+        # TODO: This is very different to the Noda Time implementation!
+
+        if len(match) > len(self.value) - self.index:
+            return False
+
+        # Extract the substring from the current index to the length of the match string
+        substring = self.value[self.index : self.index + len(match)]
+
+        # Compare the case-insensitive substrings
+        if substring.lower() == match.lower():
+            if move_on_success:
+                # Move the cursor to the end of the matched segment
+                self.move(self.index + len(match))
+            return True
+        return False
+
+    def _compare_ordinal(self, match: str) -> int:
+        """Compares the value from the current cursor position with the given match. If the
+        given match string is longer than the remaining length, the comparison still goes
+        ahead but the result is never 0: if the result of comparing to the end of the
+        value returns 0, the result is -1 to indicate that the value is earlier than the given match.
+        Conversely, if the remaining value is longer than the match string, the comparison only
+        goes as far as the end of the match. So "xabcd" with the cursor at "a" will return 0 when
+        matched with "abc".
+
+        :param match: The string to compare with the current cursor position.
+        :return: A negative number if the value (from the current cursor position) is lexicographically
+            earlier than the given match string; 0 if they are equal (as far as the end of the match) and
+            a positive number if the value is lexicographically later than the given match string.
+        """
+        remaining = self.value[self.index :]
+        if len(match) > len(remaining):
+            # If match is longer than remaining, compare up to the end of remaining.
+            # If they are equal, return -1 to indicate `value` is earlier than `match`.
+            result = (remaining > match[: len(remaining)]) - (remaining < match[: len(remaining)])
+            return -1 if result == 0 else result
+        else:
+            # If remaining is longer or equal, compare up to the length of match.
+            result = (remaining[: len(match)] > match) - (remaining[: len(match)] < match)
+            return result
+
+    def _parse_int64(self) -> tuple[ParseResult | None, int]:
+        """Parses digits at the current point in the string as a signed 64-bit integer value. Currently this method only
+        supports cultures whose negative sign is "-" (and using ASCII digits).
+
+        :return: A 2-tuple of either a ``ParseResult`` or ``None`` depending on whether the parse operation succeeded,
+            and the result integer value. The value of this is not guaranteed to be anything specific if the return
+            value is non-null.
+        """
+        # TODO: unchecked
+        result = 0
+        start_index = self.index
+        negative = self.current == "-"
+        if negative:
+            if not self.move_next():
+                self.move(start_index)
+                return ParseResult._end_of_string(self), result
+        count = 0
+        digit: int
+        while result < 922337203685477580 and ((digit := self.__get_digit()) != -1):
+            result = result * 10 + digit
+            count += 1
+            if not self.move_next():
+                break
+
+        if count == 0:
+            self.move(start_index)
+            return ParseResult._missing_number(self), result
+
+        if result >= 922337203685477580 and (digit := self.__get_digit()) != -1:
+            if result > 922337203685477580:
+                return self.__build_number_out_of_range_result(start_index), result
+            if negative and (digit == 8):
+                self.move_next()
+                result = _CsharpConstants.LONG_MIN_VALUE
+                return None, result
+            if digit > 7:
+                return self.__build_number_out_of_range_result(start_index), result
+            # We know we can cope with this digit
+            result = result * 10 + digit
+            self.move_next()
+            if self.__get_digit() != -1:
+                # Too many digits. Die.
+                return self.__build_number_out_of_range_result(start_index), result
+
+        if negative:
+            result = -result
+        return None, result
+
+    def __build_number_out_of_range_result(self, start_index: int) -> ParseResult:
+        self.move(start_index)
+        if self.current == "-":
+            self.move_next()
+        # End of string works like not finding a digit.
+        while self.__get_digit() != -1:
+            self.move_next()
+        bad_value = self.value[start_index : self.index - start_index]
+        self.move(start_index)
+        return ParseResult._value_out_of_range(self, bad_value)
+
+    def _parse_digits(self, minimum_digits: int, maximum_digits: int) -> tuple[bool, int]:
+        """Parses digits at the current point in the string. If the minimum required digits are not present then the
+        index is unchanged. If there are more digits than the maximum allowed they are ignored.
+
+        :param minimum_digits: The minimum allowed digits.
+        :param maximum_digits: The maximum allowed digits.
+        :return: A 2-tuple of a bool indicating success/failure, and the result integer value. The value of this is not
+            guaranteed to be anything specific if the return value is false.
+        """
+        # TODO: unchecked
+        result = 0
+        local_index = self.index
+        max_index = local_index + maximum_digits
+        if max_index >= self.length:
+            max_index = self.length
+        while local_index < max_index:
+            digit = self.value[local_index]
+            if not digit.isdigit():
+                break
+            result = result * 10 + int(digit)
+            local_index += 1
+        count: int = local_index - self.index
+        if count < minimum_digits:
+            return False, result
+        self.move(local_index)
+        return True, result
+
+    def _parse_fraction(self, maximum_digits: int, scale: int, minimum_digits: int) -> tuple[bool, int]:
+        """Parses digits at the current point in the string as a fractional value.
+
+        :param maximum_digits: The maximum allowed digits. Trusted to be less than or equal to scale.
+        :param scale: The scale of the fractional value.
+        :param minimum_digits: The minimum number of digits that must be specified in the value.
+        :return: A 2-tuple of a bool indicating success/failure, and the result integer scaled by scale. The value of
+            this integer is not guaranteed to be anything specific if the return value is false.
+        """
+        # TODO: unchecked
+
+        # TODO: Preconditions.DebugCheckArgument
+
+        result = 0
+        local_index = self.index
+        min_index = local_index + minimum_digits
+        if min_index >= self.length:
+            # If we don't have all the digits we're meant to have, we can't possibly succeed.
+            return False, result
+        max_index = min(local_index + maximum_digits, self.length)
+        while local_index < max_index:
+            digit = self.value[local_index]
+            if not digit.isdigit():
+                break
+            result = result * 10 + int(digit)
+            local_index += 1
+        count: int = local_index - self.index
+        # Couldn't parse the minimum number of digits required?
+        if count < minimum_digits:
+            return False, result
+        result = int(result * math.pow(10.0, scale - count))
+        self.move(local_index)
+        return True, result
+
+    def __get_digit(self) -> int:
+        """Gets the integer value of the current digit character, or -1 for "not a digit".
+
+        This currently only handles ASCII digits, which is all we have to parse to stay in line with the BCL.
+        """
+        # TODO unchecked
+        if self.current.isdigit():
+            return int(self.current)
+        return -1

--- a/pyoda_time/text/patterns/__init__.py
+++ b/pyoda_time/text/patterns/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from ._pattern_bcl_support import _PatternBclSupport  # noqa: F401
+from ._pattern_cursor import _PatternCursor  # noqa: F401
+from ._pattern_fields import _PatternFields  # noqa: F401

--- a/pyoda_time/text/patterns/_i_pattern_parser.py
+++ b/pyoda_time/text/patterns/_i_pattern_parser.py
@@ -1,0 +1,16 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Protocol, TypeVar
+
+from ...globalization import _PyodaFormatInfo
+from .._i_pattern import IPattern
+
+T = TypeVar("T")
+
+
+class _IPatternParser(Protocol[T]):
+    """Internal interface used by FixedFormatInfoPatternParser."""
+
+    def parse_pattern(self, pattern: str, format_info: _PyodaFormatInfo) -> IPattern[T]:
+        ...

--- a/pyoda_time/text/patterns/_pattern_bcl_support.py
+++ b/pyoda_time/text/patterns/_pattern_bcl_support.py
@@ -1,0 +1,35 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from typing import Callable, Final, Generic, TypeVar, final
+
+from ..._compatibility._i_format_provider import IFormatProvider
+from ...globalization._pyoda_format_info import _PyodaFormatInfo
+from ...utility import _sealed
+from .._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
+from .._i_pattern import IPattern
+
+T = TypeVar("T")
+
+
+@_sealed
+@final
+class _PatternBclSupport(Generic[T]):
+    """Class providing simple support for the various Parse/TryParse/ParseExact/TryParseExact/Format overloads provided
+    by individual types."""
+
+    def __init__(
+        self,
+        default_format_pattern: str,
+        pattern_parser: Callable[[_PyodaFormatInfo], _FixedFormatInfoPatternParser[T]],
+    ) -> None:
+        self.__pattern_parser: Final[Callable[[_PyodaFormatInfo], _FixedFormatInfoPatternParser[T]]] = pattern_parser
+        self.__default_format_pattern: Final[str] = default_format_pattern
+
+    def format(self, value: T, pattern_text: str | None, format_provider: IFormatProvider) -> str:
+        if pattern_text is None or not pattern_text.strip():
+            pattern_text = self.__default_format_pattern
+        format_info: _PyodaFormatInfo = _PyodaFormatInfo.get_instance(format_provider)
+        pattern: IPattern[T] = self.__pattern_parser(format_info)._parse_pattern(pattern_text)
+        return pattern.format(value)

--- a/pyoda_time/text/patterns/_pattern_cursor.py
+++ b/pyoda_time/text/patterns/_pattern_cursor.py
@@ -1,0 +1,102 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from typing import Final, final
+
+from ..._compatibility._string_builder import StringBuilder
+from ...utility import _sealed
+from .._invalid_pattern_exception import InvalidPatternError
+from .._text_cursor import _TextCursor
+from .._text_error_messages import TextErrorMessages
+
+
+@final
+@_sealed
+class _PatternCursor(_TextCursor):
+    """Extends ``_TextCursor`` to simplify parsing patterns such as "uuuu-MM-dd"."""
+
+    # The character signifying the start of an embedded pattern.
+    _EMBEDDED_PATTERN_START: Final[str] = "<"
+    # The character signifying the end of an embedded pattern.
+    _EMBEDDED_PATTERN_END: Final[str] = ">"
+
+    def get_quoted_string(self, close_quote: str) -> str:
+        """Return the quoted string.
+
+        The cursor is left positioned at the end of the quoted region.
+
+        :param close_quote: The close quote character to match for the end of the quoted string.
+        :return: The quoted string sans open and close quotes. This can be an empty string.
+        """
+        builder = StringBuilder()
+        end_quote_found = False
+        while self.move_next():
+            if self.current == close_quote:
+                self.move_next()
+                end_quote_found = True
+                break
+            if self.current == "\\":
+                if not self.move_next():
+                    raise InvalidPatternError(TextErrorMessages.ESCAPE_AT_END_OF_STRING)
+            builder.append(self.current)
+        if not end_quote_found:
+            raise InvalidPatternError(TextErrorMessages.MISSING_END_QUOTE, close_quote)
+        self.move_previous()
+        return builder.to_string()
+
+    def get_repeat_count(self, maximum_count: int) -> int:
+        """Gets the pattern repeat count.
+
+        The cursor is left on the final character of the repeated sequence.
+
+        :param maximum_count: The maximum number of repetitions allowed.
+        :return: The repetition count which is always at least ``1``.
+        """
+        pattern_character = self.current
+        start_position = self.index
+        while self.move_next() and (self.current == pattern_character):
+            pass
+        repeat_length = self.index - start_position
+        # Move the cursor back to the last character of the repeated pattern
+        self.move_previous()
+        if repeat_length > maximum_count:
+            raise InvalidPatternError(TextErrorMessages.REPEAT_COUNT_EXCEEDED, pattern_character, maximum_count)
+        return repeat_length
+
+    def get_embedded_pattern(self) -> str:
+        """Returns a string containing the embedded pattern within this one.
+
+        The cursor is expected to be positioned immediately before the ``_EMBEDDED_PATTERN_START`` character (``<``),
+        and on success the cursor will be positioned on the ``_EMBEDDED_PATTERN_END`` character (``>``).
+
+        Quote characters (``'`` and ``"``) and escaped characters (escaped with a backslash) are handled
+        but not unescaped: the resulting pattern should be ready for parsing as normal. It is assumed that the
+        embedded pattern will itself handle embedded patterns, so if the input is on the first ``<``
+        of ``"before <outer1 <inner> outer2> after"``
+        this method will return ``"outer1 <inner> outer2"`` and the cursor will be positioned
+        on the final ``>`` afterwards.
+
+        :return: The embedded pattern, not including the start/end pattern characters.
+        """
+        if (not self.move_next()) or (self.current != self._EMBEDDED_PATTERN_START):
+            raise InvalidPatternError(TextErrorMessages.MISSING_EMBEDDED_PATTERN_START, self._EMBEDDED_PATTERN_START)
+        start_index = self.index + 1
+        depth = 1  # For nesting
+        while self.move_next():
+            current = self.current
+            if current == self._EMBEDDED_PATTERN_END:
+                depth -= 1
+                if depth == 0:
+                    return self.value[start_index : self.index]
+            elif current == self._EMBEDDED_PATTERN_START:
+                depth += 1
+            elif current == "\\":
+                if not self.move_next():
+                    raise InvalidPatternError(TextErrorMessages.ESCAPE_AT_END_OF_STRING)
+            elif current == "'" or current == '"':
+                # We really don't care about the value here. It's slightly inefficient to
+                # create the substring and then ignore it, but it's unlikely to be significant.
+                _ = self.get_quoted_string(current)
+        # We've reached the end of the enclosing pattern without reaching the end of the embedded pattern. Oops.
+        raise InvalidPatternError(TextErrorMessages.MISSING_EMBEDDED_PATTERN_END, self._EMBEDDED_PATTERN_END)

--- a/pyoda_time/text/patterns/_pattern_fields.py
+++ b/pyoda_time/text/patterns/_pattern_fields.py
@@ -1,0 +1,67 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from enum import Flag
+
+
+class _PatternFields(Flag):
+    """Enum representing the fields available within patterns.
+
+    This single enum is shared by all parser types for simplicity, although most fields aren't used by most parsers.
+    Pattern fields don't necessarily have corresponding duration or date/time fields, due to concepts such as "sign".
+    """
+
+    NONE = 0
+    SIGN = 1 << 0
+    HOURS_12 = 1 << 1
+    HOURS_24 = 1 << 2
+    MINUTES = 1 << 3
+    SECONDS = 1 << 4
+    FRACTIONAL_SECONDS = 1 << 5
+    AM_PM = 1 << 6
+    YEAR = 1 << 7
+    YEAR_TWO_DIGITS = 1 << 8  # Actually year of *era* as two digits...
+    YEAR_OF_ERA = 1 << 9
+    MONTH_OF_YEAR_NUMERIC = 1 << 10
+    MONTH_OF_YEAR_TEXT = 1 << 11
+    DAY_OF_MONTH = 1 << 12
+    DAY_OF_WEEK = 1 << 13
+    ERA = 1 << 14
+    CALENDAR = 1 << 15
+    ZONE = 1 << 16
+    ZONE_ABBREVIATION = 1 << 17
+    EMBEDDED_OFFSET = 1 << 18
+    # D, H, M, or S in a DurationPattern.
+    TOTAL_DURATION = 1 << 19
+    # No other date fields permitted; use calendar/year/month/day from bucket
+    EMBEDDED_DATE = 1 << 20
+    # No other time fields permitted; user hours24/minutes/seconds/fractional seconds from bucket
+    EMBEDDED_TIME = 1 << 21
+
+    ALL_TIME_FIELDS = HOURS_12 | HOURS_24 | MINUTES | SECONDS | FRACTIONAL_SECONDS | AM_PM | EMBEDDED_TIME
+    ALL_DATE_FIELDS = (
+        YEAR
+        | YEAR_TWO_DIGITS
+        | YEAR_OF_ERA
+        | MONTH_OF_YEAR_NUMERIC
+        | MONTH_OF_YEAR_TEXT
+        | DAY_OF_MONTH
+        | DAY_OF_WEEK
+        | ERA
+        | CALENDAR
+        | EMBEDDED_DATE
+    )
+
+    # In Noda Time, the following methods are implemented as extension methods
+    # on a ``PatternFieldsExtensions`` class.
+
+    def has_any(self, target: _PatternFields) -> bool:
+        """Returns true if the given set of fields contains any of the target fields."""
+        return (self & target) != _PatternFields.NONE
+
+    def has_all(self, target: _PatternFields) -> bool:
+        """Returns true if the given set of fields contains all of the target fields."""
+        return (self & target) == target

--- a/pyoda_time/text/patterns/_stepped_pattern_builder.py
+++ b/pyoda_time/text/patterns/_stepped_pattern_builder.py
@@ -1,0 +1,408 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from typing import (
+    Callable,
+    Final,
+    Generic,
+    Mapping,
+    Protocol,
+    TypeVar,
+    final,
+    runtime_checkable,
+)
+
+from ..._compatibility._string_builder import StringBuilder
+from ...globalization import _PyodaFormatInfo
+from ...utility import _Preconditions, _sealed
+from .. import InvalidPatternError, ParseResult, _ParseBucket, _ValueCursor
+from .._format_helper import FormatHelper
+from .._i_partial_pattern import _IPartialPattern
+from .._text_error_messages import TextErrorMessages
+from . import _PatternCursor, _PatternFields
+
+TResult = TypeVar("TResult")
+TBucket = TypeVar("TBucket", bound="_ParseBucket")
+
+
+@_sealed
+@final
+class _SteppedPatternBuilder(Generic[TResult, TBucket]):
+    """Builder for a pattern which implements parsing and formatting as a sequence of steps applied in turn."""
+
+    @property
+    def _format_info(self) -> _PyodaFormatInfo:
+        return self.__format_info
+
+    @property
+    def _used_fields(self) -> _PatternFields:
+        return self.__used_fields
+
+    def __init__(self, format_info: _PyodaFormatInfo, bucket_provider: Callable[[], TBucket]) -> None:
+        self.__format_info: Final[_PyodaFormatInfo] = format_info
+        self.__format_actions: Final[list[Callable[[TResult, StringBuilder], None]]] = []
+        self.__parse_actions: Final[list[Callable[[_ValueCursor, TBucket], ParseResult[TResult] | None]]] = []
+        self.__bucket_provider: Final[Callable[[], TBucket]] = bucket_provider
+        self.__used_fields: _PatternFields = _PatternFields.NONE
+        self.__format_only: bool = False
+
+    def _create_sample_bucket(self) -> TBucket:
+        """Calls the bucket provider and returns a sample bucket.
+
+        This means that any values normally propagated via the bucket can also be used when building the pattern.
+        """
+        return self.__bucket_provider()
+
+    def _set_format_only(self) -> None:
+        """Sets this pattern to only be capable of formatting; any attempt to parse using the built pattern will fail
+        immediately."""
+        self.__format_only = True
+
+    def _parse_custom_pattern(
+        self,
+        pattern_text: str,
+        character_handlers: Mapping[str, Callable[[_PatternCursor, _SteppedPatternBuilder[TResult, TBucket]], None]],
+    ) -> None:
+        """Performs common parsing operations: start with a parse action to move the
+        value cursor onto the first character, then call a character handler for each
+        character in the pattern to build up the steps. If any handler fails,
+        that failure is returned - otherwise the return value is null.
+        """
+        pattern_cursor = _PatternCursor(pattern_text)
+
+        while pattern_cursor.move_next():
+            if handler := character_handlers.get(pattern_cursor.current):
+                handler(pattern_cursor, self)
+            else:
+                current = pattern_cursor.current
+                if (
+                    (ord("A") <= ord(current) <= ord("Z"))
+                    or (ord("a") <= ord(current) <= ord("z"))
+                    or current == _PatternCursor._EMBEDDED_PATTERN_START
+                    or current == _PatternCursor._EMBEDDED_PATTERN_END
+                ):
+                    raise InvalidPatternError(TextErrorMessages.UNQUOTED_LITERAL, current)
+
+                def failure(cursor: _ValueCursor) -> ParseResult[TResult]:
+                    return ParseResult._mismatched_character(cursor, current)
+
+                self._add_literal(current, failure)
+
+    def _validate_used_fields(self) -> None:
+        """Validates the combination of fields used."""
+
+        # We assume invalid combinations are global across all parsers. The way that
+        # the patterns are parsed ensures we never end up with any invalid individual fields
+        # (e.g. time fields within a date pattern).
+
+        if (self.__used_fields & (_PatternFields.ERA | _PatternFields.YEAR_OF_ERA)) == _PatternFields.ERA:
+            raise InvalidPatternError(TextErrorMessages.ERA_WITHOUT_YEAR_OF_ERA)
+        calendar_and_era: Final[_PatternFields] = _PatternFields.ERA | _PatternFields.CALENDAR
+        if (self.__used_fields & calendar_and_era) == calendar_and_era:
+            raise InvalidPatternError(TextErrorMessages.CALENDAR_AND_ERA)
+
+    def _build(self, sample: TResult) -> _IPartialPattern[TResult]:
+        """Returns a built pattern.
+
+        This is mostly to keep the API for the builder separate from that of the pattern, and for thread safety
+        (publishing a new object, thus leading to a memory barrier). Note that this builder *must not* be used after the
+        result has been built.
+        """
+        # If we've got an embedded date and any *other* date fields, throw.
+        if self.__used_fields.has_any(_PatternFields.EMBEDDED_DATE) and self._used_fields.has_any(
+            _PatternFields.ALL_DATE_FIELDS & ~_PatternFields.EMBEDDED_DATE
+        ):
+            raise InvalidPatternError(TextErrorMessages.DATE_FIELD_AND_EMBEDDED_DATE)
+        # Ditto for time
+        if self.__used_fields.has_any(_PatternFields.EMBEDDED_TIME) and self._used_fields.has_any(
+            _PatternFields.ALL_TIME_FIELDS & ~_PatternFields.EMBEDDED_TIME
+        ):
+            raise InvalidPatternError(TextErrorMessages.TIME_FIELD_AND_EMBEDDED_TIME)
+
+        delegates = []
+
+        for format_action in self.__format_actions:
+            # TODO: Figure out how to port multicast delegate
+            # TODO: Consider using hasattr() instead of isinstance().
+            #  The python docs say isinstance() is markedly slower with runtime_checkable Protocols.
+            if isinstance(format_action, self._IPostPatternParseFormatAction):
+                delegates.append(format_action.build_format_action(self.__used_fields))
+            else:
+                delegates.append(format_action)
+
+        def multicast_delegate(result: TResult, sb: StringBuilder) -> None:
+            for d in delegates:
+                d(result, sb)
+
+        return self.__SteppedPattern(
+            format_actions=multicast_delegate,
+            parse_actions=None if self.__format_only else self.__parse_actions,
+            bucket_provider=self.__bucket_provider,
+            used_fields=self.__used_fields,
+            sample=sample,
+        )
+
+    def _add_field(self, field: _PatternFields, character_in_pattern: str) -> None:
+        """Registers that a pattern field has been used in this pattern, and throws a suitable error result if it's
+        already been used."""
+        new_used_fields = self.__used_fields | field
+        if new_used_fields == self.__used_fields:
+            raise InvalidPatternError(TextErrorMessages.REPEATED_FIELD_IN_PATTERN, character_in_pattern)
+        self.__used_fields = new_used_fields
+
+    def _add_parse_action(self, parse_action: Callable[[_ValueCursor, TBucket], ParseResult[TResult] | None]) -> None:
+        self.__parse_actions.append(parse_action)
+
+    def _add_format_action(self, format_action: Callable[[TResult, StringBuilder], None]) -> None:
+        self.__format_actions.append(format_action)
+
+    def _add_parse_value_action(
+        self,
+        minimum_digits: int,
+        maximum_digits: int,
+        pattern_char: str,
+        minimum_value: int,
+        maximum_value: int,
+        value_setter: Callable[[TBucket, int], None],
+        type_: type[TResult],
+    ) -> None:
+        def parse_value_action(cursor: _ValueCursor, bucket: TBucket) -> ParseResult[TResult] | None:
+            starting_index = cursor.index
+            negative = cursor._match("-")
+            if negative and minimum_value >= 0:
+                cursor.move(starting_index)
+                return ParseResult[TResult]._unexpected_negative(cursor)
+            success, value = cursor._parse_digits(minimum_digits, maximum_digits)
+            if not success:
+                cursor.move(starting_index)
+                return ParseResult._mismatched_number(cursor, pattern_char * minimum_digits)
+            if negative:
+                value = -value
+            if value < minimum_value or value > maximum_value:
+                cursor.move(starting_index)
+                return ParseResult[TResult]._field_value_out_of_range(cursor, value, pattern_char, type_)
+
+            value_setter(bucket, value)
+            return None
+
+        self._add_parse_action(parse_value_action)
+
+    def _add_literal(self, expected_text: str, failure: Callable[[_ValueCursor], ParseResult[TResult]], /) -> None:
+        """Adds text which must be matched exactly when parsing, and appended directly when formatting."""
+
+        def parse_action(cursor: _ValueCursor, bucket: _ParseBucket[TResult]) -> ParseResult[TResult] | None:
+            if cursor._match(expected_text):
+                return None
+            return failure(cursor)
+
+        def format_action(value: TResult, builder: StringBuilder) -> None:
+            builder.append(expected_text)
+
+        self._add_parse_action(parse_action)
+        self._add_format_action(format_action)
+        return
+
+    @classmethod
+    def _handle_quote(cls, pattern: _PatternCursor, builder: _SteppedPatternBuilder[TResult, TBucket]) -> None:
+        quoted: str = pattern.get_quoted_string(pattern.current)
+        builder._add_literal(quoted, ParseResult[TResult]._quoted_string_mismatch)
+
+    @classmethod
+    def _handle_backslash(cls, pattern: _PatternCursor, builder: _SteppedPatternBuilder[TResult, TBucket]) -> None:
+        if not pattern.move_next():
+            raise InvalidPatternError(TextErrorMessages.ESCAPE_AT_END_OF_STRING)
+
+        current = pattern.current
+
+        def failure(cursor: _ValueCursor) -> ParseResult[TResult]:
+            return ParseResult[TResult]._escaped_character_missmatch(cursor, current)
+
+        builder._add_literal(pattern.current, failure)
+
+    @classmethod
+    def _handle_percent(cls, pattern: _PatternCursor, _builder: _SteppedPatternBuilder[TResult, TBucket]) -> None:
+        """Handle a leading "%" which acts as a pseudo-escape - it's mostly used to allow format strings such as '%H'
+        to mean 'use a custom format string consisting of H instead of a standard pattern H'."""
+        if pattern.has_more_characters:
+            if pattern.peek_next() != "%":
+                # Handle the next character as normal
+                return
+            raise InvalidPatternError(TextErrorMessages.PERCENT_DOUBLED)
+        raise InvalidPatternError(TextErrorMessages.PERCENT_AT_END_OF_STRING)
+
+    @classmethod
+    def _handle_padded_field(
+        cls,
+        max_count: int,
+        field: _PatternFields,
+        min_value: int,
+        max_value: int,
+        getter: Callable[[TResult], int],
+        setter: Callable[[TBucket, int], None],
+        type_: type[TResult],
+    ) -> Callable[[_PatternCursor, _SteppedPatternBuilder[TResult, TBucket]], None]:
+        def handler(pattern: _PatternCursor, builder: _SteppedPatternBuilder[TResult, TBucket]) -> None:
+            count = pattern.get_repeat_count(max_count)
+            builder._add_field(field, pattern.current)
+            builder._add_parse_value_action(count, max_count, pattern.current, min_value, max_value, setter, type_)
+            builder.add_format_left_pad(
+                count, getter, assume_non_negative=(min_value >= 0), assume_fits_in_count=(count == max_count)
+            )
+
+        return handler
+
+    def add_required_sign(
+        self, sign_setter: Callable[[TBucket, bool], None], non_negative_predicate: Callable[[TResult], bool]
+    ) -> None:
+        """Adds parse and format actions for a mandatory positive/negative sign."""
+
+        def parse_action(string: _ValueCursor, bucket: TBucket) -> ParseResult[TResult] | None:
+            if string._match("-"):
+                sign_setter(bucket, False)
+                return None
+
+            if string._match("+"):
+                sign_setter(bucket, True)
+                return None
+
+            return ParseResult[TResult]._missing_sign(string)
+
+        def format_action(value: TResult, sb: StringBuilder) -> None:
+            sb.append("+" if non_negative_predicate(value) else "-")
+
+        self._add_parse_action(parse_action)
+        self._add_format_action(format_action)
+
+    def add_negative_only_sign(
+        self, sign_setter: Callable[[TBucket, bool], None], non_negative_predicate: Callable[[TResult], bool]
+    ) -> None:
+        """Adds parse and format actions for an "negative only" sign."""
+
+        def parse_action(string: _ValueCursor, bucket: TBucket) -> ParseResult[TResult] | None:
+            if string._match("-"):
+                sign_setter(bucket, False)
+                return None
+
+            if string._match("+"):
+                return ParseResult[TResult]._positive_sign_invalid(string)
+
+            sign_setter(bucket, True)
+            return None
+
+        def format_action(value: TResult, sb: StringBuilder) -> None:
+            if not non_negative_predicate(value):
+                sb.append("-")
+
+        self._add_parse_action(parse_action)
+        self._add_format_action(format_action)
+
+    def add_format_left_pad(
+        self, count: int, selector: Callable[[TResult], int], assume_non_negative: bool, assume_fits_in_count: bool
+    ) -> None:
+        """Adds an action to pad a selected value to a given minimum length.
+
+        :param count: The minimum length to pad to
+        :param selector: The selector function to apply to obtain a value to format
+        :param assume_non_negative: Whether it is safe to assume the value will be non-negative
+        :param assume_fits_in_count: Whether it is safe to assume the value will not exceed the specified length
+        """
+        if count == 2 and assume_non_negative and assume_fits_in_count:
+
+            def format_action(value: TResult, sb: StringBuilder) -> None:
+                FormatHelper.format_2_digits_non_negative(selector(value), sb)
+        elif count == 4 and assume_fits_in_count:
+
+            def format_action(value: TResult, sb: StringBuilder) -> None:
+                FormatHelper.format_4_digits_value_fits(selector(value), sb)
+        elif assume_non_negative:
+
+            def format_action(value: TResult, sb: StringBuilder) -> None:
+                FormatHelper.left_pad_non_negative(selector(value), count, sb)
+        else:
+
+            def format_action(value: TResult, sb: StringBuilder) -> None:
+                FormatHelper.left_pad(selector(value), count, sb)
+
+        self._add_format_action(format_action)
+
+    @runtime_checkable
+    class _IPostPatternParseFormatAction(Protocol):
+        """Hack to handle genitive month names.
+
+        We only know what we need to do *after* we've parsed the whole pattern.
+        """
+
+        def build_format_action(self, final_fields: _PatternFields) -> Callable[[TResult, StringBuilder], None]:
+            ...
+
+    class __SteppedPattern(_IPartialPattern[TResult]):
+        def __init__(
+            self,
+            format_actions: Callable[[TResult, StringBuilder], None],
+            parse_actions: list[Callable[[_ValueCursor, TBucket], ParseResult[TResult] | None]] | None,
+            bucket_provider: Callable[[], TBucket],
+            used_fields: _PatternFields,
+            sample: TResult,
+        ) -> None:
+            self.__format_actions: Final[Callable[[TResult, StringBuilder], None]] = format_actions
+            # This will be null if the pattern is only capable of formatting.
+            self.__parse_actions: Final[
+                list[Callable[[_ValueCursor, TBucket], ParseResult[TResult] | None]] | None
+            ] = parse_actions
+            self.__bucket_provider: Final[Callable[[], TBucket]] = bucket_provider
+            self.__used_fields: Final[_PatternFields] = used_fields
+
+            # Format the sample value to work out the expected length, so we
+            # can use that when creating a StringBuilder. This will definitely not always
+            # be appropriate, but it's a start.
+            builder = StringBuilder()
+            format_actions(sample, builder)
+            self.__expected_length: Final[int] = builder.length
+
+        def parse(self, text: str) -> ParseResult[TResult]:
+            if self.__parse_actions is None:
+                return ParseResult[TResult]._format_only_pattern
+            if text is None:
+                return ParseResult[TResult]._argument_null("text")
+            if len(text) == 0:
+                return ParseResult[TResult]._value_string_empty()
+
+            value_cursor = _ValueCursor(text)
+            # Prime the pump... the value cursor ends up *before* the first character, but
+            # our steps always assume it's *on* the right character.
+            value_cursor.move_next()
+            result = self.parse_partial(value_cursor)
+            if not result.success:
+                return result
+            # Check that we've used up all the text
+            if value_cursor.current != _ValueCursor._NUL:
+                return ParseResult[TResult]._extra_value_characters(value_cursor, value_cursor.remainder)
+            return result
+
+        def format(self, value: TResult) -> str:
+            builder = StringBuilder(capacity=self.__expected_length)
+            # This will call all the actions in the multicast delegate.
+            self.__format_actions(value, builder)
+            return builder.to_string()
+
+        def parse_partial(self, cursor: _ValueCursor) -> ParseResult[TResult]:
+            # At the moment we shouldn't get a partial parse for a format-only pattern, but
+            # let's guard against it for the future.
+            if self.__parse_actions is None:
+                return ParseResult[TResult]._format_only_pattern
+
+            bucket = self.__bucket_provider()
+
+            for action in self.__parse_actions:
+                failure: ParseResult[TResult] | None = action(cursor, bucket)
+                if failure is not None:
+                    return failure
+
+            return bucket.calculate_value(self.__used_fields, cursor.value)
+
+        def append_format(self, value: TResult, builder: StringBuilder) -> StringBuilder:
+            _Preconditions._check_not_null(builder, "builder")
+            self.__format_actions(value, builder)
+            return builder

--- a/pyoda_time/time_zones/_fixed_date_time_zone.py
+++ b/pyoda_time/time_zones/_fixed_date_time_zone.py
@@ -47,8 +47,15 @@ class _FixedDateTimeZone(DateTimeZone):
             return None
         if id_ == cls._UTC_ID:
             return cls.utc
-        # TODO: requires OffsetPattern
-        raise NotImplementedError("OffsetPattern is required")
+        from pyoda_time.text import ParseResult
+        from pyoda_time.text._offset_pattern import OffsetPattern
+
+        parse_result: ParseResult[Offset] = OffsetPattern.general_invariant.parse(id_[len(cls._UTC_ID) :])
+        return cls.for_offset(parse_result.value) if parse_result.success else None
+
+    @classmethod
+    def for_offset(cls, offset: Offset) -> DateTimeZone:
+        raise NotImplementedError
 
     def get_zone_interval(self, instant: Instant) -> ZoneInterval:
         return self.__interval

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.12"
+pyicu = "^2.12"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.4.3,<9.0.0"

--- a/tests/calendars/test_islamic_calendar_system.py
+++ b/tests/calendars/test_islamic_calendar_system.py
@@ -278,7 +278,7 @@ class TestIslamicCalendarSystem:
         ids: set[str] = set()
         for leap_year_pattern in IslamicLeapYearPattern:
             for epoch in IslamicEpoch:
-                calendar = CalendarSystem.get_islamic_calendar(leap_year_pattern, epoch)
+                calendar: CalendarSystem = CalendarSystem.get_islamic_calendar(leap_year_pattern, epoch)
                 queue.append(calendar)
                 assert calendar not in set_  # Check we haven't already seen it...
                 set_.add(calendar)
@@ -287,8 +287,8 @@ class TestIslamicCalendarSystem:
         # Now check we get the same references again...
         for leap_year_pattern in IslamicLeapYearPattern:
             for epoch in IslamicEpoch:
-                old_calendar = queue.popleft()
-                new_calendar = CalendarSystem.get_islamic_calendar(leap_year_pattern, epoch)
+                old_calendar: CalendarSystem = queue.popleft()
+                new_calendar: CalendarSystem = CalendarSystem.get_islamic_calendar(leap_year_pattern, epoch)
                 assert new_calendar.id == old_calendar.id
                 assert new_calendar is old_calendar
 

--- a/tests/culture_saver.py
+++ b/tests/culture_saver.py
@@ -9,6 +9,8 @@ from pyoda_time._compatibility._culture_info import CultureInfo
 
 
 class _BothSaver(ContextManager):
+    """A context manager for temporarily changing cultures and which resets the culture on exit."""
+
     @property
     def __current_culture(self) -> CultureInfo:
         return CultureInfo.current_culture
@@ -49,6 +51,19 @@ class _BothSaver(ContextManager):
 
 
 class CultureSaver:
+    """Provides a simple context manager for temporarily setting the culture of a thread.
+
+    Usage::
+
+        with CultureSaver.set_cultures(CultureInfo("en-US")):
+            # code to run under the United States English culture
+    """
+
     @classmethod
     def set_cultures(cls, new_culture_info: CultureInfo) -> ContextManager:
+        """Sets both the UI and basic cultures of the current thread.
+
+        :param new_culture_info: The new culture info.
+        :return: A context manager which temporarily sets the current culture, then resets the culture upon exit.
+        """
         return _BothSaver(new_culture_info, new_culture_info)

--- a/tests/culture_saver.py
+++ b/tests/culture_saver.py
@@ -1,0 +1,54 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from types import TracebackType
+from typing import ContextManager
+
+from pyoda_time._compatibility._culture_info import CultureInfo
+
+
+class _BothSaver(ContextManager):
+    @property
+    def __current_culture(self) -> CultureInfo:
+        return CultureInfo.current_culture
+
+    @__current_culture.setter
+    def __current_culture(self, value: CultureInfo) -> None:
+        CultureInfo.current_culture = value
+
+    @property
+    def __current_ui_culture(self) -> CultureInfo:
+        # TODO: fix or remove this - it's only here for completeness sake
+        return CultureInfo.invariant_culture
+
+    @__current_ui_culture.setter
+    def __current_ui_culture(self, value: CultureInfo) -> None:
+        # TODO: fix or remove this - it's only here for completeness sake
+        CultureInfo.current_culture = value
+
+    def __init__(self, new_culture: CultureInfo, new_ui_culture: CultureInfo) -> None:
+        self.__old_culture = self.__current_culture
+        self.__old_ui_culture = self.__current_ui_culture
+
+        self.__current_culture = new_culture
+        self.__new_ui_culture = new_ui_culture
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(
+        self,
+        __exc_type: type[BaseException] | None,
+        __exc_value: BaseException | None,
+        __traceback: TracebackType | None,
+    ) -> bool | None:
+        self.__current_culture = self.__old_culture
+        self.__new_ui_culture = self.__old_ui_culture
+        return None  # Don't swallow exceptions
+
+
+class CultureSaver:
+    @classmethod
+    def set_cultures(cls, new_culture_info: CultureInfo) -> ContextManager:
+        return _BothSaver(new_culture_info, new_culture_info)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -39,6 +39,8 @@ def test_public_api_does_not_leak_imports(namespace: types.ModuleType) -> None:
         known_submodules = [
             "calendars",
             "fields",
+            "globalization",
+            "text",
             "time_zones",
             "utility",
         ]

--- a/tests/text/__init__.py
+++ b/tests/text/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.

--- a/tests/text/cultures.py
+++ b/tests/text/cultures.py
@@ -37,4 +37,4 @@ class _CulturesMeta(type):
 
 
 class Cultures(metaclass=_CulturesMeta):
-    pass
+    """Cultures to use from various tests."""

--- a/tests/text/cultures.py
+++ b/tests/text/cultures.py
@@ -1,0 +1,40 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Final
+
+from pyoda_time._compatibility._culture_info import CultureInfo
+
+
+class _CulturesMeta(type):
+    __cache: Final[dict[str, CultureInfo]] = {}
+
+    @classmethod
+    def __get_or_create(cls, name: str) -> CultureInfo:
+        """Manages the cache of CultureInfo objects in metaclass properties."""
+        if not (culture_info := cls.__cache.get(name)):
+            culture_info = cls.__cache[name] = CultureInfo(name)
+        return culture_info
+
+    @property
+    def en_us(self) -> CultureInfo:
+        # TODO: CultureInfo.ReadOnly()
+        return self.__get_or_create("en-US")
+
+    @property
+    def fr_fr(self) -> CultureInfo:
+        # TODO: CultureInfo.ReadOnly()
+        return self.__get_or_create(name="fr-FR")
+
+    @property
+    def dot_time_separator(self) -> CultureInfo:
+        # TODO: CultureInfo.ReadOnly()
+        # We don't use this culture for anything other than hosting
+        # the dot time separator, so it should be fine to cache it.
+        ci: CultureInfo = self.__get_or_create("fi-FI")
+        ci.date_time_format.time_separator = "."
+        return ci
+
+
+class Cultures(metaclass=_CulturesMeta):
+    pass

--- a/tests/text/pattern_test_base.py
+++ b/tests/text/pattern_test_base.py
@@ -1,0 +1,45 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from abc import ABC
+from typing import Generic, TypeVar
+
+from pyoda_time.text._i_pattern import IPattern
+
+from .pattern_test_data import PatternTestData
+
+T = TypeVar("T")
+
+
+class PatternTestBase(ABC, Generic[T]):
+    @staticmethod
+    def test_invalid_patterns(invalid_pattern_data: PatternTestData[T]) -> None:
+        if invalid_pattern_data.pattern == "hh":
+            pass
+        invalid_pattern_data.test_invalid_pattern()
+
+    @staticmethod
+    def test_parse_failures(parse_failure_data: PatternTestData[T]) -> None:
+        parse_failure_data.test_parse_failure()
+
+    @staticmethod
+    def test_parse(parse_data: PatternTestData[T]) -> None:
+        parse_data.test_parse()
+
+    @staticmethod
+    def test_format(format_data: PatternTestData[T]) -> None:
+        format_data.test_format()
+
+    @staticmethod
+    def test_append_format(format_data: PatternTestData[T]) -> None:
+        format_data.test_append_format()
+
+    def assert_round_trip(self, value: T, pattern: IPattern[T]) -> None:
+        text = pattern.format(value)
+        parse_result = pattern.parse(text)
+        assert parse_result.value == value, f"{value} != {parse_result.value}"
+
+    def assert_parse_null(self, pattern: IPattern[T]) -> None:
+        result = pattern.parse(None)  # type: ignore
+        assert not result.success
+        assert isinstance(result.exception, ValueError)

--- a/tests/text/pattern_test_data.py
+++ b/tests/text/pattern_test_data.py
@@ -1,0 +1,116 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from abc import abstractmethod
+from typing import Any, Final, Generic, TypeVar
+
+import pytest
+
+from pyoda_time._compatibility._culture_info import CultureInfo
+from pyoda_time._compatibility._string_builder import StringBuilder
+from pyoda_time.text import InvalidPatternError, UnparsableValueError, _ValueCursor
+from pyoda_time.text._i_partial_pattern import _IPartialPattern
+from pyoda_time.text._i_pattern import IPattern
+
+T = TypeVar("T")
+
+
+class PatternTestData(Generic[T]):
+    @property
+    @abstractmethod
+    def default_template(self) -> T:
+        raise NotImplementedError
+
+    def __init__(
+        self,
+        value: T,
+        *,
+        culture: CultureInfo = CultureInfo.invariant_culture,
+        standard_pattern: IPattern[T] | None = None,
+        pattern: str | None = None,
+        text: str | None = None,
+        template: T | None = None,
+        description: str | None = None,
+        message: str | None = None,
+        parameters: list | None = None,
+    ) -> None:
+        self.value: Final[T] = value
+        self.culture: CultureInfo = culture
+        self.standard_pattern: IPattern[T] | None = standard_pattern
+        self.pattern: str | None = pattern
+        self.text: str | None = text
+        self.template: Final[T] = template or self.default_template
+        self.description: str | None = description
+        self.message: str | None = message
+        self.parameters = parameters or []
+
+    @abstractmethod
+    def create_pattern(self) -> IPattern[T]:
+        raise NotImplementedError
+
+    def test_parse(self) -> None:
+        assert self.message is None
+        pattern: IPattern[T] = self.create_pattern()
+        assert self.text is not None, "Must provide `text` for this test!"
+        result = pattern.parse(self.text)
+        actual_value: T = result.value
+        assert self.value == actual_value
+
+        if self.standard_pattern is not None:
+            assert self.value == self.standard_pattern.parse(self.text).value
+
+    def test_format(self) -> None:
+        assert self.message is None
+        pattern: IPattern[T] = self.create_pattern()
+        assert self.text == pattern.format(self.value), f"expected `{self.text}` to be `{self.value}"
+
+        if self.standard_pattern is not None:
+            assert self.text == self.standard_pattern.format(self.value)
+
+    def test_parse_partial(self) -> None:
+        pattern = self.create_partial_pattern()
+        assert self.message is None
+        cursor = _ValueCursor(f"^{self.text}#")
+        # Move to the ^
+        cursor.move_next()
+        # Move to the start of the text
+        cursor.move_next()
+        result = pattern.parse_partial(cursor)
+        actual_value = result.value
+        assert self.value == actual_value
+        assert cursor.current == "#"
+
+    def create_partial_pattern(self) -> _IPartialPattern[T]:
+        raise NotImplementedError("Virtual method - implement in subclasses")
+
+    def test_append_format(self) -> None:
+        assert self.message is None
+        pattern: IPattern[T] = self.create_pattern()
+        builder = StringBuilder("x")
+        pattern.append_format(self.value, builder)
+        assert builder.to_string() == f"x{self.text}"
+
+    def test_invalid_pattern(self) -> None:
+        assert self.message is not None, "Expected `message` to be provided."
+        expected_message: str = self.format_message(self.message, self.parameters)
+        with pytest.raises(InvalidPatternError) as e:
+            self.create_pattern()
+        assert str(e.value) == expected_message
+
+    def test_parse_failure(self) -> None:
+        assert self.message is not None, "Expected `message` to be provided."
+        expected_message: str = self.format_message(self.message, self.parameters)
+        pattern: IPattern[T] = self.create_pattern()
+        assert self.text is not None, "Expected `text` to be provided."
+        result = pattern.parse(self.text)
+        assert not result.success, "Expected parsing to fail, but it succeeded"
+        with pytest.raises(UnparsableValueError) as e:
+            result.get_value_or_throw()
+        assert str(e.value).startswith(
+            expected_message
+        ), f"Expected message to start with {expected_message}; was actually {e.value!s}"
+
+    # TODO: def __repr__() & delete parametrize ids= in tests
+
+    def format_message(self, message: str, parameters: list[Any]) -> str:
+        return message.format(*parameters)

--- a/tests/text/patterns/__init__.py
+++ b/tests/text/patterns/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.

--- a/tests/text/patterns/test_pattern_cursor.py
+++ b/tests/text/patterns/test_pattern_cursor.py
@@ -1,0 +1,141 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import pytest
+
+from pyoda_time.text import InvalidPatternError, _TextCursor
+from pyoda_time.text.patterns import _PatternCursor
+
+from ..text_cursor_test_base import TextCursorTestBase
+
+
+class TestPatternCursor(TextCursorTestBase):
+    def _make_cursor(self, value: str) -> _TextCursor:
+        return _PatternCursor(value)
+
+    @pytest.mark.parametrize(
+        "pattern,expected_error_message",
+        [
+            ("'abc\\", "The format string has an escape character (backslash '\\') at the end of the string."),
+            ("'abc", 'The format string is missing the end quote character "\'".'),
+        ],
+        ids=["Escape at end", "Missing closing quote"],
+    )
+    def test_get_quoted_string_invalid(self, pattern: str, expected_error_message: str) -> None:
+        cursor = _PatternCursor(pattern)
+        assert self._get_next_character(cursor) == "'"
+        with pytest.raises(InvalidPatternError) as e:
+            cursor.get_quoted_string("'")
+        assert str(e.value) == expected_error_message
+
+    @pytest.mark.parametrize(
+        "pattern,expected",
+        [
+            ("'abc'", "abc"),
+            ("''", ""),
+            ("'\"abc\"'", '"abc"'),
+            ("'ab\\c'", "abc"),
+            ("'ab\\'c'", "ab'c"),
+        ],
+        ids=["abc", "''", "Double quotes", "Escaped backslash", "Escaped close quote"],
+    )
+    def test_get_quoted_string_valid(self, pattern: str, expected: str) -> None:
+        cursor = _PatternCursor(pattern)
+        assert self._get_next_character(cursor) == "'"
+        actual = cursor.get_quoted_string("'")
+        assert actual == expected
+        assert not cursor.move_next()
+
+    def test_get_quoted_string_handles_other_quote(self) -> None:
+        cursor = _PatternCursor("[abc]")
+        self._get_next_character(cursor)
+        actual = cursor.get_quoted_string("]")
+        assert actual == "abc"
+        assert not cursor.move_next()
+
+    def test_get_quoted_string_not_at_end(self) -> None:
+        cursor = _PatternCursor("'abc'more")
+        open_quote = self._get_next_character(cursor)
+        actual = cursor.get_quoted_string(open_quote)
+        assert actual == "abc"
+        self._validate_current_character(cursor, 4, "'")
+        assert self._get_next_character(cursor) == "m"
+
+    @pytest.mark.parametrize(
+        "text,expected_count",
+        [
+            ("aaa", 3),
+            ("a", 1),
+            ("aaadaa", 3),
+        ],
+    )
+    def test_get_repeat_count_valid(self, text: str, expected_count: int) -> None:
+        cursor = _PatternCursor(text)
+        assert cursor.move_next()
+        actual = cursor.get_repeat_count(10)
+        assert actual == expected_count
+        self._validate_current_character(cursor, expected_count - 1, "a")
+
+    def test_get_repeat_count_exceeds_max(self) -> None:
+        cursor = _PatternCursor("aaa")
+        assert cursor.move_next()
+        with pytest.raises(InvalidPatternError) as e:
+            cursor.get_repeat_count(2)
+        assert (
+            str(e.value) == "There were more consecutive copies of the pattern character "
+            '"a" than the maximum allowed (2) in the format string.'
+        )
+
+    @pytest.mark.parametrize(
+        "pattern,expected_embedded",
+        [
+            ("x<HH:mm>y", "HH:mm"),
+            ("x<HH:'T'mm>y", "HH:'T'mm"),
+            (r"x<HH:\Tmm>y", r"HH:\Tmm"),
+            ("x<a<b>c>y", "a<b>c"),
+            ("x<a'<'bc>y", "a'<'bc"),
+            ("x<a'>'bc>y", "a'>'bc"),
+            (r"x<a\<bc>y", r"a\<bc"),
+            (r"x<a\>bc>y", r"a\>bc"),
+        ],
+        ids=[
+            "Simple",
+            "Quoting",
+            "Escaping",
+            "Simple nesting",
+            "Quoted start embedded",
+            "Quoted end embedded",
+            "Escaped start embedded",
+            "Escaped end embedded",
+        ],
+    )
+    def test_get_embedded_pattern_valid(self, pattern: str, expected_embedded: str) -> None:
+        cursor = _PatternCursor(pattern)
+        cursor.move_next()
+        embedded: str = cursor.get_embedded_pattern()
+        assert embedded == expected_embedded
+        self._validate_current_character(cursor, len(expected_embedded) + 2, ">")
+
+    @pytest.mark.parametrize(
+        "text,expected_error_message",
+        [
+            ("x(oops)", "The pattern has an embedded pattern which is missing its opening character ('<')."),
+            ("x<oops)", "The pattern has an embedded pattern which is missing its closing character ('>')."),
+            (r"x<oops\>", "The pattern has an embedded pattern which is missing its closing character ('>')."),
+            ("x<oops'>'", "The pattern has an embedded pattern which is missing its closing character ('>')."),
+            ("x<oops<nested>", "The pattern has an embedded pattern which is missing its closing character ('>')."),
+        ],
+        ids=[
+            "Wrong start character",
+            "No end",
+            "Escaped end",
+            "Quoted end",
+            "Incomplete after nesting",
+        ],
+    )
+    def test_get_embedded_pattern_invalid(self, text: str, expected_error_message: str) -> None:
+        cursor = _PatternCursor(text)
+        cursor.move_next()
+        with pytest.raises(InvalidPatternError) as e:
+            cursor.get_embedded_pattern()
+        assert str(e.value) == expected_error_message

--- a/tests/text/patterns/test_pattern_field_extensions.py
+++ b/tests/text/patterns/test_pattern_field_extensions.py
@@ -1,0 +1,37 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+
+from pyoda_time.text.patterns import _PatternFields
+
+
+class TestPatternFieldExtensions:
+    def test_is_used_no_match(self) -> None:
+        assert not (_PatternFields.HOURS_12 | _PatternFields.MINUTES).has_any(_PatternFields.HOURS_24)
+
+    def test_is_used_single_value_match(self) -> None:
+        assert _PatternFields.HOURS_24.has_any(_PatternFields.HOURS_24)
+
+    def test_is_field_used_multi_value_match(self) -> None:
+        assert (_PatternFields.HOURS_24 | _PatternFields.MINUTES).has_any(_PatternFields.HOURS_24)
+
+    def test_is_field_used_no_match(self) -> None:
+        assert not (_PatternFields.HOURS_12 | _PatternFields.MINUTES).has_any(
+            _PatternFields.HOURS_24 | _PatternFields.SECONDS
+        )
+
+    def test_all_are_used_partial_match(self) -> None:
+        assert not (_PatternFields.HOURS_12 | _PatternFields.MINUTES).has_all(
+            _PatternFields.HOURS_12 | _PatternFields.SECONDS
+        )
+
+    def test_all_are_used_complete_match(self) -> None:
+        assert (_PatternFields.HOURS_12 | _PatternFields.MINUTES).has_all(
+            _PatternFields.HOURS_12 | _PatternFields.MINUTES
+        )
+
+    def test_all_are_used_complete_match_with_more(self) -> None:
+        assert (_PatternFields.HOURS_24 | _PatternFields.MINUTES | _PatternFields.HOURS_12).has_all(
+            _PatternFields.HOURS_24 | _PatternFields.MINUTES | _PatternFields.HOURS_12
+        )

--- a/tests/text/patterns/test_stepped_pattern_builder.py
+++ b/tests/text/patterns/test_stepped_pattern_builder.py
@@ -1,0 +1,120 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import cast
+
+import pytest
+
+from pyoda_time import LocalDate, Offset
+from pyoda_time._compatibility._string_builder import StringBuilder
+from pyoda_time.globalization import _PyodaFormatInfo
+from pyoda_time.text import (
+    InvalidPatternError,
+    ParseResult,
+    UnparsableValueError,
+    _ParseBucket,
+    _TextCursor,
+    _ValueCursor,
+)
+from pyoda_time.text._i_partial_pattern import _IPartialPattern
+from pyoda_time.text._offset_pattern_parser import _OffsetPatternParser
+from pyoda_time.text.patterns import _PatternCursor, _PatternFields
+from pyoda_time.text.patterns._stepped_pattern_builder import _SteppedPatternBuilder
+
+
+class SampleBucket(_ParseBucket[LocalDate]):
+    def calculate_value(self, used_fields: _PatternFields, value: str) -> ParseResult[LocalDate]:
+        raise NotImplementedError
+
+
+class TestSteppedPatternBuilder:
+    SIMPLE_OFFSET_PATTERN: _IPartialPattern[Offset] = cast(
+        _IPartialPattern[Offset], _OffsetPatternParser().parse_pattern("HH:mm", _PyodaFormatInfo.invariant_info)
+    )
+
+    def test_parse_partial_valid_in_middle(self) -> None:
+        value = _ValueCursor("x17:30y")
+        value.move_next()
+        value.move_next()
+        # Start already looking at the value to parse
+        assert value.current == "1"
+        result = self.SIMPLE_OFFSET_PATTERN.parse_partial(value)
+        assert result.value == Offset.from_hours_and_minutes(17, 30)
+        # Finish just after the value
+        assert value.current == "y"
+
+    def test_parse_partial_valid_at_end(self) -> None:
+        value = _ValueCursor("x17:30")
+        value.move_next()
+        value.move_next()
+        result = self.SIMPLE_OFFSET_PATTERN.parse_partial(value)
+        assert result.value == Offset.from_hours_and_minutes(17, 30)
+        # Finish just after the value, which in this case is at the end.
+        assert value.current == _TextCursor._NUL
+
+    def test_parse_partial_invalid(self) -> None:
+        value = _ValueCursor("x17:y")
+        value.move_next()
+        value.move_next()
+        result = self.SIMPLE_OFFSET_PATTERN.parse_partial(value)
+        with pytest.raises(UnparsableValueError) as e:
+            result.get_value_or_throw()
+        assert (
+            str(e.value) == 'The value string does not match the required number from the format string "mm". '
+            "Value being parsed: 'x17:^y'. (^ indicates error position.)"
+        )
+
+    def test_format_only_parsing_fails(self) -> None:
+        def format_action(date: LocalDate, sb: StringBuilder) -> None:
+            sb.append("Formatted")
+
+        builder = _SteppedPatternBuilder[LocalDate, SampleBucket](_PyodaFormatInfo.invariant_info, SampleBucket)
+        builder._add_format_action(format_action)
+        builder._set_format_only()
+        pattern = builder._build(LocalDate.min_iso_value)
+
+        value = _ValueCursor("xyz")
+        result = pattern.parse_partial(value)
+        assert result == ParseResult._format_only_pattern
+        result = pattern.parse("xyz")
+        assert result == ParseResult._format_only_pattern
+
+    def test_append_format(self) -> None:
+        builder = StringBuilder("x")
+        offset = Offset.from_hours_and_minutes(17, 30)
+        self.SIMPLE_OFFSET_PATTERN.append_format(offset, builder)
+        assert builder.to_string() == "x17:30"
+
+    @pytest.mark.parametrize(
+        "text,valid",
+        [("aBaB", True), ("aBAB", False), ("<aBaB", False), ("aBaB>", False)],
+        ids=[
+            "Valid",
+            "Case-sensitive",
+            "< is reserved",
+            "> is reserved",
+        ],
+    )
+    def test_unhandled_literal(self, text: str, valid: bool) -> None:
+        def handler(_: _PatternCursor, __: _SteppedPatternBuilder[LocalDate, SampleBucket]) -> None:
+            return None
+
+        handlers = {
+            "a": handler,
+            "B": handler,
+        }
+        builder = _SteppedPatternBuilder[LocalDate, SampleBucket](
+            _PyodaFormatInfo.invariant_info,
+            SampleBucket,
+        )
+        if valid:
+            builder._parse_custom_pattern(text, handlers)
+        else:
+            with pytest.raises(InvalidPatternError) as e:
+                builder._parse_custom_pattern(text, handlers)
+            assert str(e.value).startswith("The character ")
+            assert str(e.value).endswith(
+                "is not a format specifier for this pattern type, and should "
+                "be quoted to act as a literal. Note that each type of pattern "
+                "has its own set of valid format specifiers."
+            )

--- a/tests/text/test_offset_pattern.py
+++ b/tests/text/test_offset_pattern.py
@@ -1,0 +1,391 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from _pytest.mark import ParameterSet
+from culture_saver import CultureSaver
+from helpers import create_negative_offset, create_positive_offset
+
+from pyoda_time import Offset
+from pyoda_time._compatibility._culture_info import CultureInfo
+from pyoda_time.text._i_partial_pattern import _IPartialPattern
+from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.text._offset_pattern import OffsetPattern
+from pyoda_time.text._text_error_messages import TextErrorMessages
+
+from .cultures import Cultures
+from .pattern_test_base import PatternTestBase
+from .pattern_test_data import PatternTestData
+
+
+class Data(PatternTestData[Offset]):
+    @property
+    def default_template(self) -> Offset:
+        return Offset.zero
+
+    def create_pattern(self) -> IPattern[Offset]:
+        assert self.pattern is not None, "Must provide `pattern` for this test"
+        return OffsetPattern.create_with_invariant_culture(self.pattern).with_culture(self.culture)
+
+    def create_partial_pattern(self) -> _IPartialPattern[Offset]:
+        assert self.pattern is not None, "Must provide `pattern` for this test"
+        return OffsetPattern.create_with_invariant_culture(self.pattern).with_culture(self.culture)._underlying_pattern
+
+
+FORMAT_ONLY_DATA = [
+    Data(create_positive_offset(3, 0, 0), culture=Cultures.en_us, text="", pattern="%-"),
+    # Losing information
+    Data(create_positive_offset(5, 6, 7), culture=Cultures.en_us, text="05", pattern="HH"),
+    Data(create_positive_offset(5, 6, 7), culture=Cultures.en_us, text="06", pattern="mm"),
+    Data(create_positive_offset(5, 6, 7), culture=Cultures.en_us, text="07", pattern="ss"),
+    Data(create_positive_offset(5, 6, 7), culture=Cultures.en_us, text="5", pattern="%H"),
+    Data(create_positive_offset(5, 6, 7), culture=Cultures.en_us, text="6", pattern="%m"),
+    Data(create_positive_offset(5, 6, 7), culture=Cultures.en_us, text="7", pattern="%s"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="+18", pattern="g"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="18", pattern="%H"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="0", pattern="%m"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="0", pattern="%s"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="m", pattern="\\m"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="m", pattern="'m'"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="mmmmmmmmmm", pattern="'mmmmmmmmmm'"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="z", pattern="'z'"),
+    Data(Offset.max_value, culture=Cultures.en_us, text="zqw", pattern="'zqw'"),
+    Data(create_negative_offset(3, 0, 0), culture=Cultures.en_us, text="-", pattern="%-"),
+    Data(create_positive_offset(3, 0, 0), culture=Cultures.en_us, text="+", pattern="%+"),
+    Data(create_negative_offset(3, 0, 0), culture=Cultures.en_us, text="-", pattern="%+"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.en_us, text="+05", pattern="s"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.en_us, text="+05:12", pattern="m"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.en_us, text="+05:12:34", pattern="l"),
+]
+
+PARSE_ONLY_DATA = [
+    Data(Offset.zero, culture=Cultures.en_us, text="*", pattern="%*"),
+    Data(Offset.zero, culture=Cultures.en_us, text="zqw", pattern="'zqw'"),
+    Data(Offset.zero, culture=Cultures.en_us, text="-", pattern="%-"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+", pattern="%+"),
+    Data(Offset.zero, culture=Cultures.en_us, text="-", pattern="%+"),
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.en_us, text="+05", pattern="s"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.en_us, text="+05:12", pattern="m"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.en_us, text="+05:12:34", pattern="l"),
+    Data(Offset.zero, pattern="Z+HH:mm", text="+00:00"),  # Lenient when parsing Z-prefixed patterns.
+]
+
+
+INVALID_PATTERN_DATA = [
+    Data(value=Offset.zero, pattern="", message=TextErrorMessages.FORMAT_STRING_EMPTY),
+    Data(value=Offset.zero, pattern="%Z", message=TextErrorMessages.EMPTY_ZPREFIXED_OFFSET_PATTERN),
+    Data(value=Offset.zero, pattern="HH:mmZ", message=TextErrorMessages.ZPREFIX_NOT_AT_START_OF_PATTERN),
+    Data(value=Offset.zero, pattern="%%H", message=TextErrorMessages.PERCENT_DOUBLED),
+    Data(value=Offset.zero, pattern="HH:HH", message=TextErrorMessages.REPEATED_FIELD_IN_PATTERN, parameters=["H"]),
+    Data(value=Offset.zero, pattern="mm:mm", message=TextErrorMessages.REPEATED_FIELD_IN_PATTERN, parameters=["m"]),
+    Data(value=Offset.zero, pattern="ss:ss", message=TextErrorMessages.REPEATED_FIELD_IN_PATTERN, parameters=["s"]),
+    Data(value=Offset.zero, pattern="+HH:-mm", message=TextErrorMessages.REPEATED_FIELD_IN_PATTERN, parameters=["-"]),
+    Data(value=Offset.zero, pattern="-HH:+mm", message=TextErrorMessages.REPEATED_FIELD_IN_PATTERN, parameters=["+"]),
+    Data(
+        value=Offset.zero,
+        pattern="!",
+        message=TextErrorMessages.UNKNOWN_STANDARD_FORMAT,
+        parameters=["!", Offset.__name__],
+    ),
+    Data(
+        value=Offset.zero,
+        pattern="%",
+        message=TextErrorMessages.UNKNOWN_STANDARD_FORMAT,
+        parameters=["%", Offset.__name__],
+    ),
+    Data(value=Offset.zero, pattern="%%", message=TextErrorMessages.PERCENT_DOUBLED),
+    Data(value=Offset.zero, pattern="%\\", message=TextErrorMessages.ESCAPE_AT_END_OF_STRING),
+    Data(
+        value=Offset.zero,
+        pattern="\\",
+        message=TextErrorMessages.UNKNOWN_STANDARD_FORMAT,
+        parameters=["\\", Offset.__name__],
+    ),
+    Data(value=Offset.zero, pattern="H%", message=TextErrorMessages.PERCENT_AT_END_OF_STRING),
+    Data(
+        value=Offset.zero,
+        pattern="hh",
+        message=TextErrorMessages.HOUR12_PATTERN_NOT_SUPPORTED,
+        parameters=[Offset.__name__],
+    ),
+    Data(value=Offset.zero, pattern="HHH", message=TextErrorMessages.REPEAT_COUNT_EXCEEDED, parameters=["H", 2]),
+    Data(value=Offset.zero, pattern="mmm", message=TextErrorMessages.REPEAT_COUNT_EXCEEDED, parameters=["m", 2]),
+    Data(
+        value=Offset.zero,
+        pattern="mmmmmmmmmmmmmmmmmmm",
+        message=TextErrorMessages.REPEAT_COUNT_EXCEEDED,
+        parameters=["m", 2],
+    ),
+    Data(value=Offset.zero, pattern="'qwe", message=TextErrorMessages.MISSING_END_QUOTE, parameters=["'"]),
+    Data(value=Offset.zero, pattern="'qwe\\", message=TextErrorMessages.ESCAPE_AT_END_OF_STRING),
+    Data(value=Offset.zero, pattern="'qwe\\'", message=TextErrorMessages.MISSING_END_QUOTE, parameters=["'"]),
+    Data(value=Offset.zero, pattern="sss", message=TextErrorMessages.REPEAT_COUNT_EXCEEDED, parameters=["s", 2]),
+]
+
+PARSE_FAILURE_DATA = [
+    Data(value=Offset.zero, culture=Cultures.en_us, text="", pattern="g", message=TextErrorMessages.VALUE_STRING_EMPTY),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="1",
+        pattern="HH",
+        message=TextErrorMessages.MISMATCHED_NUMBER,
+        parameters=["HH"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="1",
+        pattern="mm",
+        message=TextErrorMessages.MISMATCHED_NUMBER,
+        parameters=["mm"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="1",
+        pattern="ss",
+        message=TextErrorMessages.MISMATCHED_NUMBER,
+        parameters=["ss"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="12:34 ",
+        pattern="HH:mm",
+        message=TextErrorMessages.EXTRA_VALUE_CHARACTERS,
+        parameters=[" "],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="1a",
+        pattern="H ",
+        message=TextErrorMessages.MISMATCHED_CHARACTER,
+        parameters=[" "],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="2:",
+        pattern="%H",
+        message=TextErrorMessages.EXTRA_VALUE_CHARACTERS,
+        parameters=[":"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="a",
+        pattern="%.",
+        message=TextErrorMessages.MISMATCHED_CHARACTER,
+        parameters=["."],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="a",
+        pattern="%:",
+        message=TextErrorMessages.TIME_SEPARATOR_MISMATCH,
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="a",
+        pattern="%H",
+        message=TextErrorMessages.MISMATCHED_NUMBER,
+        parameters=["H"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="a",
+        pattern="%m",
+        message=TextErrorMessages.MISMATCHED_NUMBER,
+        parameters=["m"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="a",
+        pattern="%s",
+        message=TextErrorMessages.MISMATCHED_NUMBER,
+        parameters=["s"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="a",
+        pattern=".H",
+        message=TextErrorMessages.MISMATCHED_CHARACTER,
+        parameters=["."],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="a",
+        pattern="\\'",
+        message=TextErrorMessages.ESCAPED_CHARACTER_MISMATCH,
+        parameters=["'"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="axc",
+        pattern="'abc'",
+        message=TextErrorMessages.QUOTED_STRING_MISMATCH,
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="z",
+        pattern="%*",
+        message=TextErrorMessages.MISMATCHED_CHARACTER,
+        parameters=["*"],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="24",
+        pattern="HH",
+        message=TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=[24, "H", Offset.__name__],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="60",
+        pattern="mm",
+        message=TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=[60, "m", Offset.__name__],
+    ),
+    Data(
+        value=Offset.zero,
+        culture=Cultures.en_us,
+        text="60",
+        pattern="ss",
+        message=TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=[60, "s", Offset.__name__],
+    ),
+    Data(value=Offset.zero, text="+12", pattern="-HH", message=TextErrorMessages.POSITIVE_SIGN_INVALID),
+]
+
+FORMAT_AND_PARSE_DATA = [
+    Data(Offset.zero, culture=Cultures.en_us, text=".", pattern="%."),  # decimal separator
+    Data(Offset.zero, culture=Cultures.en_us, text=":", pattern="%:"),  # date separator
+    Data(Offset.zero, culture=Cultures.dot_time_separator, text=".", pattern="%."),  # decimal separator (always period)
+    Data(Offset.zero, culture=Cultures.dot_time_separator, text=".", pattern="%:"),  # date separator
+    Data(Offset.zero, culture=Cultures.en_us, text="H", pattern="\\H"),
+    Data(Offset.zero, culture=Cultures.en_us, text="HHss", pattern="'HHss'"),
+    Data(create_positive_offset(0, 0, 12), culture=Cultures.en_us, text="12", pattern="%s"),
+    Data(create_positive_offset(0, 0, 12), culture=Cultures.en_us, text="12", pattern="ss"),
+    Data(create_positive_offset(0, 0, 2), culture=Cultures.en_us, text="2", pattern="%s"),
+    Data(create_positive_offset(0, 12, 0), culture=Cultures.en_us, text="12", pattern="%m"),
+    Data(create_positive_offset(0, 12, 0), culture=Cultures.en_us, text="12", pattern="mm"),
+    Data(create_positive_offset(0, 2, 0), culture=Cultures.en_us, text="2", pattern="%m"),
+    Data(create_positive_offset(12, 0, 0), culture=Cultures.en_us, text="12", pattern="%H"),
+    Data(create_positive_offset(12, 0, 0), culture=Cultures.en_us, text="12", pattern="HH"),
+    Data(create_positive_offset(2, 0, 0), culture=Cultures.en_us, text="2", pattern="%H"),
+    # Standard patterns with punctuation...
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.en_us, text="+05", pattern="G"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.en_us, text="+05:12", pattern="G"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.en_us, text="+05:12:34", pattern="G"),
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.en_us, text="+05", pattern="g"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.en_us, text="+05:12", pattern="g"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.en_us, text="+05:12:34", pattern="g"),
+    Data(Offset.min_value, culture=Cultures.en_us, text="-18", pattern="g"),
+    Data(Offset.zero, culture=Cultures.en_us, text="Z", pattern="G"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+00", pattern="g"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+00", pattern="s"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+00:00", pattern="m"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+00:00:00", pattern="l"),
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.fr_fr, text="+05", pattern="g"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.fr_fr, text="+05:12", pattern="g"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.fr_fr, text="+05:12:34", pattern="g"),
+    Data(Offset.max_value, culture=Cultures.fr_fr, text="+18", pattern="g"),
+    Data(Offset.min_value, culture=Cultures.fr_fr, text="-18", pattern="g"),
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.dot_time_separator, text="+05", pattern="g"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.dot_time_separator, text="+05.12", pattern="g"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.dot_time_separator, text="+05.12.34", pattern="g"),
+    Data(Offset.max_value, culture=Cultures.dot_time_separator, text="+18", pattern="g"),
+    Data(Offset.min_value, culture=Cultures.dot_time_separator, text="-18", pattern="g"),
+    # Standard patterns without punctuation
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.en_us, text="+05", pattern="I"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.en_us, text="+0512", pattern="I"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.en_us, text="+051234", pattern="I"),
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.en_us, text="+05", pattern="i"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.en_us, text="+0512", pattern="i"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.en_us, text="+051234", pattern="i"),
+    Data(Offset.min_value, culture=Cultures.en_us, text="-18", pattern="i"),
+    Data(Offset.zero, culture=Cultures.en_us, text="Z", pattern="I"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+00", pattern="i"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+00", pattern="S"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+0000", pattern="M"),
+    Data(Offset.zero, culture=Cultures.en_us, text="+000000", pattern="L"),
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.fr_fr, text="+05", pattern="i"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.fr_fr, text="+0512", pattern="i"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.fr_fr, text="+051234", pattern="i"),
+    Data(Offset.max_value, culture=Cultures.fr_fr, text="+18", pattern="i"),
+    Data(Offset.min_value, culture=Cultures.fr_fr, text="-18", pattern="i"),
+    Data(create_positive_offset(5, 0, 0), culture=Cultures.dot_time_separator, text="+05", pattern="i"),
+    Data(create_positive_offset(5, 12, 0), culture=Cultures.dot_time_separator, text="+0512", pattern="i"),
+    Data(create_positive_offset(5, 12, 34), culture=Cultures.dot_time_separator, text="+051234", pattern="i"),
+    Data(Offset.max_value, culture=Cultures.dot_time_separator, text="+18", pattern="i"),
+    Data(Offset.min_value, culture=Cultures.dot_time_separator, text="-18", pattern="i"),
+    # Explicit patterns
+    Data(create_negative_offset(0, 30, 0), culture=Cultures.en_us, text="-00:30", pattern="+HH:mm"),
+    Data(create_negative_offset(0, 30, 0), culture=Cultures.en_us, text="-00:30", pattern="-HH:mm"),
+    Data(create_positive_offset(0, 30, 0), culture=Cultures.en_us, text="00:30", pattern="-HH:mm"),
+    # Z-prefixes
+    Data(Offset.zero, text="Z", pattern="Z+HH:mm:ss"),
+    Data(create_positive_offset(5, 12, 34), text="+05:12:34", pattern="Z+HH:mm:ss"),
+    Data(create_positive_offset(5, 12, 0), text="+05:12", pattern="Z+HH:mm"),
+]
+
+PARSE_DATA = PARSE_ONLY_DATA + FORMAT_AND_PARSE_DATA
+FORMAT_DATA = FORMAT_ONLY_DATA + FORMAT_AND_PARSE_DATA
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=}") for data in INVALID_PATTERN_DATA])
+def invalid_pattern_data(request: FixtureRequest) -> ParameterSet:
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=}") for data in PARSE_FAILURE_DATA])
+def parse_failure_data(request: FixtureRequest) -> ParameterSet:
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=}") for data in PARSE_DATA])
+def parse_data(request: FixtureRequest) -> ParameterSet:
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=} {data.culture=}") for data in FORMAT_DATA])
+def format_data(request: FixtureRequest) -> ParameterSet:
+    return request.param
+
+
+class TestOffsetPattern(PatternTestBase[Offset]):
+    @pytest.mark.parametrize("data", PARSE_DATA)
+    def test_parse_partial(self, data: PatternTestData[Offset]) -> None:
+        data.test_parse_partial()
+
+    def test_parse_null(self) -> None:
+        self.assert_parse_null(OffsetPattern.general_invariant)
+
+    def test_number_format_ignored(self) -> None:
+        culture: CultureInfo = Cultures.en_us.clone()
+        culture.number_format.positive_sign = "P"
+        culture.number_format.negative_sign = "N"
+        pattern = OffsetPattern.create("+HH:mm", culture)
+
+        assert pattern.format(Offset.from_hours(5)) == "+05:00"
+        assert pattern.format(Offset.from_hours(-5)) == "-05:00"
+
+    def test_create_with_current_culture(self) -> None:
+        with CultureSaver.set_cultures(Cultures.dot_time_separator):
+            pattern = OffsetPattern.create_with_current_culture("H:mm")
+            text = pattern.format(Offset.from_hours_and_minutes(1, 30))
+            assert text == "1.30"

--- a/tests/text/test_offset_pattern.py
+++ b/tests/text/test_offset_pattern.py
@@ -5,8 +5,6 @@
 import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.mark import ParameterSet
-from culture_saver import CultureSaver
-from helpers import create_negative_offset, create_positive_offset
 
 from pyoda_time import Offset
 from pyoda_time._compatibility._culture_info import CultureInfo
@@ -15,6 +13,8 @@ from pyoda_time.text._i_pattern import IPattern
 from pyoda_time.text._offset_pattern import OffsetPattern
 from pyoda_time.text._text_error_messages import TextErrorMessages
 
+from ..culture_saver import CultureSaver
+from ..helpers import create_negative_offset, create_positive_offset
 from .cultures import Cultures
 from .pattern_test_base import PatternTestBase
 from .pattern_test_data import PatternTestData

--- a/tests/text/test_parse_result.py
+++ b/tests/text/test_parse_result.py
@@ -1,0 +1,79 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+import pytest
+
+from pyoda_time.text import ParseResult, UnparsableValueError, _ValueCursor
+
+
+class TestParseResult:
+    FAILURE_RESULT = ParseResult[int]._for_invalid_value(_ValueCursor("text"), "text")
+
+    def test_value_success(self) -> None:
+        result = ParseResult.for_value(5)
+        assert result.value == 5
+
+    def test_value_failure(self) -> None:
+        with pytest.raises(UnparsableValueError) as e:
+            _ = self.FAILURE_RESULT.value
+
+        assert str(e.value) == "text Value being parsed: '^text'. (^ indicates error position.)"
+
+    def test_exception_success(self) -> None:
+        result: ParseResult[int] = ParseResult.for_value(5)
+        with pytest.raises(RuntimeError) as e:
+            _ = result.exception
+        assert str(e.value) == "Parse operation succeeded, so no exception is available"
+
+    def test_exception_failure(self) -> None:
+        assert isinstance(self.FAILURE_RESULT.exception, UnparsableValueError)
+
+    def test_get_value_or_throw_success(self) -> None:
+        result: ParseResult[int] = ParseResult.for_value(5)
+        assert result.get_value_or_throw() == 5
+
+    def test_get_value_or_throw_failure(self) -> None:
+        with pytest.raises(UnparsableValueError) as e:
+            self.FAILURE_RESULT.get_value_or_throw()
+        assert str(e.value) == "text Value being parsed: '^text'. (^ indicates error position.)"
+
+    def test_try_get_value_success(self) -> None:
+        result: ParseResult[int] = ParseResult.for_value(5)
+        success, actual = result.try_get_value(5)
+        assert success
+        assert actual == 5
+
+    def test_try_get_value_failure(self) -> None:
+        success, actual = self.FAILURE_RESULT.try_get_value(-1)
+        assert not success
+        assert actual == -1
+
+    def test_convert_for_failure_result(self) -> None:
+        converted: ParseResult[str] = self.FAILURE_RESULT.convert(lambda x: f"xx{x}xx")
+        with pytest.raises(UnparsableValueError) as e:
+            converted.get_value_or_throw()
+        assert str(e.value) == "text Value being parsed: '^text'. (^ indicates error position.)"
+
+    def test_convert_for_success_result(self) -> None:
+        original = ParseResult[int].for_value(10)
+        converted = original.convert(lambda x: f"xx{x}xx")
+        assert converted.value == "xx10xx"
+
+    def test_convert_error_for_failure_result(self) -> None:
+        converted: ParseResult[str] = self.FAILURE_RESULT.convert_error(str)
+        with pytest.raises(UnparsableValueError) as e:
+            converted.get_value_or_throw()
+        assert str(e.value) == "text Value being parsed: '^text'. (^ indicates error position.)"
+
+    def test_convert_error_for_success_result(self) -> None:
+        original: ParseResult[int] = ParseResult[int].for_value(10)
+        with pytest.raises(RuntimeError) as e:
+            original.convert_error(str)
+        assert str(e.value) == "convert_error should not be called on a successful parse result"
+
+    def test_for_exception(self) -> None:
+        e = Exception()
+        result: ParseResult[int] = ParseResult[int].for_exception(lambda: e)
+        assert not result.success
+        assert result.exception is e

--- a/tests/text/test_value_cursor.py
+++ b/tests/text/test_value_cursor.py
@@ -1,0 +1,288 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+import pytest
+
+from pyoda_time.text import UnparsableValueError, _TextCursor, _ValueCursor
+from pyoda_time.utility import _CsharpConstants
+
+from .text_cursor_test_base import TextCursorTestBase
+
+
+class TestValueCursor(TextCursorTestBase):
+    def _make_cursor(self, value: str) -> _TextCursor:
+        return _ValueCursor(value)
+
+    def test_match_char(self) -> None:
+        value = _ValueCursor("abc")
+        assert value.move_next()
+        assert value._match("a")
+        assert value._match("b")
+        assert value._match("c")
+        assert not value.move_next()
+
+    def test_match_string_not_matched(self) -> None:
+        value = _ValueCursor("xabcdef")
+        assert value.move_next()
+        assert not value._match("abc")
+        self._validate_current_character(value, 0, "x")
+
+    def test_match_string_over_long_string_to_match(self) -> None:
+        value = _ValueCursor("x")
+        assert value.move_next()
+        assert not value._match("long string")
+        self._validate_current_character(value, 0, "x")
+
+    def test_match_case_insensitive_match_and_move(self) -> None:
+        value = _ValueCursor("abcd")
+        assert value.move_next()
+        assert value._match_case_insensitive("AbC", True)
+        self._validate_current_character(value, 3, "d")
+
+    def test_match_case_insensitive_match_without_moving(self) -> None:
+        value = _ValueCursor("abcd")
+        assert value.move_next()
+        assert value._match_case_insensitive("AbC", False)
+        self._validate_current_character(value, 0, "a")
+
+    def test_match_case_insensitive_string_not_matched(self) -> None:
+        value = _ValueCursor("xabcdef")
+        assert value.move_next()
+        assert not value._match_case_insensitive("abc", True)
+        self._validate_current_character(value, 0, "x")
+
+    def test_match_case_insensitive_string_over_long_string_to_match(self) -> None:
+        value = _ValueCursor("x")
+        assert value.move_next()
+        assert not value._match_case_insensitive("long string", True)
+        self._validate_current_character(value, 0, "x")
+
+    def test_match_string_partial(self) -> None:
+        value = _ValueCursor("abcdef")
+        assert value.move_next()
+        assert value._match("abc")
+        self._validate_current_character(value, 3, "d")
+
+    def test_parse_digits_too_few_digits(self) -> None:
+        value = _ValueCursor("a12b")
+        assert value.move_next()
+        self._validate_current_character(value, 0, "a")
+        assert value.move_next()
+        success, result = value._parse_digits(3, 3)
+        assert not success
+        self._validate_current_character(value, 1, "1")
+
+    def test_parse_digits_no_number(self) -> None:
+        value = _ValueCursor("abc")
+        assert value.move_next()
+        success, _ = value._parse_digits(1, 2)
+        assert not success
+        self._validate_current_character(value, 0, "a")
+
+    def test_parse_digits_maximum(self) -> None:
+        value = _ValueCursor("12")
+        assert value.move_next()
+        success, actual = value._parse_digits(1, 2)
+        assert success
+        assert actual == 12
+        self._validate_end_of_string(value)
+
+    def test_parse_digits_maximum_more_digits(self) -> None:
+        value = _ValueCursor("1234")
+        assert value.move_next()
+        success, actual = value._parse_digits(1, 2)
+        assert success
+        assert actual == 12
+        self._validate_current_character(value, 2, "3")
+
+    def test_parse_digits_minimum(self) -> None:
+        value = _ValueCursor("1")
+        value.move_next()
+        success, actual = value._parse_digits(1, 2)
+        assert success
+        assert actual == 1
+        self._validate_end_of_string(value)
+
+    def test_parse_digits_minimum_non_digits(self) -> None:
+        value = _ValueCursor("1abc")
+        value.move_next()
+        success, actual = value._parse_digits(1, 2)
+        assert success
+        assert actual == 1
+        self._validate_current_character(value, 1, "a")
+
+    @pytest.mark.xfail(reason="Unlike in Noda Time, this works...")
+    def test_parse_digits_non_ascii_never_matches(self) -> None:
+        # Arabic-Indic digits 0 and 1. See
+        # https://www.unicode.org/charts/PDF/U0600.pdf
+        value = _ValueCursor("\u0660\u0661")
+        value.move_next()
+        success, actual = value._parse_digits(1, 2)
+        assert not success
+        assert actual == 1
+        self._validate_current_character(value, 1, "a")
+
+    # TODO: There are a bunch of ParseInt64Digits() tests here (as distinct from ParseDigits() tests).
+    #  But in Pyoda Time, we only have parse_digits(), because there is only int.
+    #  I've omitted most of those as they basically port to duplicate tests.
+
+    def test_parse_int64_digits_large_number(self) -> None:
+        value = _ValueCursor("9999999999999")
+        assert value.move_next()
+        success, actual = value._parse_digits(1, 13)
+        assert success
+        assert actual == 9999999999999
+
+    def test_parse_fraction_non_ascii_never_matches(self) -> None:
+        # Arabic-Indic digits 0 and 1. See
+        # https://www.unicode.org/charts/PDF/U0600.pdf
+        value = _ValueCursor("\u0660\u0661")
+        value.move_next()
+        success, actual = value._parse_fraction(2, 2, 2)
+        assert not success
+
+    def test_parse_int64_simple(self) -> None:
+        value = _ValueCursor("56x")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is None
+        assert int64 == 56
+
+    def test_parse_int64_negative(self) -> None:
+        value = _ValueCursor("-56x")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is None
+        assert int64 == -56
+
+    def test_parse_int64_non_number(self) -> None:
+        value = _ValueCursor("xyz")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is not None
+        # Cursor has not moved
+        assert value.index == 0
+        assert int64 == 0
+
+    def test_parse_int64_double_negative_sign(self) -> None:
+        value = _ValueCursor("--10xyz")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is not None
+        # Cursor has not moved
+        assert value.index == 0
+        assert int64 == 0
+
+    def test_parse_int64_negative_then_non_digit(self) -> None:
+        value = _ValueCursor("-x")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is not None
+        # Cursor has not moved
+        assert value.index == 0
+        assert int64 == 0
+
+    def test_parse_int64_number_out_of_range_low_leading_digits(self) -> None:
+        value = _ValueCursor("1000000000000000000000000")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is not None
+        # Cursor has not moved
+        assert value.index == 0
+        assert int64 == 1000000000000000000
+
+    def test_parse_int64_number_out_of_range_high_leading_digits(self) -> None:
+        value = _ValueCursor("999999999999999999999999")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is not None
+        # Cursor has not moved
+        assert value.index == 0
+        assert int64 == 999999999999999999
+
+    def test_parse_int64_number_out_of_range_max_value_leading_digits(self) -> None:
+        value = _ValueCursor("9223372036854775808")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is not None
+        # Cursor has not moved
+        assert value.index == 0
+        assert int64 == 922337203685477580
+
+    def test_parse_int64_number_out_of_range_min_value_leading_digits(self) -> None:
+        value = _ValueCursor("-9223372036854775809")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is not None
+        # Cursor has not moved
+        assert value.index == 0
+        assert int64 == 922337203685477580
+
+    def test_parse_int64_max_value(self) -> None:
+        value = _ValueCursor("9223372036854775807")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is None
+        assert int64 == _CsharpConstants.LONG_MAX_VALUE
+
+    def test_parse_int64_min_value(self) -> None:
+        value = _ValueCursor("-9223372036854775808")
+        assert value.move_next()
+        parse_result, int64 = value._parse_int64()
+        if parse_result:
+            raise parse_result.exception
+        assert parse_result is None
+        assert int64 == _CsharpConstants.LONG_MIN_VALUE
+
+    def test_compare_ordinal_exact_match_to_end_of_value(self) -> None:
+        value = _ValueCursor("xabc")
+        value.move(1)
+        assert value._compare_ordinal("abc") == 0
+        assert value.index == 1  # Cursor hasn't moved
+
+    def test_compare_ordinal_exact_match_value_continues(self) -> None:
+        value = _ValueCursor("xabc")
+        value.move(1)
+        assert value._compare_ordinal("ab") == 0
+        assert value.index == 1  # Cursor hasn't moved
+
+    def test_compare_ordinal_value_is_earlier(self) -> None:
+        value = _ValueCursor("xabc")
+        value.move(1)
+        assert value._compare_ordinal("mm") < 0
+        assert value.index == 1  # Cursor hasn't moved
+
+    def test_compare_ordinal_value_is_later(self) -> None:
+        value = _ValueCursor("xabc")
+        value.move(1)
+        assert value._compare_ordinal("aa") > 0
+        assert value.index == 1  # Cursor hasn't moved
+
+    def test_compare_ordinal_long_match_equal_to_end(self) -> None:
+        value = _ValueCursor("xabc")
+        value.move(1)
+        assert value._compare_ordinal("abcd") < 0
+        assert value.index == 1  # Cursor hasn't moved
+
+    def test_compare_ordinal_long_match_value_is_earlier(self) -> None:
+        value = _ValueCursor("xabc")
+        value.move(1)
+        assert value._compare_ordinal("cccc") < 0
+        assert value.index == 1  # Cursor hasn't moved
+
+    def test_compare_ordinal_long_match_value_is_later(self) -> None:
+        value = _ValueCursor("xabc")
+        value.move(1)
+        assert value._compare_ordinal("aaaa") > 0
+        assert value.index == 1  # Cursor hasn't moved
+
+    def test_parse_int64_too_many_digits(self) -> None:
+        # We can cope as far as 9223372036854775807, but the trailing 1 causes a failure.
+        value = _ValueCursor("92233720368547758071")
+        value.move(0)
+        parse_result, int64 = value._parse_int64()
+        assert parse_result is not None  # for mypy purposes
+        assert not parse_result.success
+        assert isinstance(parse_result.exception, UnparsableValueError)
+        assert value.index == 0  # Cursor hasn't moved

--- a/tests/text/text_cursor_test_base.py
+++ b/tests/text/text_cursor_test_base.py
@@ -1,0 +1,85 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from abc import ABC, abstractmethod
+
+from pyoda_time.text import _TextCursor
+
+
+class TextCursorTestBase(ABC):
+    def test_constructor(self) -> None:
+        test_string = "test"
+        cursor: _TextCursor = self._make_cursor(test_string)
+        self._validate_contents(cursor, test_string)
+        self._validate_beginning_of_string(cursor)
+
+    def test_move(self) -> None:
+        cursor: _TextCursor = self._make_cursor("test")
+        self._validate_beginning_of_string(cursor)
+        assert cursor.move(0)
+        self._validate_current_character(cursor, 0, "t")
+        assert cursor.move(1)
+        self._validate_current_character(cursor, 1, "e")
+        assert cursor.move(2)
+        self._validate_current_character(cursor, 2, "s")
+        assert cursor.move(3)
+        self._validate_current_character(cursor, 3, "t")
+        assert not cursor.move(4)
+        self._validate_end_of_string(cursor)
+
+    def test_move_next_previous(self) -> None:
+        cursor: _TextCursor = self._make_cursor("test")
+        self._validate_beginning_of_string(cursor)
+        assert cursor.move(2), "move(2)"
+        self._validate_current_character(cursor, 2, "s")
+        assert cursor.move_previous(), "move_previous()"
+        self._validate_current_character(cursor, 1, "e")
+        assert cursor.move_next(), "move_next()"
+        self._validate_current_character(cursor, 2, "s")
+        assert cursor.move_previous(), "move_previous()"  # 1
+        assert cursor.move_previous(), "move_previous()"  # 0
+        assert not cursor.move_previous()
+        self._validate_current_character(cursor, -1, "\0")
+        assert not cursor.move_previous()
+        self._validate_current_character(cursor, -1, "\0")
+
+    def test_move_invalid(self) -> None:
+        cursor: _TextCursor = self._make_cursor("test")
+        self._validate_beginning_of_string(cursor)
+        assert not cursor.move(-1000)
+        self._validate_beginning_of_string(cursor)
+        assert not cursor.move(1000)
+        self._validate_end_of_string(cursor)
+        assert not cursor.move(-1000)
+        self._validate_beginning_of_string(cursor)
+
+    def _get_next_character(self, cursor: _TextCursor) -> str:
+        assert cursor.move_next()
+        return cursor.current
+
+    @classmethod
+    def _validate_beginning_of_string(cls, cursor: _TextCursor) -> None:
+        cls._validate_current_character(cursor, -1, _TextCursor._NUL)
+
+    @staticmethod
+    def _validate_current_character(
+        cursor: _TextCursor, expected_current_index: int, expected_current_character: str
+    ) -> None:
+        assert cursor.current == expected_current_character
+        assert cursor.index == expected_current_index
+
+    @classmethod
+    def _validate_end_of_string(cls, cursor: _TextCursor) -> None:
+        cls._validate_current_character(cursor, cursor.length, _TextCursor._NUL)
+
+    @staticmethod
+    def _validate_contents(cursor: _TextCursor, value: str, length: int = -1) -> None:
+        if length < 0:
+            length = len(value)
+        assert cursor.value == value, "cursor value mismatch"
+        assert cursor.length == length, "cursor length mismatch"
+
+    @abstractmethod
+    def _make_cursor(self, value: str) -> _TextCursor:
+        raise NotImplementedError


### PR DESCRIPTION
This PR introduces a complete port of OffsetPattern from Noda Time to Pyoda Time, including all supporting tests and the foundational pattern parsing/formatting logic. It marks a significant step towards achieving full functionality parity with Noda Time.

Highlights:
- Successfully ported OffsetPattern and integrated fundamental pattern logic.
- The necessity of implementing a CultureInfo equivalent emerged as a crucial step for an accurate port.
- Developed a preliminary version of CultureInfo in Python, leveraging PyICU for locale management.
- Encountered and overcame complexities related to System.Globalization.CultureInfo in .NET, necessitating an exploration of the dotnet framework's source code and the integration of ICU data.

Take-aways:
- Continue porting other Patterns, expected to be more straightforward with the groundwork laid.
- (Long Term:) While a `CultureInfo` equivalent is necessary for the initial, faithful port of Noda Time, subsequent iterations of this codebase will likely shift towards being more idiosyncratic to the language in which they are written. Start considering whether it is helpful to have an equivalent to `CultureInfo` which is more commonly associate with dotnet embedded within this library, or whether something else might feel more natural.