### PR TITLE
feat: Implement `PyodaFormatInfo`

### DIFF
--- a/pyoda_time/_compatibility/_calendar.py
+++ b/pyoda_time/_compatibility/_calendar.py
@@ -1,6 +1,10 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+import copy
 from abc import ABC
 
 from pyoda_time._compatibility._calendar_id import _CalendarId
@@ -9,6 +13,28 @@ from pyoda_time._compatibility._calendar_id import _CalendarId
 class Calendar(ABC):  # TODO: ICloneable
     """A bare-bones equivalent to the ``System.Globalization.Calendar`` abstract class in .NET."""
 
+    def __init__(self) -> None:
+        self.__is_read_only: bool = False
+
     @property
     def _id(self) -> _CalendarId:
         return _CalendarId.UNINITIALIZED_VALUE
+
+    @property
+    def is_read_only(self) -> bool:
+        """Gets a value indicating whether this ``Calendar`` is read-only."""
+        return self.__is_read_only
+
+    @staticmethod
+    def read_only(calendar: Calendar) -> Calendar:
+        """Returns a read-only version of the specified ``Calendar``."""
+        if calendar is None:
+            raise ValueError("Calendar must not be None.")
+        if calendar.is_read_only:
+            return calendar
+        calendar_1: Calendar = copy.copy(calendar)
+        calendar_1._set_read_only_state(True)
+        return calendar_1
+
+    def _set_read_only_state(self, read_only: bool) -> None:
+        self.__is_read_only = read_only

--- a/pyoda_time/_compatibility/_calendar_data.py
+++ b/pyoda_time/_compatibility/_calendar_data.py
@@ -1,0 +1,400 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Sequence, cast, final
+
+from icu import DateFormat, DateFormatSymbols, DateTimePatternGenerator, Locale
+
+from pyoda_time._compatibility._calendar_id import _CalendarId
+from pyoda_time._compatibility._globalization_mode import _GlobalizationMode
+from pyoda_time._compatibility._string_builder import StringBuilder
+from pyoda_time.utility import _sealed
+
+
+class _CalendarDataType(IntEnum):
+    UNINITIALIZED = 0
+    NATIVE_NAME = 1
+    MONTH_DAY = 2
+    SHORT_DATES = 3
+    LONG_DATES = 4
+    YEAR_MONTHS = 5
+    DAY_NAMES = 6
+    ABBREV_DAY_NAMES = 7
+    MONTH_NAMES = 8
+    ABBREV_MONTH_NAMES = 9
+    SUPER_SHORT_DAY_NAMES = 10
+    MONTH_GENITIVE_NAMES = 11
+    ABBREV_MONTH_GENITIVE_NAMES = 12
+    ERA_NAMES = 13
+    ABBREV_ERA_NAMES = 14
+
+
+@dataclass
+class _IcuEnumCalendarsData:
+    results: list[str] = field(default_factory=list)
+    disallow_duplicates: bool = False
+
+
+class _CalendarDataMeta(type):
+    @property
+    def _invariant(self) -> _CalendarData:
+        raise NotImplementedError
+
+
+@_sealed
+@final
+class _CalendarData(metaclass=_CalendarDataMeta):
+    def __init__(self, locale_name: str, calendar_id: _CalendarId, bUseUserOverrides: bool) -> None:
+        self._bUseUserOverrides = bUseUserOverrides
+
+        # In C# these private fields are all defined outside of the constructor.
+        # But this is Python, so...
+        self._sNativeName: str | None = None
+        self._saShortDates: Sequence[str] | None = None
+        self._saYearMonths: Sequence[str] | None = None
+        self._saLongDates: Sequence[str] | None = None
+        self._sMonthDay: str | None = None
+        self._saEraNames: list[str] = []
+        self._saAbbrevEraNames: Sequence[str] | None = None
+        self._saAbbrevEnglishEraNames: Sequence[str] | None = None
+        self._saDayNames: Sequence[str] | None = None
+        self._saAbbrevDayNames: Sequence[str] | None = None
+        self._saSuperShortDayNames: Sequence[str] | None = None
+        self._saMonthNames: Sequence[str] | None = None
+        self._saAbbrevMonthNames: Sequence[str] | None = None
+        self._saMonthGenitiveNames: Sequence[str] | None = None
+        self._saAbbrevMonthGenitiveNames: Sequence[str] | None = None
+        self._saLeapYearMonthNames: Sequence[str] | None = None
+        self._iTwoDigitYearMax: int = 2029
+        self.__iCurrentEra: int = 0
+        self._iCurrentEra: int = 0
+
+        if not self.__load_calendar_data_from_system_core(locale_name, calendar_id):
+            raise NotImplementedError()
+
+        self.__initialize_era_names(locale_name, calendar_id)
+
+        # TODO: There is a whole lot left to implement here
+
+    def __icu_load_calendar_data_from_system(self, locale_name: str, calendar_id: _CalendarId) -> bool:
+        # TODO: This needs a bunch more work, and is very different to .NET
+
+        assert not _GlobalizationMode._use_nls
+
+        locale: Locale = Locale(locale_name)
+        datetime_pattern_generator: DateTimePatternGenerator = DateTimePatternGenerator.createInstance(locale)
+        date_format_symbols: DateFormatSymbols = DateFormatSymbols(locale)
+
+        self._sNativeName = calendar_id.to_icu_calendar_name()
+        self._sMonthDay = datetime_pattern_generator.getBestPattern("MMMMd")
+
+        if self._sMonthDay:
+            self._sMonthDay = self.__normalize_date_pattern(self._sMonthDay)
+
+        # .NET builds up a string array of three short date patterns:
+        #
+        # - ICU's "kShort" pattern
+        # - ICU's "kMedium" pattern
+        # - A specific skeleton ("yMd"), which closely matches what is used on Windows.
+        #
+        # Source at:
+        # https://github.com/dotnet/runtime/blob/b181ed507c07bdcfb84e2a2b4786d3c2c763db8c/src/native/libs/System.Globalization.Native/pal_calendarData.c#L494-L499
+        #
+        # See also (specifically, how it disallows duplicates):
+        # https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Icu.cs,99c4abaab8c2bae5,references
+        patterns = []
+        for pattern in [
+            DateFormat.createDateInstance(DateFormat.kShort, locale).toPattern(),
+            DateFormat.createDateInstance(DateFormat.kMedium, locale).toPattern(),
+            datetime_pattern_generator.getBestPattern("yMd"),
+        ]:
+            if pattern not in patterns:
+                patterns.append(pattern)
+        self._saShortDates = patterns
+
+        # The first item in the collection which getWeekdays() returns is an empty string.
+        # Interestingly, .NET removes that empty string.
+        # Even more interestingly, NodaFormatInfo adds it back in, and moves the days around.
+        self._saDayNames = [name for name in date_format_symbols.getWeekdays() if name]
+        assert len(self._saDayNames) == 7
+
+        abbrev_day_names_result, self._saAbbrevDayNames = self._enum_calendar_info(
+            locale_name,
+            calendar_id,
+            _CalendarDataType.ABBREV_DAY_NAMES,
+        )
+
+        month_names_result, self._saMonthNames, leap_hebrew_month_name = self.__enum_month_names(
+            locale_name, calendar_id, _CalendarDataType.MONTH_NAMES
+        )
+        if leap_hebrew_month_name:
+            assert self._saMonthNames
+
+            # In Hebrew calendar, get the leap month name Adar II and override the non-leap month 7
+            assert calendar_id == _CalendarId.HEBREW and len(self._saMonthNames) == 13
+            self._saLeapYearMonthNames = list(self._saMonthNames)
+            self._saLeapYearMonthNames[6] = leap_hebrew_month_name
+
+            # The returned data from ICU has 6th month name as 'Adar I' and 7th month name as 'Adar'
+            # We need to adjust that in the list used with non-leap year to have 6th month as 'Adar'
+            # and 7th month as 'Adar II'
+            # note that when formatting non-leap year dates, 7th month shouldn't get used at all.
+            self._saMonthNames[5] = self._saMonthNames[6]
+            self._saMonthNames[6] = leap_hebrew_month_name
+
+        abbreviated_month_names_result, self._saAbbrevMonthNames, _ = self.__enum_month_names(
+            locale_name, calendar_id, _CalendarDataType.ABBREV_MONTH_NAMES
+        )
+
+        month_genitive_names_result, self._saMonthGenitiveNames, _ = self.__enum_month_names(
+            locale_name, calendar_id, _CalendarDataType.MONTH_GENITIVE_NAMES
+        )
+
+        abbrev_month_genitive_names_result, self._saAbbrevMonthGenitiveNames, _ = self.__enum_month_names(
+            locale_name, calendar_id, _CalendarDataType.ABBREV_MONTH_GENITIVE_NAMES
+        )
+
+        # The cast here is because icu has no return type annotation for getEras()
+        self._saEraNames = cast(list[str], date_format_symbols.getEras())
+
+        # .NET expects that only the Japanese calendars have more than 1 era.
+        # So for other calendars, only return the latest era.
+        if (
+            calendar_id != _CalendarId.JAPAN
+            and calendar_id != _CalendarId.JAPANESELUNISOLAR
+            and len(self._saEraNames) > 0
+        ):
+            # TODO: Do the same thing for short era names when/if that is implemented
+            latest_era_name = self._saEraNames[-1]
+            self._saEraNames = [latest_era_name]
+
+        return all(
+            (
+                # TODO: Add other bools here
+                abbrev_day_names_result,
+                month_names_result,
+                abbreviated_month_names_result,
+                month_genitive_names_result,
+                abbrev_month_genitive_names_result,
+            )
+        )
+
+    def __load_calendar_data_from_system_core(self, locale_name: str, calendar_id: _CalendarId) -> bool:
+        return self.__icu_load_calendar_data_from_system(locale_name, calendar_id)
+
+    def __initialize_era_names(self, locale_name: str, calendar_id: _CalendarId) -> None:
+        def are_era_names_empty() -> bool:
+            return not self._saEraNames or not self._saEraNames[0]
+
+        # Note that the saEraNames only include "A.D."
+        # We don't have localized names for other calendars available from windows
+        match calendar_id:
+            # For Localized Gregorian we really expect the data from the OS.
+            case _CalendarId.GREGORIAN:
+                # Fallback for CoreCLR < Win7 or culture.dll missing
+                if are_era_names_empty():
+                    self._saEraNames = ["A.D."]
+            # The rest of the calendars have constant data, so we'll just use that
+            case _CalendarId.GREGORIAN_US, _CalendarId.JULIAN:
+                self._saEraNames = ["A.D."]
+            case _CalendarId.HEBREW:
+                self._saEraNames = ["C.E."]
+            case _CalendarId.HIJRI, _CalendarId.UMALQURA:
+                if locale_name == "dv-MV":
+                    # Special case for Divehi
+                    self._saEraNames = ["\u0780\u07a8\u0796\u07b0\u0783\u07a9"]
+                else:
+                    self._saEraNames = ["\u0628\u0639\u062f \u0627\u0644\u0647\u062c\u0631\u0629"]
+            case _CalendarId.GREGORIAN_ARABIC, _CalendarId.GREGORIAN_XLIT_ENGLISH, _CalendarId.GREGORIAN_XLIT_FRENCH:
+                # These are all the same:
+                self._saEraNames = ["\u0645"]
+            case _CalendarId.GREGORIAN_ME_FRENCH:
+                self._saEraNames = ["ap. J.-C."]
+            case _CalendarId.TAIWAN:
+                if self.__system_supports_taiwanese_calendar():
+                    self._saEraNames = ["\u4e2d\u83ef\u6c11\u570b"]
+                else:
+                    self._saEraNames = [""]
+            case _CalendarId.KOREA:
+                self._saEraNames = ["\ub2e8\uae30"]
+            case _CalendarId.THAI:
+                self._saEraNames = ["\u0e1e\u002e\u0e28\u002e"]
+            case _CalendarId.JAPAN, _CalendarId.JAPANESELUNISOLAR:
+                from pyoda_time._compatibility._japanese_calendar import JapaneseCalendar
+
+                self._saEraNames = JapaneseCalendar._era_names()
+            case _CalendarId.PERSIAN:
+                if are_era_names_empty():
+                    self._saEraNames = ["\u0647\u002e\u0634"]
+            case _:
+                # Most calendars are just "A.D."
+                self._saEraNames = self.__class__._invariant._saEraNames
+
+    @classmethod
+    def __normalize_date_pattern(cls, date_pattern: str) -> str:
+        """The ICU date format characters are not exactly the same as the .NET date format characters.
+
+        NormalizeDatePattern will take in an ICU date pattern and return the equivalent .NET date pattern.
+
+        see Date Field Symbol Table in
+        http://userguide.icu-project.org/formatparse/datetime
+        and https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx
+        """
+
+        destination = StringBuilder()
+
+        index = 0
+
+        while index < len(date_pattern):
+            match date_pattern[index]:
+                case "'":
+                    # single quotes escape characters, like 'de' in es-SP
+                    # so read verbatim until the next single quote
+                    destination.append(date_pattern[index])
+                    index += 1
+                    while index < len(date_pattern):
+                        current = date_pattern[index]
+                        destination.append(current)
+                        index += 1
+                        if current == "'":
+                            break
+                case "E", "e", "c":
+                    # 'E' in ICU is the day of the week, which maps to 3 or 4 'd's in .NET
+                    # 'e' in ICU is the local day of the week, which has no representation in .NET, but
+                    # maps closest to 3 or 4 'd's in .NET
+                    # 'c' in ICU is the stand-alone day of the week, which has no representation in .NET, but
+                    # maps closest to 3 or 4 'd's in .NET
+                    index = cls.__normalize_day_of_week(date_pattern, destination, index)
+                case "L", "M":
+                    # 'L' in ICU is the stand-alone name of the month,
+                    # which maps closest to 'M' in .NET since it doesn't support stand-alone month names in patterns
+                    # 'M' in both ICU and .NET is the month,
+                    # but ICU supports 5 'M's, which is the super short month name
+                    occurrences, index = cls.__count_occurrences(date_pattern, date_pattern[index], index)
+                    if occurrences > 4:
+                        # 5 'L's or 'M's in ICU is the super short name, which maps closest to MMM in .NET
+                        occurrences = 3
+                    destination.append("M" * occurrences)
+                case "G":
+                    # 'G' in ICU is the era, which maps to 'g' in .NET
+                    _, index = cls.__count_occurrences(date_pattern, date_pattern[index], index)
+                    # it doesn't matter how many 'G's, since .NET only supports 'g' or 'gg', and they
+                    # have the same meaning
+                    destination.append("g")
+                case "y":
+                    # a single 'y' in ICU is the year with no padding or trimming.
+                    # a single 'y' in .NET is the year with 1 or 2 digits
+                    # so convert any single 'y' to 'yyyy'
+                    occurrences, index = cls.__count_occurrences(date_pattern, "y", index)
+                    if occurrences == 1:
+                        occurrences = 4
+                    destination.append("y" * occurrences)
+                case _:
+                    unsupported_date_field_symbols = "YuUrQqwWDFg"
+                    assert date_pattern[index] not in unsupported_date_field_symbols
+                    destination.append(date_pattern[index])
+                    index += 1
+
+        return destination.to_string()
+
+    @classmethod
+    def __normalize_day_of_week(cls, date_pattern: str, destination: StringBuilder, index: int) -> int:
+        day_char = date_pattern[index]
+        occurrences, index = cls.__count_occurrences(date_pattern, day_char, index)
+        occurrences = max(occurrences, 3)
+        if occurrences > 4:
+            # 5 and 6 E/e/c characters in ICU is the super short names, which maps closest to ddd in .NET
+            occurrences = 3
+
+        destination.append("d" * occurrences)
+
+        return index
+
+    @classmethod
+    def __count_occurrences(cls, date_pattern: str, value: str, index: int) -> tuple[int, int]:
+        start_index = index
+        while index < len(date_pattern) and date_pattern[index] == value:
+            index += 1
+
+        return index - start_index, index
+
+    @classmethod
+    def __enum_month_names(
+        cls,
+        locale_name: str,
+        calendar_id: _CalendarId,
+        data_type: _CalendarDataType,
+    ) -> tuple[bool, list[str] | None, str | None]:
+        """Return a 3-tuple containing.
+
+        * True if the operation was successful, False otherwise
+        * A list of month names if the operation was successful, otherwise None
+        * A string representing the leap Hebrew month if successful, otherwise None
+        """
+        month_names: list[str] | None = None
+        leap_hebrew_month_name: str | None = None
+
+        callback_context = _IcuEnumCalendarsData()
+
+        result: bool = cls.__enum_calendar_info(locale_name, calendar_id, data_type, callback_context)
+
+        if result:
+            # the month-name arrays are expected to have 13 elements.  If ICU only returns 12, add an
+            # extra empty string to fill the array.
+            if len(callback_context.results) == 12:
+                callback_context.results.append("")
+
+            if len(callback_context.results) > 13:
+                assert calendar_id == _CalendarId.HEBREW and len(callback_context.results) == 14
+
+                if calendar_id == _CalendarId.HEBREW:
+                    leap_hebrew_month_name = callback_context.results[13]
+                callback_context.results.pop(13)
+            month_names = callback_context.results
+
+        return result, month_names, leap_hebrew_month_name
+
+    @classmethod
+    def _enum_calendar_info(
+        cls, locale_name: str, calendar_id: _CalendarId, data_type: _CalendarDataType
+    ) -> tuple[bool, list[str]]:
+        callback_context = _IcuEnumCalendarsData()
+        result = cls.__enum_calendar_info(locale_name, calendar_id, data_type, callback_context)
+        return result, callback_context.results
+
+    @classmethod
+    def __enum_calendar_info(
+        cls,
+        locale_name: str,
+        calendar_id: _CalendarId,
+        data_type: _CalendarDataType,
+        callback_context: _IcuEnumCalendarsData,
+    ) -> bool:
+        from pyoda_time._compatibility._interop import _Interop
+
+        return _Interop._Globalization._enum_calendar_info(
+            cls.__enum_calendar_info_callback, locale_name, calendar_id, data_type, callback_context
+        )
+
+    @classmethod
+    def __enum_calendar_info_callback(cls, calendar_string: str, context: _IcuEnumCalendarsData) -> None:
+        if context.disallow_duplicates:
+            if calendar_string in context.results:
+                return
+        context.results.append(calendar_string)
+
+    @classmethod
+    def __system_supports_taiwanese_calendar(cls) -> bool:
+        if _GlobalizationMode._use_nls:
+            raise NotImplementedError
+        return cls.__icu_system_supports_taiwanese_calendar()
+
+    @staticmethod
+    def __icu_system_supports_taiwanese_calendar() -> bool:
+        assert not _GlobalizationMode._use_nls
+        return True

