### PR TITLE
docs: add readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Based on https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
+
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.12"
+  jobs:
+    post_create_environment:
+      - pip install poetry
+    post_install:
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Adds configuration for readthedocs.org.

I won't know if this works before it is merged - it may well need to be revisited.