### PR TITLE
docs: set custom domain as canonical url in sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,13 @@ exclude_patterns: list[str] = []
 
 # Options for HTML output
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_baseurl = "https://pyodatime.org/"
+
+html_context = {
+    "canonical_url": "https://pyodatime.org/",
+}
+
 html_static_path = ["_static"]
 
 html_favicon = "_static/favicon.ico"


### PR DESCRIPTION
Sets the canonical url to https://pyodatime.org/ in sphinx.

This is also configured in readthedocs.

(Note: first PR with readthedocs preview!)