--- a/pyoda_time/_compatibility/_calendar_id.py
+++ b/pyoda_time/_compatibility/_calendar_id.py
@@ -2,8 +2,19 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 
+from __future__ import annotations
 
 from enum import Enum
+
+GREGORIAN_NAME = "gregorian"
+JAPANESE_NAME = "japanese"
+BUDDHIST_NAME = "buddhist"
+HEBREW_NAME = "hebrew"
+DANGI_NAME = "dangi"
+PERSIAN_NAME = "persian"
+ISLAMIC_NAME = "islamic"
+ISLAMIC_UMALQURA_NAME = "islamic-umalqura"
+ROC_NAME = "roc"
 
 
 class _CalendarId(Enum):
@@ -35,3 +46,60 @@ class _CalendarId(Enum):
     PERSIAN = 22
     UMALQURA = 23
     LAST_CALENDAR = 23  # Last calendar ID
+
+    @classmethod
+    def from_icu_calendar_name(cls, icu_calendar_name: str) -> _CalendarId:
+        """Gets the associated CalendarId for the ICU calendar name.
+
+        Equivalent to:
+        https://github.com/dotnet/runtime/blob/b181ed507c07bdcfb84e2a2b4786d3c2c763db8c/src/native/libs/System.Globalization.Native/pal_calendarData.c#L82-L107
+
+        :param icu_calendar_name: The ICU calendar name.
+        :return: The associated CalendarId.
+        """
+        if icu_calendar_name == GREGORIAN_NAME:
+            return _CalendarId.GREGORIAN
+        elif icu_calendar_name == JAPANESE_NAME:
+            return _CalendarId.JAPAN
+        elif icu_calendar_name == BUDDHIST_NAME:
+            return _CalendarId.THAI
+        elif icu_calendar_name == HEBREW_NAME:
+            return _CalendarId.HEBREW
+        elif icu_calendar_name == DANGI_NAME:
+            return _CalendarId.KOREA
+        elif icu_calendar_name == PERSIAN_NAME:
+            return _CalendarId.PERSIAN
+        elif icu_calendar_name == ISLAMIC_NAME:
+            return _CalendarId.HIJRI
+        elif icu_calendar_name == ISLAMIC_UMALQURA_NAME:
+            return _CalendarId.UMALQURA
+        elif icu_calendar_name == ROC_NAME:
+            return _CalendarId.TAIWAN
+        else:
+            return _CalendarId.UNINITIALIZED_VALUE
+
+    def to_icu_calendar_name(self) -> str:
+        """Gets the associated ICU calendar name for the _CalendarId.
+
+        This is roughly equivalent to:
+        https://github.com/dotnet/runtime/blob/b181ed507c07bdcfb84e2a2b4786d3c2c763db8c/src/native/libs/System.Globalization.Native/pal_calendarData.c#L30-L76
+        """
+        match self:
+            case _CalendarId.JAPAN:
+                return JAPANESE_NAME
+            case _CalendarId.THAI:
+                return BUDDHIST_NAME
+            case _CalendarId.HEBREW:
+                return HEBREW_NAME
+            case _CalendarId.KOREA:
+                return DANGI_NAME
+            case _CalendarId.PERSIAN:
+                return PERSIAN_NAME
+            case _CalendarId.HIJRI:
+                return ISLAMIC_NAME
+            case _CalendarId.UMALQURA:
+                return ISLAMIC_UMALQURA_NAME
+            case _CalendarId.TAIWAN:
+                return ROC_NAME
+            case _:
+                return GREGORIAN_NAME

--- a/pyoda_time/_compatibility/_culture_types.py
+++ b/pyoda_time/_compatibility/_culture_types.py
@@ -1,0 +1,43 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from enum import Flag
+
+
+class CultureTypes(Flag):
+    """The enumeration constants used in CultureInfo.GetCultures().
+
+    On Linux platforms, the only enum values used there is NeutralCultures and SpecificCultures. the rest are obsolete
+    or not valid on Linux.
+    """
+
+    # Cultures that are associated with a language but are not specific to a country/region.
+    NEUTRAL_CULTURES = 1
+
+    # Cultures that are specific to a country/region.
+    SPECIFIC_CULTURES = 2
+
+    # This member is deprecated. All cultures that are installed in the Windows operating system.
+    INSTALLED_WIN32_CULTURES = 4
+
+    # All cultures that recognized by .NET, including neutral and specific cultures and custom cultures created by the
+    # user.
+    #
+    # On .NET Framework 4 and later versions and .NET Core running on Windows, it includes the culture data available
+    # from the Windows operating system. On .NET Core running on Linux and macOS, it includes culture data defined in
+    # the ICU libraries.
+    ALL_CULTURES = INSTALLED_WIN32_CULTURES | SPECIFIC_CULTURES | NEUTRAL_CULTURES
+
+    # This member is deprecated. Custom cultures created by the user.
+    USER_CUSTOM_CULTURE = 8
+
+    # This member is deprecated. Custom cultures created by the user that replace cultures shipped with the .NET
+    # Framework.
+    REPLACEMENT_CULTURES = 16
+
+    # This member is deprecated and is ignored.
+    WINDOWS_ONLY_CULTURES = 32
+
+    # This member is deprecated
+    FRAMEWORK_CULTURES = 64

--- a/pyoda_time/_compatibility/_date_time_format_info.py
+++ b/pyoda_time/_compatibility/_date_time_format_info.py
@@ -4,16 +4,37 @@
 
 from __future__ import annotations
 
-from typing import Any
+import copy
+from typing import Any, Sequence, _ProtocolMeta
 
 from pyoda_time._compatibility._calendar import Calendar
 from pyoda_time._compatibility._calendar_id import _CalendarId
 from pyoda_time._compatibility._culture_data import _CultureData
-from pyoda_time._compatibility._i_format_provider import IFormatProvider
+
+
+class _DateTimeFormatInfoMeta(type):
+    __s_invariantInfo: DateTimeFormatInfo | None = None
+
+    @property
+    def invariant_info(self) -> DateTimeFormatInfo:
+        """Gets the default read-only ``DateTimeFormatInfo`` object that is culture-independent (invariant).
+
+        :return: A read-only object that is culture-independent (invariant).
+        """
+        if self.__s_invariantInfo is None:
+            date_time_format_info = DateTimeFormatInfo()
+            date_time_format_info.calendar._set_read_only_state(True)
+            date_time_format_info._is_read_only = True
+            self.__s_invariantInfo = date_time_format_info
+        return self.__s_invariantInfo
+
+
+class _CombinedMeta(_ProtocolMeta, _DateTimeFormatInfoMeta):
+    """Intermediary class which prevents a metaclass conflict."""
 
 
 # TODO: ICloneable
-class DateTimeFormatInfo(IFormatProvider):
+class DateTimeFormatInfo(metaclass=_CombinedMeta):
     """Provides culture-specific information about the format of date and time values."""
 
     def __init__(self) -> None:
@@ -21,25 +42,83 @@ class DateTimeFormatInfo(IFormatProvider):
         from ._gregorian_calendar import GregorianCalendar
 
         self._culture_data: _CultureData = CultureInfo.invariant_culture._culture_data
-        self._calendar: Calendar = GregorianCalendar()
+        self.__calendar: Calendar = GregorianCalendar()
 
         self._is_read_only: bool = False
 
         # Cached values exposed via lazy-initialising properties
+        self.__date_separator: str | None = None
         self.__time_separator: str | None = None
+        self.__day_names: Sequence[str] | None = None
+        self.__abbreviated_day_names: Sequence[str] | None = None
+        self.__m_era_names: list[str] | None = None
+        self.__month_names: list[str] | None = None
+        self.__abbreviated_month_names: Sequence[str] | None = None
+        self.__genitive_month_names: Sequence[str] | None = None
+        self.__m_genitive_abbreviated_month_names: Sequence[str] | None = None
 
     @classmethod
     def _ctor(cls, culture_data: _CultureData, cal: Calendar) -> DateTimeFormatInfo:
         self = cls.__new__(cls)
         self._culture_data = culture_data
-        self._calendar = cal
+        self.__calendar = cal
         self._is_read_only = False
         self.__initialize_overridable_properties(culture_data, cal._id)
 
         # Cached values exposed via lazy-initialising properties
+        self.__date_separator = None
         self.__time_separator = None
+        self.__day_names = None
+        self.__abbreviated_day_names = None
+        self.__m_era_names = None
+        self.__month_names = None
+        self.__abbreviated_month_names = None
+        self.__genitive_month_names = None
+        self.__m_genitive_abbreviated_month_names = None
 
         return self
+
+    def __internal_get_abbreviated_day_of_week_names(self) -> Sequence[str]:
+        return self.__abbreviated_day_names or self.__internal_get_abbreviated_day_of_week_names_core()
+
+    def __internal_get_abbreviated_day_of_week_names_core(self) -> Sequence[str]:
+        # Get the abbreviated day names for our current calendar
+        self.__abbreviated_day_names = self._culture_data._abbreviated_day_names(self.calendar._id)
+        assert len(self.__abbreviated_day_names) == 7
+        return self.__abbreviated_day_names
+
+    def __internal_get_day_of_week_names(self) -> Sequence[str]:
+        """Create an array of string which contains the day names."""
+        return self.__day_names or self.__internal_get_day_of_week_names_core()
+
+    def __internal_get_day_of_week_names_core(self) -> Sequence[str]:
+        self.__day_names = self._culture_data._day_names(self.calendar._id)
+        assert len(self.__day_names) == 7, "Expected 7 day names in a week"
+        return self.__day_names
+
+    def __internal_get_abbreviated_month_names(self) -> Sequence[str]:
+        if self.__abbreviated_month_names is None:
+            self.__abbreviated_month_names = self.__internal_get_abbreviated_month_names_core()
+        return self.__abbreviated_month_names
+
+    def __internal_get_abbreviated_month_names_core(self) -> Sequence[str]:
+        self.__abbreviated_month_names = self._culture_data._abbreviated_month_names(self.calendar._id)
+        return self.__abbreviated_month_names
+
+    def __internal_get_month_names(self) -> Sequence[str]:
+        """Create an array of string which contains the month names."""
+        return self.__month_names or self.__internal_get_month_names_core()
+
+    def __internal_get_month_names_core(self) -> Sequence[str]:
+        month_names = self._culture_data._month_names(self.calendar._id)
+        assert len(month_names) in (12, 13), "Expected 12 or 13 month names in a year"
+        return month_names
+
+    @property
+    def date_separator(self) -> str:
+        if self.__date_separator is None:
+            self.__date_separator = self._culture_data._date_separator(self.calendar._id)
+        return self.__date_separator
 
     @property
     def time_separator(self) -> str:
@@ -60,13 +139,205 @@ class DateTimeFormatInfo(IFormatProvider):
         if self._is_read_only:
             raise RuntimeError("Cannot write read-only DateFormatInfo")
 
-    @property
-    def is_read_only(self) -> bool:
-        return self._is_read_only
-
     def __initialize_overridable_properties(self, culture_data: _CultureData, calendar_id: _CalendarId) -> None:
         # TODO: implement __initialize_overridable_properties()
         pass
 
     def get_format(self, format_type: type) -> Any | None:
         raise NotImplementedError
+
+    @property
+    def calendar(self) -> Calendar:
+        """Gets or sets the calendar to use for the current culture.
+
+        :return: The calendar to use for the current culture.
+        """
+        return self.__calendar
+
+    @calendar.setter
+    def calendar(self, calendar: Calendar) -> None:
+        if self.is_read_only:
+            raise RuntimeError("Cannot assign calendar to read-only DateFormatInfo")
+        if calendar is None:
+            raise ValueError("Calendar cannot be None")
+        if calendar != self.__calendar:
+            # TODO: There is a bunch of other stuff that happens here...
+            self.__calendar = calendar
+
+    @property
+    def _era_names(self) -> list[str]:
+        if not self.__m_era_names:
+            self.__m_era_names = self._culture_data._era_names(self.calendar._id)
+        return self.__m_era_names
+
+    @staticmethod
+    def __check_null_value(values: Sequence[str], length: int) -> None:
+        """Check if a string array contains a null value, and throw ArgumentNullException with parameter name
+        'value'."""
+        assert values is not None, "value != null"
+        assert len(values) >= length
+        for i in range(length):
+            if values[i] is None:
+                raise ValueError("values contains null values")
+
+    @property
+    def abbreviated_day_names(self) -> list[str]:
+        return list(self.__internal_get_abbreviated_day_of_week_names())
+
+    @abbreviated_day_names.setter
+    def abbreviated_day_names(self, value: list[str]) -> None:
+        if self.is_read_only:
+            raise RuntimeError("Cannot assign to read-only DateFormatInfo")
+        if value is None:
+            raise ValueError("day_names cannot be None")
+        if len(value) != 7:
+            raise ValueError("Expected value to contain 7 items")
+        self.__check_null_value(value, len(value))
+        # TODO: ClearTokenHashTable()
+        self.__abbreviated_day_names = value
+
+    @property
+    def day_names(self) -> list[str]:
+        """Gets or sets a one-dimensional string array that contains the culture-specific full names of the days of the
+        week.
+
+        :return: A one-dimensional string array that contains the culture-specific full names of the days of the week.
+            The array for ``DateTimeFormatInfo.invariant_info`` contains "Sunday", "Monday", "Tuesday", "Wednesday",
+            "Thursday", "Friday", and "Saturday".
+        """
+        return list(self.__internal_get_day_of_week_names())
+
+    @day_names.setter
+    def day_names(self, value: list[str]) -> None:
+        if self.is_read_only:
+            raise RuntimeError("Cannot assign to read-only DateFormatInfo")
+        if value is None:
+            raise ValueError("day_names cannot be None")
+        if len(value) != 7:
+            raise ValueError("Expected day_names to contain 7 items")
+        self.__check_null_value(value, len(value))
+        # TODO: ClearTokenHashTable();
+        self.__day_names = value
+
+    @property
+    def abbreviated_month_names(self) -> list[str]:
+        """Gets or sets the culture-specific abbreviated names of the months.
+
+        :return:
+        """
+        return list(self.__internal_get_abbreviated_month_names())
+
+    @abbreviated_month_names.setter
+    def abbreviated_month_names(self, value: list[str]) -> None:
+        self.__verify_writable()
+        if value is None:
+            raise TypeError("value cannot be None")
+        if len(value) != 13:
+            raise ValueError("Expected value to contain 13 items")
+
+        self.__check_null_value(value, len(value) - 1)
+        # TODO: ClearTokenHashTable()
+        self.__abbreviated_month_names = value
+
+    @property
+    def month_names(self) -> list[str]:
+        """Gets or sets the culture-specific full names of the months.
+
+        In a 12-month calendar, the 13th element of the array is an empty string.
+
+        The array for ``DateTimeFormatInfo.invariant_info`` contains "January",
+        "February", "March", "April", "May", "June", "July", "August", "September",
+        "October", "November", "December", and "".
+
+        :return: A list containing the culture-specific full names of the months.
+        """
+        return list(self.__internal_get_month_names())
+
+    @month_names.setter
+    def month_names(self, value: list[str]) -> None:
+        self.__verify_writable()
+        if value is None:
+            raise TypeError("value cannot be None")
+        if len(value) != 13:
+            raise ValueError("Expected value to contain 13 items")
+
+        self.__check_null_value(value, len(value) - 1)
+        self.__month_names = value
+        # TODO: ClearTokenHashTable()
+
+    @property
+    def abbreviated_month_genitive_names(self) -> Sequence[str]:
+        """Gets or sets a string array of abbreviated month names associated with the current ``DateTimeFormatInfo``
+        object.
+
+        :return: An array of abbreviated month names.
+        """
+        return list(self.__internal_get_genitive_month_names(abbreviated=True))
+
+    @abbreviated_month_genitive_names.setter
+    def abbreviated_month_genitive_names(self, value: Sequence[str]) -> None:
+        self.__verify_writable()
+        if value is None:
+            raise TypeError("value cannot be None")
+        if len(value) != 13:
+            raise ValueError("Expected value to contain 13 items")
+
+        self.__check_null_value(value, len(value) - 1)
+        # TODO: ClearTokenHashTable()
+        self.__m_genitive_abbreviated_month_names = value
+
+    @property
+    def month_genitive_names(self) -> Sequence[str]:
+        """Gets or sets a string array of month names associated with the current ``DateTimeFormatInfo`` object.
+
+        :return: A string array of month names.
+        """
+        return tuple(self.__internal_get_genitive_month_names(abbreviated=False))
+
+    @month_genitive_names.setter
+    def month_genitive_names(self, value: Sequence[str]) -> None:
+        self.__verify_writable()
+        if value is None:
+            raise TypeError("value cannot be None")
+        if len(value) != 13:
+            raise ValueError("Expected value to contain 13 items")
+
+        self.__check_null_value(value, len(value) - 1)
+        self.__genitive_month_names = value
+        # TODO: ClearTokenHashTable()
+
+    def __internal_get_genitive_month_names(self, abbreviated: bool) -> Sequence[str]:
+        """Retrieve the array which contains the month names in genitive form.
+
+        If this culture does not use the genitive form, the normal month name is returned.
+        """
+        if abbreviated:
+            if self.__m_genitive_abbreviated_month_names is None:
+                self.__m_genitive_abbreviated_month_names = self._culture_data._abbreviated_genitive_month_names(
+                    self.calendar._id
+                )
+                assert (
+                    len(self.__m_genitive_abbreviated_month_names) == 13
+                ), "Expected 13 abbreviated genitive month names in a year"
+            return self.__m_genitive_abbreviated_month_names
+
+        if self.__genitive_month_names is None:
+            self.__genitive_month_names = self._culture_data._genitive_month_names(self.calendar._id)
+            assert len(self.__genitive_month_names) == 13, "Expected 13 genitive month names in a year"
+        return self.__genitive_month_names
+
+    @staticmethod
+    def read_only(dtfi: DateTimeFormatInfo) -> DateTimeFormatInfo:
+        if dtfi is None:
+            raise ValueError("dtfi cannot be None")
+        if dtfi.is_read_only:
+            return dtfi
+        date_time_format_info: DateTimeFormatInfo = copy.copy(dtfi)
+        date_time_format_info.__calendar = Calendar.read_only(dtfi.calendar)
+        date_time_format_info._is_read_only = True
+        return date_time_format_info
+
+    @property
+    def is_read_only(self) -> bool:
+        """Gets a value indicating whether the ``DateTimeFormatInfo`` object is read-only."""
+        return self._is_read_only

--- a/pyoda_time/_compatibility/_globalization_mode.py
+++ b/pyoda_time/_compatibility/_globalization_mode.py
@@ -1,0 +1,40 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+
+class __GlobalizationModeSettingsMeta(type):
+    @property
+    def _invariant(cls) -> bool:
+        # TODO: In .NET, this can be configured e.g. by environment variable.
+        return False
+
+    @property
+    def _predefined_cultures_only(cls) -> bool:
+        # TODO: In .NET, this can be configured e.g. by environment variable.
+        return cls._invariant
+
+
+class _GlobalizationModeSettings(metaclass=__GlobalizationModeSettingsMeta):
+    pass
+
+
+class _GlobalizationModeMeta(type):
+    __settings = _GlobalizationModeSettings
+
+    @property
+    def _invariant(cls) -> bool:
+        return cls.__settings._invariant
+
+    @property
+    def _predefined_cultures_only(cls) -> bool:
+        return cls.__settings._predefined_cultures_only
+
+    @property
+    def _use_nls(self) -> bool:
+        # TODO: Hard-coded here because we only support ICU
+        return False
+
+
+class _GlobalizationMode(metaclass=_GlobalizationModeMeta):
+    """Rough sketch of GlobalizationMode in .NET."""

--- a/pyoda_time/_compatibility/_gregorian_calendar.py
+++ b/pyoda_time/_compatibility/_gregorian_calendar.py
@@ -1,6 +1,8 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
+from typing import Final
+
 from pyoda_time._compatibility._calendar import Calendar
 from pyoda_time._compatibility._calendar_id import _CalendarId
 from pyoda_time._compatibility._gregorian_calendar_types import GregorianCalendarTypes
@@ -9,9 +11,13 @@ from pyoda_time._compatibility._gregorian_calendar_types import GregorianCalenda
 class GregorianCalendar(Calendar):
     """Represents the Gregorian calendar."""
 
+    _MIN_YEAR: Final[int] = 1
+    _MAX_YEAR: Final[int] = 9999
+
     @property
     def _id(self) -> _CalendarId:
         return _CalendarId(self._type.value)
 
     def __init__(self, type_: GregorianCalendarTypes = GregorianCalendarTypes.Localized) -> None:
+        super().__init__()
         self._type = type_

--- a/pyoda_time/_compatibility/_gregorian_calendar_helper.py
+++ b/pyoda_time/_compatibility/_gregorian_calendar_helper.py
@@ -1,0 +1,35 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from datetime import datetime
+from typing import final
+
+from pyoda_time.utility import _sealed
+
+
+@_sealed
+@final
+class _EraInfo:
+    def __init__(
+        self,
+        era: int,
+        start_year: int,
+        start_month: int,
+        start_day: int,
+        year_offset: int,
+        min_era_year: int,
+        max_era_year: int,
+        era_name: str | None = None,
+        abbrev_era_name: str | None = None,
+        english_era_name: str | None = None,
+    ) -> None:
+        self._era = era
+        self._year_offset = year_offset
+        self._min_era_year = min_era_year
+        self._max_era_year = max_era_year
+        from pyoda_time.utility import _to_ticks
+
+        self._ticks = _to_ticks(datetime(start_year, start_month, start_day))
+        self._era_name = era_name
+        self._abbrev_era_name = abbrev_era_name
+        self._english_era_name = english_era_name

--- a/pyoda_time/_compatibility/_hebrew_calendar.py
+++ b/pyoda_time/_compatibility/_hebrew_calendar.py
@@ -1,0 +1,63 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class HebrewCalendar(Calendar):
+    """Rules for the Hebrew calendar:
+    - The Hebrew calendar is both a Lunar (months) and Solar (years)
+      calendar, but allows for a week of seven days.
+    - Days begin at sunset.
+    - Leap Years occur in the 3, 6, 8, 11, 14, 17, &amp; 19th years of a
+      19-year cycle.  Year = leap iff ((7y+1) mod 19 &lt; 7).
+    - There are 12 months in a common year and 13 months in a leap year.
+    - In a common year, the 6th month, Adar, has 29 days.  In a leap
+      year, the 6th month, Adar I, has 30 days and the leap month,
+      Adar II, has 29 days.
+    - Common years have 353-355 days.  Leap years have 383-385 days.
+    - The Hebrew new year (Rosh HaShanah) begins on the 1st of Tishri,
+      the 7th month in the list below.
+    - The new year may not begin on Sunday, Wednesday, or Friday.
+    - If the new year would fall on a Tuesday and the conjunction of
+      the following year were at midday or later, the new year is
+      delayed until Thursday.
+    - If the new year would fall on a Monday after a leap year, the
+      new year is delayed until Tuesday.
+    - The length of the 8th and 9th months vary from year to year,
+      depending on the overall length of the year.
+    - The length of a year is determined by the dates of the new
+      years (Tishri 1) preceding and following the year in question.
+    - The 2th month is long (30 days) if the year has 355 or 385 days.
+    - The 3th month is short (29 days) if the year has 353 or 383 days.
+    - The Hebrew months are:
+      1.  Tishri        (30 days)
+      2.  Heshvan       (29 or 30 days)
+      3.  Kislev        (29 or 30 days)
+      4.  Teveth        (29 days)
+      5.  Shevat        (30 days)
+      6.  Adar I        (30 days)
+      7.  Adar {II}     (29 days, this only exists if that year is a leap year)
+      8.  Nisan         (30 days)
+      9.  Iyyar         (29 days)
+      10. Sivan         (30 days)
+      11. Tammuz        (29 days)
+      12. Av            (30 days)
+      13. Elul          (29 days)
+
+    Calendar support range:
+        ==========  ==========  ==========
+        Calendar    Minimum     Maximum
+        ==========  ==========  ==========
+        Gregorian   1583/01/01  2239/09/29
+        Hebrew      5343/04/07  5999/13/29
+        ==========  ==========  ==========
+
+    Includes CHebrew implementation;i.e All the code necessary for converting
+    Gregorian to Hebrew Lunar from 1583 to 2239.
+    """
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.HEBREW

--- a/pyoda_time/_compatibility/_hijri_calendar.py
+++ b/pyoda_time/_compatibility/_hijri_calendar.py
@@ -1,0 +1,51 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class HijriCalendar(Calendar):
+    """Rules for the Hijri calendar:
+    - The Hijri calendar is a strictly Lunar calendar.
+    - Days begin at sunset.
+    - Islamic Year 1 (Muharram 1, 1 A.H.) is equivalent to absolute date
+      227015 (Friday, July 16, 622 C.E. - Julian).
+    - Leap Years occur in the 2, 5, 7, 10, 13, 16, 18, 21, 24, 26, &amp; 29th
+      years of a 30-year cycle.  Year = leap iff ((11y+14) mod 30 &lt; 11).
+    - There are 12 months which contain alternately 30 and 29 days.
+    - The 12th month, Dhu al-Hijjah, contains 30 days instead of 29 days
+      in a leap year.
+    - Common years have 354 days.  Leap years have 355 days.
+    - There are 10,631 days in a 30-year cycle.
+    - The Islamic months are:
+        1.  Muharram       (30 days)
+        2.  Safar          (29 days)
+        3.  Rabi I         (30 days)
+        4.  Rabi II        (29 days)
+        5.  Jumada I       (30 days)
+        6.  Jumada II      (29 days)
+        7.  Rajab          (30 days)
+        8.  Sha'ban        (29 days)
+        9.  Ramadan        (30 days)
+        10. Shawwal        (29 days)
+        11. Dhu al-Qada    (30 days)
+        12. Dhu al-Hijjah  (29 days) {30}
+
+    NOTE
+    The calculation of the HijriCalendar is based on the absolute date.  And the
+    absolute date means the number of days from January 1st, 1 A.D.
+    Therefore, we do not support the days before the January 1st, 1 A.D.
+
+    Calendar support range:
+        ==========  ==========  ==========
+        Calendar    Minimum     Maximum
+        ==========  ==========  ==========
+        Gregorian   0622/07/18   9999/12/31
+        Hijri       0001/01/01   9666/04/03
+        ==========  ==========  ==========
+    """
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.HIJRI

--- a/pyoda_time/_compatibility/_interop.py
+++ b/pyoda_time/_compatibility/_interop.py
@@ -1,0 +1,159 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Callable
+
+import icu
+
+from pyoda_time._compatibility._calendar_data import _CalendarDataType, _IcuEnumCalendarsData
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class _Interop:
+    class _Globalization:
+        @classmethod
+        def _enum_calendar_info(
+            cls,
+            callback: Callable[[str, _IcuEnumCalendarsData], None],
+            locale_name: str,
+            calendar_id: _CalendarId,
+            calendar_data_type: _CalendarDataType,
+            context: _IcuEnumCalendarsData,
+        ) -> bool:
+            return cls.__enum_calendar_info(
+                callback,
+                locale_name,
+                calendar_id,
+                calendar_data_type,
+                context,
+            )
+
+        @classmethod
+        def __enum_calendar_info(
+            cls,
+            callback: Callable[[str, _IcuEnumCalendarsData], None],
+            locale_name: str,
+            calendar_id: _CalendarId,
+            calendar_data_type: _CalendarDataType,
+            context: _IcuEnumCalendarsData,
+        ) -> bool:
+            """In .NET this function calls into native code.
+
+            Specifically, it calls `GlobalizationNative_EnumCalendarInfo` which interacts with ICU.
+
+            https://github.com/dotnet/runtime/blob/b181ed507c07bdcfb84e2a2b4786d3c2c763db8c/src/native/libs/System.Globalization.Native/pal_calendarData.c#L479
+
+            In Python, this function mimics the behavior of that native code.
+            """
+            match calendar_data_type:
+                case _CalendarDataType.ABBREV_DAY_NAMES:
+                    return cls.__enum_symbols(
+                        locale_name,
+                        calendar_id,
+                        calendar_data_type,
+                        1,
+                        callback,
+                        context,
+                    )
+                case _CalendarDataType.MONTH_NAMES:
+                    return cls.__enum_symbols(
+                        locale_name,
+                        calendar_id,
+                        calendar_data_type,
+                        0,
+                        callback,
+                        context,
+                    )
+                case _CalendarDataType.ABBREV_MONTH_NAMES:
+                    return cls.__enum_symbols(
+                        locale_name,
+                        calendar_id,
+                        calendar_data_type,
+                        0,
+                        callback,
+                        context,
+                    )
+                case _CalendarDataType.MONTH_GENITIVE_NAMES:
+                    return cls.__enum_symbols(
+                        locale_name,
+                        calendar_id,
+                        calendar_data_type,
+                        0,
+                        callback,
+                        context,
+                    )
+                case _CalendarDataType.ABBREV_MONTH_GENITIVE_NAMES:
+                    return cls.__enum_symbols(
+                        locale_name,
+                        calendar_id,
+                        calendar_data_type,
+                        0,
+                        callback,
+                        context,
+                    )
+                case _:
+                    raise NotImplementedError
+
+        @classmethod
+        def __enum_symbols(
+            cls,
+            locale_name: str,
+            calendar_id: _CalendarId,
+            type_: _CalendarDataType,
+            start_index: int,
+            callback: Callable[[str, _IcuEnumCalendarsData], None],
+            context: _IcuEnumCalendarsData,
+        ) -> bool:
+            # .NET's native code calls ICU's C API here.
+            #
+            # https://github.com/dotnet/runtime/blob/b181ed507c07bdcfb84e2a2b4786d3c2c763db8c/src/native/libs/System.Globalization.Native/pal_calendarData.c#L295
+            #
+            # This Python code attempts to mimic that, using PyICU.
+            #
+            # More context on ICU's C API, e.g. udat_open(), udat_setCalendar() and friends:
+            # https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/udat_8h.html#a27dd4504fd957101d616aaeaf9e8ec9c
+
+            locale = icu.Locale(locale_name)
+            # To the best of my knowledge, ICU defaults to Gregorian calendar for most locales.
+            # So we need to explicitly tell it which calendar to use.
+            locale.setKeywordValue("calendar", calendar_id.to_icu_calendar_name())
+            calendar = icu.Calendar.createInstance(locale)
+
+            date_format: icu.SimpleDateFormat = icu.SimpleDateFormat("", locale)
+            date_format.setCalendar(calendar)
+            date_format_symbols: icu.DateFormatSymbols = date_format.getDateFormatSymbols()
+
+            # In native .NET code, they have to make separate calls in C to first count the number
+            # of symbols for the given symbol type (udat_countSymbols), and a call per symbol to
+            # get the value (udat_getSymbols). PyICU usage looks a little different. We have to
+            # translate those C calls to udat_getSymbols(), where a UDateFormatSymbolType argument
+            # is passed, into PyICU calls.
+
+            symbols: list[str]
+
+            match type_:
+                case _CalendarDataType.ABBREV_DAY_NAMES:
+                    symbols = date_format_symbols.getShortWeekdays()
+                case _CalendarDataType.MONTH_NAMES:
+                    symbols = date_format_symbols.getMonths(
+                        icu.DateFormatSymbols.STANDALONE, icu.DateFormatSymbols.WIDE
+                    )
+                case _CalendarDataType.ABBREV_MONTH_NAMES:
+                    # We could use .getShortMonths() here, but in the interest of consistency/explicitness...
+                    symbols = date_format_symbols.getMonths(
+                        icu.DateFormatSymbols.STANDALONE, icu.DateFormatSymbols.ABBREVIATED
+                    )
+                case _CalendarDataType.MONTH_GENITIVE_NAMES:
+                    symbols = date_format_symbols.getMonths(icu.DateFormatSymbols.FORMAT, icu.DateFormatSymbols.WIDE)
+                case _CalendarDataType.ABBREV_MONTH_GENITIVE_NAMES:
+                    symbols = date_format_symbols.getMonths(
+                        icu.DateFormatSymbols.FORMAT, icu.DateFormatSymbols.ABBREVIATED
+                    )
+
+                case _:
+                    raise NotImplementedError
+
+            for symbol in symbols[start_index:]:
+                callback(symbol, context)
+
+            return True

--- a/pyoda_time/_compatibility/_japanese_calendar.py
+++ b/pyoda_time/_compatibility/_japanese_calendar.py
@@ -1,0 +1,105 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+from pyoda_time._compatibility._globalization_mode import _GlobalizationMode
+from pyoda_time._compatibility._gregorian_calendar import GregorianCalendar
+from pyoda_time._compatibility._gregorian_calendar_helper import _EraInfo
+
+
+class JapaneseCalendar(Calendar):
+    """JapaneseCalendar is based on Gregorian calendar.  The month and day values are the same as Gregorian calendar.
+    However, the year value is an offset to the Gregorian year based on the era.
+
+    This system is adopted by Emperor Meiji in 1868. The year value is counted based on the reign of an emperor,
+    and the era begins on the day an emperor ascends the throne and continues until his death.
+    The era changes at 12:00AM.
+
+    For example, the current era is Reiwa. It started on 2019/5/1 A.D.  Therefore, Gregorian year 2019 is also Reiwa
+    1st. 2019/5/1 A.D. is also Reiwa 1st 5/1.
+
+    Any date in the year during which era is changed can be reckoned in either era. For example,
+    2019/1/1 can be 1/1 Reiwa 1st year or 1/1 Heisei 31st year.
+
+    Note: The DateTime can be represented by the JapaneseCalendar are limited to two factors:
+        1. The min value and max value of DateTime class.
+        2. The available era information.
+
+    Calendar support range:
+        ==========  ===========  =================
+        Calendar    Minimum      Maximum
+        ==========  ===========  =================
+        Gregorian   1868/09/08   9999/12/31
+        Japanese    Meiji 01/01  Reiwa 7981/12/31
+        ==========  ===========  =================
+    """
+
+    __s_japanese_era_info: list[_EraInfo] | None = None
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.JAPAN
+
+    def __init__(self) -> None:
+        super().__init__()
+        from ._culture_info import CultureInfo
+
+        try:
+            CultureInfo("ja-JP")
+        except Exception as e:
+            raise TypeError(self.__class__.__name__) from e
+
+    @classmethod
+    def _era_names(cls) -> list[str]:
+        eras: list[_EraInfo] = cls._get_era_info()  # noqa
+        # TODO: JapaneseCalendar.EraNames()
+        raise NotImplementedError("unfinished implementation")
+
+    @classmethod
+    def _get_era_info(cls) -> list[_EraInfo]:
+        r"""m_EraInfo must be listed in reverse chronological order. The most recent era should be the first element.
+        That is, m_EraInfo[0] contains the most recent era.
+
+        We know about 4 built-in eras, however users may add additional era(s) from the
+        registry, by adding values to HKLM\SYSTEM\CurrentControlSet\Control\Nls\Calendars\Japanese\Eras
+        we don't read the registry and instead we call WinRT to get the needed information
+
+        Registry values look like:
+             yyyy.mm.dd=era_abbrev_english_englishabbrev
+
+        Where yyyy.mm.dd is the registry value name, and also the date of the era start.
+        yyyy, mm, and dd are the year, month & day the era begins (4, 2 & 2 digits long)
+        era is the Japanese Era name
+        abbrev is the Abbreviated Japanese Era Name
+        english is the English name for the Era (unused)
+        englishabbrev is the Abbreviated English name for the era.
+        . is a delimiter, but the value of . doesn't matter.
+        '_' marks the space between the japanese era name, japanese abbreviated era name
+            english name, and abbreviated english names.
+        """
+
+        # See if we need to build it
+        if cls.__s_japanese_era_info is None:
+            if _GlobalizationMode._use_nls:
+                raise NotImplementedError("NlsGetJapaneseEras()")
+            cls.__s_japanese_era_info = cls.__icu_get_japanese_eras() or [
+                _EraInfo(5, 2019, 5, 1, 2018, 1, GregorianCalendar._MAX_YEAR - 2018, "\u4ee4\u548c", "\u4ee4", "R"),
+                _EraInfo(4, 1989, 1, 8, 1988, 1, 2019 - 1988, "\u5e73\u6210", "\u5e73", "H"),
+                _EraInfo(3, 1926, 12, 25, 1925, 1, 1989 - 1925, "\u662d\u548c", "\u662d", "S"),
+                _EraInfo(2, 1912, 7, 30, 1911, 1, 1926 - 1911, "\u5927\u6b63", "\u5927", "T"),
+                _EraInfo(1, 1868, 1, 1, 1867, 1, 1912 - 1867, "\u660e\u6cbb", "\u660e", "M"),
+            ]
+
+        return cls.__s_japanese_era_info
+
+    @classmethod
+    def __icu_get_japanese_eras(cls) -> list[_EraInfo] | None:
+        if _GlobalizationMode._invariant:
+            return None
+
+        assert not _GlobalizationMode._use_nls
+
+        # TODO: Noped out of this for now... implement later
+
+        return None

--- a/pyoda_time/_compatibility/_korean_calendar.py
+++ b/pyoda_time/_compatibility/_korean_calendar.py
@@ -1,0 +1,33 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class KoreanCalendar(Calendar):
+    """Korean calendar is based on the Gregorian calendar.  And the year is an offset to Gregorian calendar. That is,
+    Korean year = Gregorian year + 2333.  So 2000/01/01 A.D. is Korean 4333/01/01.
+
+    0001/1/1 A.D. is Korean year 2334.
+
+    Calendar support range:
+        ==========  ==========  ==========
+        Calendar    Minimum     Maximum
+        ==========  ==========  ==========
+        Gregorian   0001/01/01   9999/12/31
+        Korean      2334/01/01  12332/12/31
+        ==========  ==========  ==========
+    """
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.KOREA
+
+    def __init__(self) -> None:
+        from ._culture_info import CultureInfo
+
+        try:
+            CultureInfo("ko-KR")
+        except Exception as e:
+            raise TypeError(self.__class__.__name__) from e

--- a/pyoda_time/_compatibility/_number_format_info.py
+++ b/pyoda_time/_compatibility/_number_format_info.py
@@ -3,16 +3,29 @@
 # as found in the LICENSE.txt file.
 from __future__ import annotations
 
+import copy
+from typing import Any
+
 from pyoda_time._compatibility._culture_data import _CultureData
+from pyoda_time._compatibility._i_format_provider import IFormatProvider
 
 
-class NumberFormatInfo:
+class NumberFormatInfo(IFormatProvider):
     """Provides culture-specific information for formatting and parsing numeric values."""
 
     def __init__(self) -> None:
         self._positive_sign = "+"
         self._negative_sign = "-"
         self._is_read_only: bool = False
+
+    def __verify_writable(self) -> None:
+        if self._is_read_only:
+            raise RuntimeError("Cannot write read-only CultureInfo")
+
+    @property
+    def is_read_only(self) -> bool:
+        """Gets a value that indicates whether this ``NumberFormatInfo`` is read-only."""
+        return self._is_read_only
 
     @classmethod
     def _ctor(cls, culture_data: _CultureData) -> NumberFormatInfo:
@@ -44,6 +57,16 @@ class NumberFormatInfo:
         self.__verify_writable()
         self._negative_sign = value
 
-    def __verify_writable(self) -> None:
-        if self._is_read_only:
-            raise RuntimeError("Cannot write read-only CultureInfo")
+    @staticmethod
+    def read_only(nfi: NumberFormatInfo) -> NumberFormatInfo:
+        """Returns a read-only ``NumberFormatInfo`` wrapper."""
+        if nfi is None:
+            raise ValueError("nfi cannot be None")
+        if nfi.is_read_only:
+            return nfi
+        number_format_info = copy.copy(nfi)
+        number_format_info._is_read_only = True
+        return number_format_info
+
+    def get_format(self, format_type: type) -> Any | None:
+        raise NotImplementedError

--- a/pyoda_time/_compatibility/_persian_calendar.py
+++ b/pyoda_time/_compatibility/_persian_calendar.py
@@ -1,0 +1,25 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class PersianCalendar(Calendar):
+    """Modern Persian calendar is a solar observation based calendar. Each new year begins on the day when the vernal
+    equinox occurs before noon. The epoch is the date of the vernal equinox prior to the epoch of the Islamic calendar
+    (March 19, 622 Julian or March 22, 622 Gregorian) There is no Persian year 0. Ordinary years have 365 days. Leap
+    years have 366 days with the last month (Esfand) gaining the extra day.
+
+    Calendar support range:
+        ==========  ==========  ==========
+        Calendar    Minimum     Maximum
+        ==========  ==========  ==========
+        Gregorian   0622/03/22   9999/12/31
+        Persian     0001/01/01   9378/10/13
+        ==========  ==========  ==========
+    """
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.PERSIAN

--- a/pyoda_time/_compatibility/_taiwan_calendar.py
+++ b/pyoda_time/_compatibility/_taiwan_calendar.py
@@ -1,0 +1,33 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class TaiwanCalendar(Calendar):
+    """Taiwan calendar is based on the Gregorian calendar. And the year is an offset to Gregorian calendar.
+
+    That is:
+    Taiwan year = Gregorian year - 1911.  So 1912/01/01 A.D. is Taiwan 1/01/01
+
+    Calendar support range:
+        ==========  ==========  ==========
+        Calendar    Minimum     Maximum
+        ==========  ==========  ==========
+        Gregorian   1912/01/01  9999/12/31
+        Taiwan      01/01/01    8088/12/31
+        ==========  ==========  ==========
+    """
+
+    def __init__(self) -> None:
+        from ._culture_info import CultureInfo
+
+        try:
+            CultureInfo("zh-TW")
+        except Exception as e:
+            raise TypeError(self.__class__.__name__) from e
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.TAIWAN

--- a/pyoda_time/_compatibility/_text_info.py
+++ b/pyoda_time/_compatibility/_text_info.py
@@ -1,0 +1,31 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import final
+
+from pyoda_time._compatibility._culture_data import _CultureData
+from pyoda_time.utility import _private, _sealed
+
+
+@_sealed
+@final
+@_private
+class TextInfo:  # TODO: ICloneable, IDeserializationCallback?
+    __culture_data: _CultureData
+    __culture_name: str
+    __text_info_name: str
+
+    @classmethod
+    def _ctor(cls, culture_data: _CultureData) -> TextInfo:
+        self = cls.__new__(cls)
+        self.__culture_data = culture_data
+        self.__culture_name = culture_data._culture_name
+        self.__text_info_name = culture_data._text_info_name
+        return self
+
+    @classmethod
+    def read_only(cls, text_info: TextInfo) -> TextInfo:
+        raise NotImplementedError

--- a/pyoda_time/_compatibility/_thai_buddhist_calendar.py
+++ b/pyoda_time/_compatibility/_thai_buddhist_calendar.py
@@ -1,0 +1,22 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class ThaiBuddhistCalendar(Calendar):
+    """ThaiBuddhistCalendar is based on Gregorian calendar. Its year value has an offset to the Gregorain calendar.
+
+    Calendar support range:
+        ==========  ==========  ==========
+        Calendar    Minimum     Maximum
+        ==========  ==========  ==========
+        Gregorian   0001/01/01   9999/12/31
+        Thai        0544/01/01  10542/12/31
+        ==========  ==========  ==========
+    """
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.THAI

--- a/pyoda_time/_compatibility/_um_al_qura_calendar.py
+++ b/pyoda_time/_compatibility/_um_al_qura_calendar.py
@@ -1,0 +1,21 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time._compatibility._calendar import Calendar
+from pyoda_time._compatibility._calendar_id import _CalendarId
+
+
+class UmAlQuraCalendar(Calendar):
+    """
+    Calendar support range:
+        ==========  ==========  ==========
+        Calendar    Minimum     Maximum
+        ==========  ==========  ==========
+        Gregorian   1900/04/30  2077/05/13
+        UmAlQura    1318/01/01  1500/12/30
+        ==========  ==========  ==========
+    """
+
+    @property
+    def _id(self) -> _CalendarId:
+        return _CalendarId.UMALQURA

--- a/pyoda_time/globalization/_pattern_resources.py
+++ b/pyoda_time/globalization/_pattern_resources.py
@@ -1,25 +1,35 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-from typing import Final
+from typing import ClassVar
+
+from pyoda_time._compatibility._culture_info import CultureInfo
+
+
+class _ResourceManager:
+    __dict: ClassVar[dict[str, str]] = {
+        "Eras_AnnoHegirae": "A.H.|AH",
+        "Eras_AnnoMartyrum": "A.M.|AM",
+        "Eras_AnnoMundi": "A.M.|AM",
+        "Eras_AnnoPersico": "A.P.|AP",
+        "Eras_Bahai": "B.E.|BE",
+        "Eras_BeforeCommon": "B.C.|B.C.E.|BC|BCE",
+        "Eras_Common": "A.D.|AD|C.E.|CE",
+        "OffsetPatternLong": "+HH:mm:ss",
+        "OffsetPatternLongNoPunctuation": "+HHmmss",
+        "OffsetPatternMedium": "+HH:mm",
+        "OffsetPatternMediumNoPunctuation": "+HHmm",
+        "OffsetPatternShort": "+HH",
+        "OffsetPatternShortNoPunctuation": "+HH",
+    }
+
+    @classmethod
+    def get_string(cls, name: str, culture: CultureInfo | None) -> str | None:
+        # TODO: This is nothing like a C# ResourceManager. CultureInfo isn't used.
+        return cls.__dict.get(name)
 
 
 class _PatternResources:
-    """Constants for patterns.
+    """In Noda Time, this is a wrapper around a ResourceManager and the eponymous .resx."""
 
-    In Noda Time, this is a wrapper around a ResourceManager and the eponymous .resx.
-    """
-
-    ERAS_ANNO_HEGIRAE: Final[str] = "A.H.|AH"
-    ERAS_ANNO_MARTYRUM: Final[str] = "A.M.|AM"
-    ERAS_ANNO_MUNDI: Final[str] = "A.M.|AM"
-    ERAS_ANNO_PERSICO: Final[str] = "A.P.|AP"
-    ERAS_BAHAI: Final[str] = "B.E.|BE"
-    ERAS_BEFORE_COMMON: Final[str] = "B.C.|B.C.E.|BC|BCE"
-    ERAS_COMMON: Final[str] = "A.D.|AD|C.E.|CE"
-    OFFSET_PATTERN_LONG: Final[str] = "+HH:mm:ss"
-    OFFSET_PATTERN_LONG_NO_PUNCTUATION: Final[str] = "+HHmmss"
-    OFFSET_PATTERN_MEDIUM: Final[str] = "+HH:mm"
-    OFFSET_PATTERN_MEDIUM_NO_PUNCTUATION: Final[str] = "+HHmm"
-    OFFSET_PATTERN_SHORT: Final[str] = "+HH"
-    OFFSET_PATTERN_SHORT_NO_PUNCTUATION: Final[str] = "+HH"
+    _resource_manager: type[_ResourceManager] = _ResourceManager

--- a/pyoda_time/globalization/_pyoda_format_info.py
+++ b/pyoda_time/globalization/_pyoda_format_info.py
@@ -4,16 +4,27 @@
 
 from __future__ import annotations
 
+import threading
 import typing
 from typing import final
 
 from .._compatibility._culture_info import CultureInfo
 from .._compatibility._date_time_format_info import DateTimeFormatInfo
 from .._compatibility._i_format_provider import IFormatProvider
-from .._offset import Offset
 from ..calendars import Era
+from ..utility._cache import _Cache
 
 if typing.TYPE_CHECKING:
+    from .._duration import Duration
+    from .._instant import Instant
+    from .._local_date import LocalDate
+    from .._local_date_time import LocalDateTime
+    from .._local_time import LocalTime
+    from .._offset import Offset
+    from .._offset_date_time import OffsetDateTime
+    from .._offset_time import OffsetTime
+    from .._year_month import YearMonth
+    from .._zoned_date_time import ZonedDateTime
     from ..text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
 from ..utility import _Preconditions
 from ..utility._csharp_compatibility import _sealed
@@ -35,6 +46,34 @@ class _PyodaFormatInfoMeta(type):
 @final
 @_sealed
 class _PyodaFormatInfo(metaclass=_PyodaFormatInfoMeta):
+    """An ``IFormatProvider`` for Pyoda Time types, usually initialised from a ``CultureInfo``. This provides a single
+    place defining how Pyoda Time values are formatted and displayed, depending on the culture.
+
+    Currently, this is "shallow-immutable" - although none of these properties can be changed, the
+    CultureInfo itself may be mutable. If the CultureInfo is mutated after initialization, results are not
+    guaranteed: some aspects of the CultureInfo may be extracted at initialization time, others may be
+    extracted on first demand but cached, and others may be extracted on-demand each time.
+
+    Instances which use read-only CultureInfo instances are immutable,
+    and may be used freely between threads. Instances with mutable cultures should not be shared between threads
+    without external synchronization.
+    See the thread safety section of the user guide for more information.
+    """
+
+    # Names that we can use to check for broken Mono behaviour.
+    __SHORT_INVARIANT_MONTH_NAMES: typing.Final[typing.Sequence[str]] = list(
+        CultureInfo.invariant_culture.date_time_format.abbreviated_month_names
+    )
+    __LONG_INVARIANT_MONTH_NAMES: typing.Final[typing.Sequence[str]] = list(
+        CultureInfo.invariant_culture.date_time_format.month_names
+    )
+
+    __FIELD_LOCK: typing.Final[threading.Lock] = threading.Lock()
+
+    __CACHE: typing.Final[_Cache[CultureInfo, _PyodaFormatInfo]] = _Cache(
+        500, lambda culture: _PyodaFormatInfo(culture)
+    )
+
     def __init__(self, culture_info: CultureInfo, date_time_format: DateTimeFormatInfo | None = None) -> None:
         _Preconditions._check_not_null(culture_info, "culture_info")
         # _Preconditions._check_not_null(date_time_format, "date_time_format")
@@ -43,16 +82,297 @@ class _PyodaFormatInfo(metaclass=_PyodaFormatInfoMeta):
             culture_info.date_time_format if date_time_format is None else date_time_format
         )
         self.__era_descriptions: dict[Era, _EraDescription] = dict()
+        self.__short_month_names: list[str] | None = None
+        self.__short_month_genitive_names: list[str] | None = None
+        self.__long_month_names: list[str] | None = None
+        self.__long_month_genitive_names: list[str] | None = None
+        self.__long_day_names: list[str] | None = None
+
+        self.__duration_pattern_parser: _FixedFormatInfoPatternParser[Duration] | None = None
+        self.__offset_pattern_parser: _FixedFormatInfoPatternParser[Offset] | None = None
+        self.__instant_pattern_parser: _FixedFormatInfoPatternParser[Instant] | None = None
+        self.__local_time_pattern_parser: _FixedFormatInfoPatternParser[LocalTime] | None = None
+        self.__local_date_pattern_parser: _FixedFormatInfoPatternParser[LocalDate] | None = None
+        self.__local_date_time_pattern_parser: _FixedFormatInfoPatternParser[LocalDateTime] | None = None
+        self.__offset_date_time_pattern_parser: _FixedFormatInfoPatternParser[OffsetDateTime] | None = None
+        # TODO: self.__offset_date_pattern_parser: _FixedFormatInfoPatternParser[OffsetDate] | None = None
+        self.__offset_time_pattern_parser: _FixedFormatInfoPatternParser[OffsetTime] | None = None
+        self.__zoned_date_time_pattern_parser: _FixedFormatInfoPatternParser[ZonedDateTime] | None = None
+        # TODO: self.__annual_date_pattern_parser: _FixedFormatInfoPatternParser[AnnualDate] | None = None
+        self.__year_month_pattern_parser: _FixedFormatInfoPatternParser[YearMonth] | None = None
+
+    def __ensure_months_initialized(self) -> None:
+        if self.__long_month_names is not None:
+            return
+
+        with self.__FIELD_LOCK:
+            if self.__long_month_names is not None:
+                return
+            # Turn month names into 1-based read-only lists
+            self.__long_month_names = self.__convert_month_array(self.date_time_format.month_names)
+            self.__short_month_names = self.__convert_month_array(self.date_time_format.abbreviated_month_names)
+            self.__long_month_genitive_names = self.__convert_genitive_month_array(
+                self.__long_month_names, self.date_time_format.month_genitive_names, self.__LONG_INVARIANT_MONTH_NAMES
+            )
+            self.__short_month_genitive_names = self.__convert_genitive_month_array(
+                self.__short_month_names,
+                self.date_time_format.abbreviated_month_genitive_names,
+                self.__SHORT_INVARIANT_MONTH_NAMES,
+            )
+
+    @staticmethod
+    def __convert_month_array(month_names: typing.Sequence[str]) -> list[str]:
+        """The BCL returns arrays of month names starting at 0; we want a read-only list starting at 1 (with 0 as an
+        empty string)."""
+        return ["", *month_names]
+
+    def __ensure_days_initialized(self) -> None:
+        if self.__long_day_names is not None:
+            return
+
+        with self.__FIELD_LOCK:
+            if self.__long_day_names is not None:
+                return
+            self.__long_day_names = self.__convert_day_array(self.date_time_format.day_names)
+            self.__short_day_names = self.__convert_day_array(self.date_time_format.abbreviated_day_names)
+
+    @staticmethod
+    def __convert_day_array(day_names: list[str]) -> list[str]:
+        """The BCL returns arrays of week names starting at 0 as Sunday; we want a read-only list starting at 1 (with 0
+        as an empty string) and with 7 as Sunday."""
+        # TODO: The desired string array is what ICU (and PyICU) gives us.
+        #  If we refactor out the BCL stuff at some point, this sort of thing won't be necessary.
+        return ["", *day_names[1:], day_names[0]]
+
+    @classmethod
+    def __convert_genitive_month_array(
+        cls, non_genitive_names: list[str], bcl_names: typing.Sequence[str], invariant_names: typing.Sequence[str]
+    ) -> list[str]:
+        """Checks whether any of the genitive names differ from the non-genitive names, and returns either a reference
+        to the non-genitive names or a converted list as per ConvertMonthArray."""
+        # In Noda Time, this method works around two Mono bugs; One where genitive month names are
+        # identical to invariant month names, and another where abbreviated month names are strings
+        # containing integers.
+        #
+        # I don't anticipate that we will have those issues in Pyoda Time, but there is a test which
+        # mimics the mono behaviour and I want the Python implementation to not differ from the mother
+        # project too much at this stage. We may remove these workarounds at a later date.
+
+        # Workaround for Mono 3.0.6 returning numeric strings for genitive month names.
+        if bcl_names[0].isdigit():
+            return non_genitive_names
+
+        # Workaround for Mono using invariant genitive month names for non-invariant cultures.
+        for i in range(len(bcl_names)):
+            if bcl_names[i] != non_genitive_names[i] != invariant_names[i]:
+                return cls.__convert_month_array(bcl_names)
+
+        return non_genitive_names
 
     @property
     def culture_info(self) -> CultureInfo:
         """Gets the culture info associated with this format provider."""
         return self.__culture_info
 
+    # TODO: public CompareInfo CompareInfo => CultureInfo.CompareInfo;
+
+    @property
+    def _offset_pattern_parser(self) -> _FixedFormatInfoPatternParser[Offset]:
+        from ..text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
+        from ..text._offset_pattern_parser import _OffsetPatternParser
+
+        return _FixedFormatInfoPatternParser(_OffsetPatternParser(), self)
+
+    # TODO:
+    #  internal FixedFormatInfoPatternParser<Duration> DurationPatternParser
+    #  internal FixedFormatInfoPatternParser<Instant> InstantPatternParser
+    #  internal FixedFormatInfoPatternParser<LocalTime> LocalTimePatternParser
+    #  internal FixedFormatInfoPatternParser<LocalDate> LocalDatePatternParser
+    #  internal FixedFormatInfoPatternParser<LocalDateTime> LocalDateTimePatternParser
+    #  internal FixedFormatInfoPatternParser<OffsetDateTime> OffsetDateTimePatternParser
+    #  internal FixedFormatInfoPatternParser<OffsetDate> OffsetDatePatternParser
+    #  internal FixedFormatInfoPatternParser<OffsetTime> OffsetTimePatternParser
+    #  internal FixedFormatInfoPatternParser<ZonedDateTime> ZonedDateTimePatternParser
+    #  internal FixedFormatInfoPatternParser<AnnualDate> AnnualDatePatternParser
+    #  internal FixedFormatInfoPatternParser<YearMonth> YearMonthPatternParser
+
+    # TODO: private FixedFormatInfoPatternParser<T> EnsureFixedFormatInitialized<T>
+    #  (ref FixedFormatInfoPatternParser<T>? field, Func<IPatternParser<T>> patternParserFactory)
+
+    @property
+    def long_month_names(self) -> typing.Sequence[str]:
+        """Returns a read-only list of the names of the months for the default calendar for this culture.
+
+        See the usage guide for caveats around the use of these names for other calendars. Element 0 of the list is
+        null, to allow a more natural mapping from (say) 1 to the string "January".
+        """
+        self.__ensure_months_initialized()
+        return typing.cast(list[str], self.__long_month_names)
+
+    @property
+    def short_month_names(self) -> typing.Sequence[str]:
+        """Returns a read-only list of the abbreviated names of the months for the default calendar for this culture.
+
+        See the usage guide for caveats around the use of these names for other calendars. Element 0 of the list is
+        null, to allow a more natural mapping from (say) 1 to the string "Jan".
+        """
+        self.__ensure_months_initialized()
+        return typing.cast(list[str], self.__short_month_names)
+
+    @property
+    def long_month_genitive_names(self) -> typing.Sequence[str]:
+        """Returns a read-only list of the names of the months for the default calendar for this culture.
+
+        See the usage guide for caveats around the use of these names for other calendars.
+        Element 0 of the list is null, to allow a more natural mapping from (say) 1 to the string "January".
+        The genitive form is used for month text where the day of month also appears in the pattern.
+        If the culture does not use genitive month names, this property will return the same reference as
+        ``long_month_names``.
+        """
+        self.__ensure_months_initialized()
+        return typing.cast(list[str], self.__long_month_genitive_names)
+
+    @property
+    def short_month_genitive_names(self) -> typing.Sequence[str]:
+        """Returns a read-only list of the abbreviated names of the months for the default calendar for this culture.
+
+        See the usage guide for caveats around the use of these names for other calendars.
+        Element 0 of the list is null, to allow a more natural mapping from (say) 1 to the string "Jan".
+        The genitive form is used for month text where the day also appears in the pattern.
+        If the culture does not use genitive month names, this property will return the same reference as
+        ``short_month_names``.
+        """
+        self.__ensure_months_initialized()
+        return typing.cast(list[str], self.__short_month_genitive_names)
+
+    @property
+    def long_day_names(self) -> typing.Sequence[str]:
+        """Returns a read-only list of the names of the days of the week for the default calendar for this culture.
+
+        See the usage guide for caveats around the use of these names for other calendars.
+        Element 0 of the list is null, and the other elements correspond with the index values returned from
+        ``LocalDateTime.DayOfWeek`` and similar properties.
+        """
+        self.__ensure_days_initialized()
+        # Cast required as mypy thinks this might be None.
+        return typing.cast(list[str], self.__long_day_names)
+
+    @property
+    def short_day_names(self) -> typing.Sequence[str]:
+        """Returns a read-only list of the abbreviated names of the days of the week for the default calendar for this
+        culture.
+
+        See the usage guide for caveats around the use of these names for other calendars.
+        Element 0 of the list is null, and the other elements correspond with the index values returned from
+        ``LocalDateTime.day_of_week`` and similar properties.
+        """
+        self.__ensure_days_initialized()
+        return self.__short_day_names
+
+    @property
+    def date_time_format(self) -> DateTimeFormatInfo:
+        """Gets the BCL date time format associated with this formatting information.
+
+        This is usually the ``DateTimeFormatInfo`` from ``culture_info``,
+        but in some cases they're different: if a DateTimeFormatInfo is provided with no
+        CultureInfo, that's used for format strings but the invariant culture is used for
+        text comparisons and culture lookups for non-BCL formats (such as Offset) and for error messages.
+        """
+        return self.__date_time_format
+
     @property
     def time_separator(self) -> str:
         """Gets the time separator."""
         return self.__date_time_format.time_separator
+
+    @property
+    def date_separator(self) -> str:
+        """Gets the date separator."""
+        return self.__date_time_format.date_separator
+
+    # TODO:
+    #  public string AMDesignator => DateTimeFormat.AMDesignator;
+    #  public string PMDesignator => DateTimeFormat.PMDesignator;
+
+    def get_era_names(self, era: Era) -> list[str]:
+        """Returns the names for the given era in this culture.
+
+        :param era: The era to find the names of.
+        :return: A read-only list of names for the given era, or an empty list if the era is not known in this culture.
+        """
+        _Preconditions._check_not_null(era, "era")
+        return self.__get_era_description(era)._all_names
+
+    def get_era_primary_name(self, era: Era) -> str:
+        """Returns the primary name for the given era in this culture.
+
+        :param era: The era to find the primary name of.
+        :return: The primary name for the given era, or an empty string if the era name is not known.
+        """
+        _Preconditions._check_not_null(era, "era")
+        return self.__get_era_description(era)._primary_name
+
+    def __get_era_description(self, era: Era) -> _EraDescription:
+        with self.__FIELD_LOCK:
+            if (description := self.__era_descriptions.get(era)) is None:
+                description = self.__era_descriptions[era] = _EraDescription._for_era(era, self.culture_info)
+            return description
+
+    @property
+    def offset_pattern_long(self) -> str:
+        """Gets the ``Offset`` 'l' pattern."""
+        return typing.cast(str, _PatternResources._resource_manager.get_string("OffsetPatternLong", self.culture_info))
+
+    @property
+    def offset_pattern_medium(self) -> str:
+        """Gets the ``Offset`` 'm' pattern."""
+        return typing.cast(
+            str, _PatternResources._resource_manager.get_string("OffsetPatternMedium", self.culture_info)
+        )
+
+    @property
+    def offset_pattern_short(self) -> str:
+        """Gets the ``Offset`` 's' pattern."""
+        return typing.cast(str, _PatternResources._resource_manager.get_string("OffsetPatternShort", self.culture_info))
+
+    @property
+    def offset_pattern_long_no_punctuation(self) -> str:
+        """Gets the ``Offset`` 'L' pattern."""
+        return typing.cast(
+            str, _PatternResources._resource_manager.get_string("OffsetPatternLongNoPunctuation", self.culture_info)
+        )
+
+    @property
+    def offset_pattern_medium_no_punctuation(self) -> str:
+        """Gets the ``Offset`` 'M' pattern."""
+        return typing.cast(
+            str, _PatternResources._resource_manager.get_string("OffsetPatternMediumNoPunctuation", self.culture_info)
+        )
+
+    @property
+    def offset_pattern_short_no_punctuation(self) -> str:
+        """Gets the ``Offset`` 'S' pattern."""
+        return typing.cast(
+            str, _PatternResources._resource_manager.get_string("OffsetPatternShortNoPunctuation", self.culture_info)
+        )
+
+    @classmethod
+    def _clear_cache(cls) -> None:
+        """Clears the cache.
+
+        Only used for test purposes.
+        """
+        cls.__CACHE.clear()
+
+    @classmethod
+    def _get_format_info(cls, culture_info: CultureInfo) -> _PyodaFormatInfo:
+        """Gets the ``_PyodaFormatInfo`` for the given ``CultureInfo``."""
+        _Preconditions._check_not_null(culture_info, "culture_info")
+        if culture_info == CultureInfo.invariant_culture:
+            return _PyodaFormatInfo.invariant_info
+        if not culture_info.is_read_only:
+            return _PyodaFormatInfo(culture_info)
+        return cls.__CACHE.get_or_add(culture_info)
 
     @classmethod
     def get_instance(cls, provider: IFormatProvider | None) -> _PyodaFormatInfo:
@@ -65,65 +385,61 @@ class _PyodaFormatInfo(metaclass=_PyodaFormatInfoMeta):
         /// resource lookups. Otherwise, ``ValueError`` is thrown.
         """
         if provider is None:
-            return cls.get_format_info(cls.current_info.culture_info)
+            return cls._get_format_info(cls.current_info.culture_info)
         if isinstance(provider, CultureInfo):
-            return cls.get_format_info(provider)
+            return cls._get_format_info(provider)
         if isinstance(provider, DateTimeFormatInfo):
             return _PyodaFormatInfo(CultureInfo.invariant_culture, provider)
         raise ValueError(f"Cannot use provider of type {type(provider).__name__} in Pyoda Time")
 
     def __str__(self) -> str:
-        return f"PyodaFormatInfo[{self.__culture_info._name}]"
-
-    @property
-    def offset_pattern_parser(self) -> _FixedFormatInfoPatternParser[Offset]:
-        from ..text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
-        from ..text._offset_pattern_parser import _OffsetPatternParser
-
-        return _FixedFormatInfoPatternParser[Offset](_OffsetPatternParser(), self)
-
-    @property
-    def offset_pattern_long(self) -> str:
-        """Gets the ``Offset`` 'l' pattern."""
-        return _PatternResources.OFFSET_PATTERN_LONG
-
-    @property
-    def offset_pattern_medium(self) -> str:
-        """Gets the ``Offset`` 'm' pattern."""
-        return _PatternResources.OFFSET_PATTERN_MEDIUM
-
-    @property
-    def offset_pattern_short(self) -> str:
-        """Gets the ``Offset`` 's' pattern."""
-        return _PatternResources.OFFSET_PATTERN_SHORT
-
-    @property
-    def offset_pattern_long_no_punctuation(self) -> str:
-        """Gets the ``Offset`` 'L' pattern."""
-        return _PatternResources.OFFSET_PATTERN_LONG_NO_PUNCTUATION
-
-    @property
-    def offset_pattern_medium_no_punctuation(self) -> str:
-        """Gets the ``Offset`` 'M' pattern."""
-        return _PatternResources.OFFSET_PATTERN_MEDIUM_NO_PUNCTUATION
-
-    @property
-    def offset_pattern_short_no_punctuation(self) -> str:
-        """Gets the ``Offset`` 'S' pattern."""
-        return _PatternResources.OFFSET_PATTERN_SHORT_NO_PUNCTUATION
-
-    @classmethod
-    def get_format_info(cls, culture_info: CultureInfo) -> _PyodaFormatInfo:
-        """Gets the ``_PyodaFormatInfo`` for the given ``CultureInfo``."""
-        _Preconditions._check_not_null(culture_info, "culture_info")
-        if culture_info == CultureInfo.invariant_culture:
-            return _PyodaFormatInfo.invariant_info
-        # TODO: This is simplified to ignore caching and read-only cultures for now...
-        return _PyodaFormatInfo(culture_info)
+        """Returns a string that represents this instance."""
+        return f"PyodaFormatInfo[{self.__culture_info.name}]"
 
 
 class _EraDescription:
     """The description for an era: the primary name and all possible names."""
 
-    # TODO: EraDescription
-    pass
+    def __init__(self, primary_name: str, all_names: list[str]) -> None:
+        self._primary_name = primary_name
+        self._all_names = all_names
+
+    @classmethod
+    def _for_era(cls, era: Era, culture_info: CultureInfo) -> _EraDescription:
+        pipe_delimited = _PatternResources._resource_manager.get_string(era._resource_identifier, culture_info)
+        all_names: list[str] = []
+        primary_name: str = ""
+
+        if pipe_delimited:
+            # If the BCL has provided an era name other than the one we'd consider
+            # to be the primary one, make *that* the primary one for formatting.
+            era_name_from_culture = cls.__get_era_name_from_bcl(era, culture_info)
+            if era_name_from_culture and not pipe_delimited.startswith(era_name_from_culture + "|"):
+                pipe_delimited = f"{era_name_from_culture}|{pipe_delimited}"
+            all_names = pipe_delimited.split("|")
+            primary_name = all_names[0]
+            # Order by length, descending to avoid early out
+            # (e.g. parsing BCE as BC and then having a spare E)
+            all_names = sorted(all_names, key=lambda x: len(x), reverse=True)
+
+        return _EraDescription(primary_name, all_names)
+
+    @classmethod
+    def __get_era_name_from_bcl(cls, era: Era, culture: CultureInfo) -> str | None:
+        from pyoda_time._compatibility._gregorian_calendar import GregorianCalendar
+        from pyoda_time._compatibility._hijri_calendar import HijriCalendar
+        from pyoda_time._compatibility._persian_calendar import PersianCalendar
+        from pyoda_time._compatibility._um_al_qura_calendar import UmAlQuraCalendar
+
+        calendar = culture.date_time_format.calendar
+
+        get_era_from_calendar: bool = (
+            (era == Era.common and isinstance(calendar, GregorianCalendar))
+            or (era == Era.anno_persico and isinstance(calendar, PersianCalendar))
+            or (era == Era.anno_hegirae and isinstance(calendar, (HijriCalendar, UmAlQuraCalendar)))
+        )
+
+        if get_era_from_calendar:
+            # TODO: implement DateTimeFormat.GetEraName()
+            raise NotImplementedError("DateTimeFormat.GetEraName() not implemented")
+        return None

--- a/pyoda_time/text/_fixed_format_info_pattern_parser.py
+++ b/pyoda_time/text/_fixed_format_info_pattern_parser.py
@@ -22,6 +22,7 @@ class _FixedFormatInfoPatternParser(Generic[T]):
     def __init__(self, pattern_parser: _IPatternParser[T], format_info: _PyodaFormatInfo) -> None:
         self.__pattern_parser = pattern_parser
         self.__format_info = format_info
+        # TODO: Noda Time uses the Cache class from utility here...
         self.__cache: Final[dict[str, IPattern[T]]] = dict()
 
     def _parse_pattern(self, pattern: str) -> IPattern[T]:

--- a/pyoda_time/text/_offset_pattern.py
+++ b/pyoda_time/text/_offset_pattern.py
@@ -24,7 +24,7 @@ class _OffsetPatternMeta(type):
     @cache
     def _bcl_support(self) -> _PatternBclSupport[Offset]:
         def pattern_parser(format_info: _PyodaFormatInfo) -> _FixedFormatInfoPatternParser[Offset]:
-            return format_info.offset_pattern_parser
+            return format_info._offset_pattern_parser
 
         return _PatternBclSupport(
             OffsetPattern._DEFAULT_FORMAT_PATTERN,
@@ -114,8 +114,8 @@ class OffsetPattern(IPattern[Offset], metaclass=_CombinedMeta):
         _Preconditions._check_not_null(pattern_text, "pattern_text")
         _Preconditions._check_not_null(format_info, "format_info")
         if isinstance(format_info, CultureInfo):
-            format_info = _PyodaFormatInfo.get_format_info(format_info)
-        pattern = cast(_IPartialPattern[Offset], format_info.offset_pattern_parser._parse_pattern(pattern_text))
+            format_info = _PyodaFormatInfo._get_format_info(format_info)
+        pattern = cast(_IPartialPattern[Offset], format_info._offset_pattern_parser._parse_pattern(pattern_text))
         return OffsetPattern(pattern_text, pattern)
 
     @classmethod
@@ -165,4 +165,4 @@ class OffsetPattern(IPattern[Offset], metaclass=_CombinedMeta):
         :param culture_info: The culture to use in the new pattern.
         :return: A new pattern with the given culture.
         """
-        return self._create(self.pattern_text, _PyodaFormatInfo.get_format_info(culture_info))
+        return self._create(self.pattern_text, _PyodaFormatInfo._get_format_info(culture_info))

--- a/pyoda_time/utility/_cache.py
+++ b/pyoda_time/utility/_cache.py
@@ -1,0 +1,70 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from collections import deque
+from threading import Lock
+from typing import Callable, Final, Generic, TypeVar, final
+
+from pyoda_time.utility import _sealed
+
+TKey = TypeVar("TKey")
+TValue = TypeVar("TValue")
+
+
+@_sealed
+@final
+class _Cache(Generic[TKey, TValue]):
+    """Implements a thread-safe cache with a single computation function.
+
+    For simplicity's sake, eviction is currently on a least-recently-added basis (not LRU). This may change in the
+    future.
+    """
+
+    # TODO: IEqualityComparer?
+    def __init__(self, size: int, value_factory: Callable[[TKey], TValue]) -> None:
+        self.__size: Final[int] = size
+        self.__value_factory: Final[Callable[[TKey], TValue]] = value_factory
+        self.__lock: Final[Lock] = Lock()
+        self.__key_list: Final[deque] = deque()  # For eviction tracking
+        self.__dictionary: Final[dict[TKey, TValue]] = {}  # Main storage
+
+    def get_or_add(self, key: TKey) -> TValue:
+        """Fetches a value from the cache, populating it if necessary.
+
+        :param key: Key to fetch
+        :return: The value associated with the key.
+        """
+        with self.__lock:
+            if key in self.__dictionary:
+                return self.__dictionary[key]
+            # If not in the dictionary, prepare to add it
+            self.__key_list.append(key)
+            if key not in self.__dictionary:  # Check again to avoid race conditions
+                self.__dictionary[key] = self.__value_factory(key)
+
+            # Evict if necessary
+            while len(self.__dictionary) > self.__size:
+                evict_key = self.__key_list.popleft()
+                if evict_key in self.__dictionary:
+                    del self.__dictionary[evict_key]
+
+            return self.__dictionary[key]
+
+    def count(self) -> int:
+        """Returns the number of entries currently in the cache, primarily for diagnostic purposes."""
+        with self.__lock:
+            return len(self.__dictionary)
+
+    def keys(self) -> list[TKey]:
+        """Returns a copy of the keys in the cache as a list, for diagnostic purposes."""
+        with self.__lock:
+            return list(self.__dictionary.keys())
+
+    def clear(self) -> None:
+        """Clears the cache.
+
+        This is never surfaced publicly (directly or indirectly) - it's just for testing.
+        """
+        with self.__lock:
+            self.__key_list.clear()
+            self.__dictionary.clear()

--- a/tests/culture_saver.py
+++ b/tests/culture_saver.py
@@ -21,13 +21,11 @@ class _BothSaver(ContextManager):
 
     @property
     def __current_ui_culture(self) -> CultureInfo:
-        # TODO: fix or remove this - it's only here for completeness sake
-        return CultureInfo.invariant_culture
+        return CultureInfo.current_ui_culture
 
     @__current_ui_culture.setter
     def __current_ui_culture(self, value: CultureInfo) -> None:
-        # TODO: fix or remove this - it's only here for completeness sake
-        CultureInfo.current_culture = value
+        CultureInfo.current_ui_culture = value
 
     def __init__(self, new_culture: CultureInfo, new_ui_culture: CultureInfo) -> None:
         self.__old_culture = self.__current_culture
@@ -60,10 +58,15 @@ class CultureSaver:
     """
 
     @classmethod
-    def set_cultures(cls, new_culture_info: CultureInfo) -> ContextManager:
+    def set_cultures(
+        cls, new_culture_info: CultureInfo, new_ui_culture_info: CultureInfo | None = None
+    ) -> ContextManager:
         """Sets both the UI and basic cultures of the current thread.
 
         :param new_culture_info: The new culture info.
+        :param new_ui_culture_info: The new ui culture info.
         :return: A context manager which temporarily sets the current culture, then resets the culture upon exit.
         """
-        return _BothSaver(new_culture_info, new_culture_info)
+        if new_ui_culture_info is None:
+            new_ui_culture_info = new_culture_info
+        return _BothSaver(new_culture_info, new_ui_culture_info)

--- a/tests/globalization/__init__.py
+++ b/tests/globalization/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.

--- a/tests/globalization/failing_culture_info.py
+++ b/tests/globalization/failing_culture_info.py
@@ -1,0 +1,65 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Final
+
+from pyoda_time._compatibility._culture_info import CultureInfo, __CombinedMeta
+from pyoda_time._compatibility._date_time_format_info import DateTimeFormatInfo
+from pyoda_time._compatibility._number_format_info import NumberFormatInfo
+
+
+class _FailingCultureInfoMeta(type):
+    __lock: Final[threading.Lock] = threading.Lock()
+    __instance: FailingCultureInfo | None = None
+
+    @property
+    def instance(self) -> FailingCultureInfo:
+        if self.__instance is None:
+            with self.__lock:
+                if self.__instance is None:
+                    self.__instance = FailingCultureInfo()
+        return self.__instance
+
+
+class _CombinedMeta(_FailingCultureInfoMeta, __CombinedMeta):
+    pass
+
+
+class FailingCultureInfo(CultureInfo, metaclass=_CombinedMeta):
+    """Throws an exception if called.
+
+    This forces the testing code to set or pass a valid culture in all tests. The tests cannot be guaranteed to work if
+    the culture is not set as formatting and parsing are culture dependent.
+    """
+
+    __CULTURE_NOT_SET: Final[str] = "The formatting and parsing code tests should have set the correct culture."
+
+    def __init__(self) -> None:
+        super().__init__("en-US")
+
+    @property
+    def date_time_format(self) -> DateTimeFormatInfo:
+        raise NotImplementedError(self.__CULTURE_NOT_SET)
+
+    @date_time_format.setter
+    def date_time_format(self, value: DateTimeFormatInfo) -> None:
+        raise NotImplementedError(self.__CULTURE_NOT_SET)
+
+    @property
+    def number_format(self) -> NumberFormatInfo:
+        raise NotImplementedError(self.__CULTURE_NOT_SET)
+
+    @number_format.setter
+    def number_format(self, value: NumberFormatInfo) -> None:
+        raise NotImplementedError(self.__CULTURE_NOT_SET)
+
+    @property
+    def name(self) -> str:
+        return "Failing"
+
+    def get_format(self, format_type: type) -> Any | None:
+        raise NotImplementedError(self.__CULTURE_NOT_SET)

--- a/tests/globalization/test_pyoda_format_info.py
+++ b/tests/globalization/test_pyoda_format_info.py
@@ -1,0 +1,199 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Final
+
+import pytest
+
+from pyoda_time._compatibility._culture_info import CultureInfo
+from pyoda_time._compatibility._date_time_format_info import DateTimeFormatInfo
+from pyoda_time.calendars import Era
+from pyoda_time.globalization import _PyodaFormatInfo
+
+from ..culture_saver import CultureSaver
+from ..globalization.failing_culture_info import FailingCultureInfo
+from ..text.cultures import Cultures
+
+EN_US: Final[CultureInfo] = CultureInfo.get_culture_info("en-US")
+EN_GB: Final[CultureInfo] = CultureInfo.get_culture_info("en-GB")
+
+
+class TestPyodaFormatInfo:
+    @pytest.mark.parametrize(
+        "culture", sorted(Cultures.all_cultures, key=lambda c: c._name), ids=lambda culture: f"{culture=}"
+    )
+    def test_convert_culture(self, culture: CultureInfo) -> None:
+        """Just check we can actually build a NodaFormatInfo for every culture, outside text-specific tests."""
+        _PyodaFormatInfo._get_format_info(culture)
+
+    def test_caching_with_read_only(self) -> None:
+        original = CultureInfo("en-US")
+        # Use a read-only wrapper so that it gets cached
+        wrapper = CultureInfo.read_only(original)
+
+        pyoda_wrapper_1 = _PyodaFormatInfo._get_format_info(wrapper)
+        pyoda_wrapper_2 = _PyodaFormatInfo._get_format_info(wrapper)
+        assert pyoda_wrapper_1 is pyoda_wrapper_2
+
+    def test_caching_with_cloned_culture(self) -> None:
+        original = CultureInfo("en-US")
+        clone = original.clone()
+        assert original._name == clone._name
+        day_names = clone.date_time_format.day_names
+        day_names[1] = "@@@"
+        clone.date_time_format.day_names = day_names
+
+        # Fool Pyoda Time into believing both are read-only, so it can use a cache...
+        original = CultureInfo.read_only(original)
+        clone = CultureInfo.read_only(clone)
+
+        pyoda_original = _PyodaFormatInfo._get_format_info(original)
+        pyoda_clone = _PyodaFormatInfo._get_format_info(clone)
+        assert original.date_time_format.day_names[1] == pyoda_original.long_day_names[1] == "Monday"
+        assert clone.date_time_format.day_names[1] == pyoda_clone.long_day_names[1] == "@@@"
+        # Just check we made a difference...
+        assert pyoda_original.long_day_names[1] != pyoda_clone.long_day_names[1]
+
+    def test_constructor(self) -> None:
+        info = _PyodaFormatInfo(EN_US)
+        assert EN_US is info.culture_info
+        assert info.date_time_format is not None
+        assert info.time_separator == ":"
+        assert info.date_separator == "/"
+        assert isinstance(info.offset_pattern_long, str)
+        assert isinstance(info.offset_pattern_medium, str)
+        assert isinstance(info.offset_pattern_short, str)
+        assert str(info) == "PyodaFormatInfo[en-US]"
+
+    def test_constructor_null(self) -> None:
+        with pytest.raises(TypeError):
+            _PyodaFormatInfo(None)  # type: ignore
+
+    def test_date_time_format(self) -> None:
+        date_time_format = DateTimeFormatInfo.invariant_info
+        info = _PyodaFormatInfo(EN_US)
+        assert info.date_time_format != date_time_format
+
+    def test_get_format_info(self) -> None:
+        _PyodaFormatInfo._clear_cache()
+        info_1 = _PyodaFormatInfo._get_format_info(EN_US)
+        assert info_1 is not None
+
+        info_2 = _PyodaFormatInfo._get_format_info(EN_US)
+        assert info_1 is info_2
+
+        info_3 = _PyodaFormatInfo._get_format_info(EN_GB)
+        assert info_1 is not info_3
+
+    def test_get_format_info_null(self) -> None:
+        _PyodaFormatInfo._clear_cache()
+        with pytest.raises(TypeError):
+            _PyodaFormatInfo._get_format_info(None)  # type: ignore
+
+    def test_get_instance_culture_info(self) -> None:
+        _PyodaFormatInfo._clear_cache()
+        with CultureSaver.set_cultures(EN_US, FailingCultureInfo.instance):
+            actual = _PyodaFormatInfo.get_instance(EN_GB)
+            assert actual.culture_info is EN_GB
+
+    def test_get_instance_unusable_type(self) -> None:
+        _PyodaFormatInfo._clear_cache()
+        with pytest.raises(ValueError) as e:
+            _PyodaFormatInfo.get_instance(CultureInfo.invariant_culture.number_format)
+        assert str(e.value) == "Cannot use provider of type NumberFormatInfo in Pyoda Time"
+
+    def test_get_instance_date_time_format_info(self) -> None:
+        _PyodaFormatInfo._clear_cache()
+        with CultureSaver.set_cultures(EN_US, FailingCultureInfo.instance):
+            info = _PyodaFormatInfo.get_instance(EN_GB.date_time_format)
+            assert info.date_time_format == EN_GB.date_time_format
+            assert info.culture_info == CultureInfo.invariant_culture
+
+    def test_get_instance_null(self) -> None:
+        _PyodaFormatInfo._clear_cache()
+        with CultureSaver.set_cultures(EN_US, FailingCultureInfo.instance):
+            info = _PyodaFormatInfo.get_instance(None)
+            assert info.culture_info == CultureInfo.current_culture == EN_US
+        with CultureSaver.set_cultures(EN_GB, FailingCultureInfo.instance):
+            info = _PyodaFormatInfo.get_instance(None)
+            assert info.culture_info == CultureInfo.current_culture == EN_GB
+
+    def test_offset_pattern_long(self) -> None:
+        pattern = "This is a test"
+        info = _PyodaFormatInfo(EN_US)
+        assert info.offset_pattern_long != pattern
+
+    def test_offset_pattern_medium(self) -> None:
+        pattern = "This is a test"
+        info = _PyodaFormatInfo(EN_US)
+        assert info.offset_pattern_medium != pattern
+
+    def test_offset_pattern_short(self) -> None:
+        pattern = "This is a test"
+        info = _PyodaFormatInfo(EN_US)
+        assert info.offset_pattern_short != pattern
+
+    def test_get_era_names(self) -> None:
+        info = _PyodaFormatInfo._get_format_info(EN_US)
+        names = info.get_era_names(Era.before_common)
+        assert names == ["B.C.E.", "B.C.", "BCE", "BC"]
+
+    def test_get_era_names_no_such_era(self) -> None:
+        info = _PyodaFormatInfo._get_format_info(EN_US)
+        names = info.get_era_names(Era._ctor("Ignored", "NonExistentResource"))
+        assert len(names) == 0
+
+    def test_get_era_names_null(self) -> None:
+        info = _PyodaFormatInfo._get_format_info(EN_US)
+        with pytest.raises(TypeError):
+            info.get_era_names(None)  # type: ignore
+
+    def test_get_era_primary_name(self) -> None:
+        info = _PyodaFormatInfo._get_format_info(EN_US)
+        assert info.get_era_primary_name(Era.before_common) == "B.C."
+
+    def test_get_era_primary_name_no_such_era(self) -> None:
+        info = _PyodaFormatInfo._get_format_info(EN_US)
+        assert info.get_era_primary_name(Era._ctor("Ignored", "NonExistentResource")) == ""
+
+    def test_era_get_primary_name_null(self) -> None:
+        info = _PyodaFormatInfo._get_format_info(EN_US)
+        with pytest.raises(TypeError):
+            info.get_era_primary_name(None)  # type: ignore
+
+    def test_integer_genitive_month_names(self) -> None:
+        # Emulate behaviour of Mono 3.0.6
+        culture: CultureInfo = CultureInfo.invariant_culture.clone()
+        culture.date_time_format.month_genitive_names = [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+        ]
+        culture.date_time_format.abbreviated_month_genitive_names = [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+        ]
+        info = _PyodaFormatInfo._get_format_info(culture)
+        assert info.long_month_names == info.long_month_genitive_names
+        assert info.short_month_names == info.short_month_genitive_names

--- a/tests/text/cultures.py
+++ b/tests/text/cultures.py
@@ -1,13 +1,21 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-from typing import Final
+from typing import Final, Iterable
 
 from pyoda_time._compatibility._culture_info import CultureInfo
+from pyoda_time._compatibility._culture_types import CultureTypes
 
 
 class _CulturesMeta(type):
     __cache: Final[dict[str, CultureInfo]] = {}
+
+    @property
+    def all_cultures(cls) -> Iterable[CultureInfo]:
+        """Force the cultures to be read-only for tests, to take advantage of caching."""
+        # In Pyoda Time, there is some special casing for cultures which
+        # don't behave as expected on Mono and dotnet core.
+        return [CultureInfo.read_only(culture) for culture in CultureInfo.get_cultures(CultureTypes.SPECIFIC_CULTURES)]
 
     @classmethod
     def __get_or_create(cls, name: str) -> CultureInfo:


### PR DESCRIPTION
(...or at least as much as is required for a port of NodaFormatInfoTest.)

Having `_PyodaFormatInfo`, along with the required .NET/ICU plumbing (of which there is a lot here, and more to follow), will enable me to port more of the stuff I am actually interested in.