### PR TITLE
build: enable mypy strict mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ default_language_version:
 repos:
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v3.18.0
+    rev: v3.20.0
     hooks:
       - id: commitizen
         stages:
@@ -27,7 +27,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.1
+    rev: v0.3.4
     hooks:
       - id: ruff
         args: [--fix]
@@ -41,7 +41,10 @@ repos:
         args: ["--in-place", "--config", "./pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.8.0'
+    rev: 'v1.9.0'
     hooks:
     -   id: mypy
-        additional_dependencies: [types-pytz==2023.3.1.1]
+        additional_dependencies: [
+          types-pytz==2023.3.1.1,
+          pytest,
+        ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,9 @@ def skip_default_special_methods(app: Sphinx, what: str, name: str, obj: Any, sk
     return skip
 
 
-def process_metaclass_properties(app: Sphinx, what: str, name: str, obj: Any, options: dict, lines: list[str]) -> None:
+def process_metaclass_properties(
+    app: Sphinx, what: str, name: str, obj: Any, options: dict[str, Any], lines: list[str]
+) -> None:
     """Custom handler for autodoc-process-docstring event to process 'class properties' defined in a metaclass."""
 
     if what == "class" and hasattr(obj, "__class__"):

--- a/pyoda_time/__init__.py
+++ b/pyoda_time/__init__.py
@@ -3,8 +3,12 @@
 # as found in the LICENSE.txt file.
 
 __all__: list[str] = [
-    # Do not include sub-packages like calendars in this list.
-    # They should not be imported automatically via `import *`.
+    "calendars",
+    "fields",
+    "globalization",
+    "text",
+    "time_zones",
+    "utility",
     "CalendarSystem",
     "DateAdjusters",
     "DateInterval",
@@ -28,12 +32,12 @@ __all__: list[str] = [
 
 
 from . import (
-    calendars,  # noqa: F401
-    fields,  # noqa: F401
-    globalization,  # noqa: F401
-    text,  # noqa: F401
-    time_zones,  # noqa: F401
-    utility,  # noqa: F401
+    calendars,
+    fields,
+    globalization,
+    text,
+    time_zones,
+    utility,
 )
 from ._calendar_system import CalendarSystem
 from ._date_adjusters import DateAdjusters

--- a/pyoda_time/_calendar_system.py
+++ b/pyoda_time/_calendar_system.py
@@ -6,12 +6,18 @@ from __future__ import annotations
 
 import typing
 
-from .calendars import (
-    _CopticYearMonthDayCalculator,
-    _JulianYearMonthDayCalculator,
-    _PersianYearMonthDayCalculator,
-    _UmAlQuraYearMonthDayCalculator,
-)
+from .calendars._badi_year_month_day_calculator import _BadiYearMonthDayCalculator
+from .calendars._coptic_year_month_day_calculator import _CopticYearMonthDayCalculator
+from .calendars._era_calculator import _EraCalculator
+from .calendars._g_j_era_calculator import _GJEraCalculator
+from .calendars._gregorian_year_month_day_calculator import _GregorianYearMonthDayCalculator
+from .calendars._hebrew_year_month_day_calculator import _HebrewYearMonthDayCalculator
+from .calendars._islamic_year_month_day_calculator import _IslamicYearMonthDayCalculator
+from .calendars._julian_year_month_day_calculator import _JulianYearMonthDayCalculator
+from .calendars._persian_year_month_day_calculator import _PersianYearMonthDayCalculator
+from .calendars._single_era_calculator import _SingleEraCalculator
+from .calendars._um_al_qura_year_month_day_calculator import _UmAlQuraYearMonthDayCalculator
+from .calendars._year_month_day_calculator import _YearMonthDayCalculator
 
 if typing.TYPE_CHECKING:
     from ._year_month_day import _YearMonthDay
@@ -19,7 +25,8 @@ if typing.TYPE_CHECKING:
 
 from ._calendar_ordinal import _CalendarOrdinal
 from ._iso_day_of_week import IsoDayOfWeek
-from .utility import _csharp_modulo, _Preconditions, _private, _sealed
+from .utility._csharp_compatibility import _csharp_modulo, _private, _sealed
+from .utility._preconditions import _Preconditions
 
 __all__ = ["CalendarSystem"]
 from .calendars import (
@@ -27,14 +34,6 @@ from .calendars import (
     HebrewMonthNumbering,
     IslamicEpoch,
     IslamicLeapYearPattern,
-    _BadiYearMonthDayCalculator,
-    _EraCalculator,
-    _GJEraCalculator,
-    _GregorianYearMonthDayCalculator,
-    _HebrewYearMonthDayCalculator,
-    _IslamicYearMonthDayCalculator,
-    _SingleEraCalculator,
-    _YearMonthDayCalculator,
 )
 
 

--- a/pyoda_time/_compatibility/_calendar_data.py
+++ b/pyoda_time/_compatibility/_calendar_data.py
@@ -13,7 +13,7 @@ from icu import DateFormat, DateFormatSymbols, DateTimePatternGenerator, Locale
 from pyoda_time._compatibility._calendar_id import _CalendarId
 from pyoda_time._compatibility._globalization_mode import _GlobalizationMode
 from pyoda_time._compatibility._string_builder import StringBuilder
-from pyoda_time.utility import _sealed
+from pyoda_time.utility._csharp_compatibility import _sealed
 
 
 class _CalendarDataType(IntEnum):
@@ -200,17 +200,17 @@ class _CalendarData(metaclass=_CalendarDataMeta):
                 if are_era_names_empty():
                     self._saEraNames = ["A.D."]
             # The rest of the calendars have constant data, so we'll just use that
-            case _CalendarId.GREGORIAN_US, _CalendarId.JULIAN:
+            case _CalendarId.GREGORIAN_US | _CalendarId.JULIAN:
                 self._saEraNames = ["A.D."]
             case _CalendarId.HEBREW:
                 self._saEraNames = ["C.E."]
-            case _CalendarId.HIJRI, _CalendarId.UMALQURA:
+            case _CalendarId.HIJRI | _CalendarId.UMALQURA:
                 if locale_name == "dv-MV":
                     # Special case for Divehi
                     self._saEraNames = ["\u0780\u07a8\u0796\u07b0\u0783\u07a9"]
                 else:
                     self._saEraNames = ["\u0628\u0639\u062f \u0627\u0644\u0647\u062c\u0631\u0629"]
-            case _CalendarId.GREGORIAN_ARABIC, _CalendarId.GREGORIAN_XLIT_ENGLISH, _CalendarId.GREGORIAN_XLIT_FRENCH:
+            case _CalendarId.GREGORIAN_ARABIC | _CalendarId.GREGORIAN_XLIT_ENGLISH | _CalendarId.GREGORIAN_XLIT_FRENCH:
                 # These are all the same:
                 self._saEraNames = ["\u0645"]
             case _CalendarId.GREGORIAN_ME_FRENCH:
@@ -224,7 +224,7 @@ class _CalendarData(metaclass=_CalendarDataMeta):
                 self._saEraNames = ["\ub2e8\uae30"]
             case _CalendarId.THAI:
                 self._saEraNames = ["\u0e1e\u002e\u0e28\u002e"]
-            case _CalendarId.JAPAN, _CalendarId.JAPANESELUNISOLAR:
+            case _CalendarId.JAPAN | _CalendarId.JAPANESELUNISOLAR:
                 from pyoda_time._compatibility._japanese_calendar import JapaneseCalendar
 
                 self._saEraNames = JapaneseCalendar._era_names()
@@ -263,14 +263,14 @@ class _CalendarData(metaclass=_CalendarDataMeta):
                         index += 1
                         if current == "'":
                             break
-                case "E", "e", "c":
+                case "E" | "e" | "c":
                     # 'E' in ICU is the day of the week, which maps to 3 or 4 'd's in .NET
                     # 'e' in ICU is the local day of the week, which has no representation in .NET, but
                     # maps closest to 3 or 4 'd's in .NET
                     # 'c' in ICU is the stand-alone day of the week, which has no representation in .NET, but
                     # maps closest to 3 or 4 'd's in .NET
                     index = cls.__normalize_day_of_week(date_pattern, destination, index)
-                case "L", "M":
+                case "L" | "M":
                     # 'L' in ICU is the stand-alone name of the month,
                     # which maps closest to 'M' in .NET since it doesn't support stand-alone month names in patterns
                     # 'M' in both ICU and .NET is the month,

--- a/pyoda_time/_compatibility/_culture_data.py
+++ b/pyoda_time/_compatibility/_culture_data.py
@@ -414,7 +414,7 @@ class _CultureData(metaclass=_CultureDataMeta):
                             index_of_extensions = index
         return True, index_of_underscore, index_of_extensions
 
-    def __deepcopy__(self, memo: dict) -> _CultureData:
+    def __deepcopy__(self, memo: dict[int, typing.Any]) -> _CultureData:
         """Implementation to support CultureInfo.clone(), so we can copy.deepcopy(some_culture_info)
 
         icu.Locale is not pickleable, so we need to handle it manually.

--- a/pyoda_time/_compatibility/_gregorian_calendar_helper.py
+++ b/pyoda_time/_compatibility/_gregorian_calendar_helper.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 from typing import final
 
-from pyoda_time.utility import _sealed
+from pyoda_time.utility._csharp_compatibility import _sealed
 
 
 @_sealed
@@ -27,7 +27,7 @@ class _EraInfo:
         self._year_offset = year_offset
         self._min_era_year = min_era_year
         self._max_era_year = max_era_year
-        from pyoda_time.utility import _to_ticks
+        from pyoda_time.utility._csharp_compatibility import _to_ticks
 
         self._ticks = _to_ticks(datetime(start_year, start_month, start_day))
         self._era_name = era_name

--- a/pyoda_time/_compatibility/_text_info.py
+++ b/pyoda_time/_compatibility/_text_info.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import final
 
 from pyoda_time._compatibility._culture_data import _CultureData
-from pyoda_time.utility import _private, _sealed
+from pyoda_time.utility._csharp_compatibility import _private, _sealed
 
 
 @_sealed

--- a/pyoda_time/_date_interval.py
+++ b/pyoda_time/_date_interval.py
@@ -9,7 +9,8 @@ import typing
 if typing.TYPE_CHECKING:
     from . import LocalDate
 
-from .utility import _Preconditions, _sealed
+from .utility._csharp_compatibility import _sealed
+from .utility._preconditions import _Preconditions
 
 __all__ = ["DateInterval"]
 

--- a/pyoda_time/_date_time_zone.py
+++ b/pyoda_time/_date_time_zone.py
@@ -8,7 +8,7 @@ import abc
 import functools
 import typing
 
-from .utility import _Preconditions
+from .utility._preconditions import _Preconditions
 
 if typing.TYPE_CHECKING:
     from . import Instant, Offset
@@ -31,7 +31,7 @@ class _DateTimeZoneMeta(abc.ABCMeta):
         :return: The UTC ``DateTimeZone``.
         """
         from . import Offset
-        from .time_zones import _FixedDateTimeZone
+        from .time_zones._fixed_date_time_zone import _FixedDateTimeZone
 
         return _FixedDateTimeZone(Offset.zero)
 

--- a/pyoda_time/_duration.py
+++ b/pyoda_time/_duration.py
@@ -9,7 +9,9 @@ import decimal
 import typing
 
 from ._pyoda_constants import PyodaConstants
-from .utility import _csharp_modulo, _Preconditions, _sealed, _TickArithmetic, _towards_zero_division
+from .utility._csharp_compatibility import _csharp_modulo, _sealed, _towards_zero_division
+from .utility._preconditions import _Preconditions
+from .utility._tick_arithmetic import _TickArithmetic
 
 __all__ = ["Duration"]
 
@@ -407,7 +409,7 @@ class Duration(metaclass=_DurationMeta):
             # nanoOfDay is always non-negative (and much less than half of long.MaxValue), so adding two
             # of them together will never produce a negative result.
             return Duration._ctor(days=days, nano_of_day=nanos)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     @staticmethod
     def add(left: Duration, right: Duration) -> Duration:
@@ -435,7 +437,7 @@ class Duration(metaclass=_DurationMeta):
                 days -= 1
                 nanos += PyodaConstants.NANOSECONDS_PER_DAY
             return Duration._ctor(days=days, nano_of_day=nanos)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     @staticmethod
     def subtract(left: Duration, right: Duration) -> Duration:
@@ -467,7 +469,7 @@ class Duration(metaclass=_DurationMeta):
             return self.from_nanoseconds(_towards_zero_division(self.total_nanoseconds, other))
         if isinstance(other, Duration):
             return self.total_nanoseconds / other.total_nanoseconds
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     @staticmethod
     @typing.overload
@@ -486,12 +488,12 @@ class Duration(metaclass=_DurationMeta):
         # TODO: This is much simpler than the Noda Time implementation
         if isinstance(other, int | float):
             return self.from_nanoseconds(self.to_nanoseconds() * other)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __rmul__(self, other: int | float) -> Duration:
         if isinstance(other, int | float):
             return self * other
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     @staticmethod
     @typing.overload
@@ -525,7 +527,7 @@ class Duration(metaclass=_DurationMeta):
             return self.__days < other.__days or (
                 self.__days == other.__days and self.__nano_of_day < other.__nano_of_day
             )
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __le__(self, other: Duration | None) -> bool:
         return self < other or self == other
@@ -537,7 +539,7 @@ class Duration(metaclass=_DurationMeta):
             return (self.__days > other.__days) or (
                 (self.__days == other.__days) and (self.__nano_of_day > other.__nano_of_day)
             )
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __ge__(self, other: Duration | None) -> bool:
         return self > other or self == other
@@ -563,7 +565,7 @@ class Duration(metaclass=_DurationMeta):
 
     # region IComparable<Duration> Members
 
-    def compare_to(self, other: Duration) -> int:
+    def compare_to(self, other: Duration | None) -> int:
         """Compares the current object with another object of the same type. See the type documentation for a
         description of ordering semantics.
 

--- a/pyoda_time/_instant.py
+++ b/pyoda_time/_instant.py
@@ -20,7 +20,9 @@ if typing.TYPE_CHECKING:
     )
     from ._local_instant import _LocalInstant
 
-from .utility import _Preconditions, _sealed, _TickArithmetic, _to_ticks, _towards_zero_division
+from .utility._csharp_compatibility import _sealed, _to_ticks, _towards_zero_division
+from .utility._preconditions import _Preconditions
+from .utility._tick_arithmetic import _TickArithmetic
 
 
 class _InstantMeta(type):
@@ -146,19 +148,19 @@ class Instant(metaclass=_InstantMeta):
     def __lt__(self, other: Instant) -> bool:
         if isinstance(other, Instant):
             return self.__duration < other.__duration
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __le__(self, other: Instant) -> bool:
         if isinstance(other, Instant):
             return self < other or self == other
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __add__(self, other: Duration) -> Instant:
         from . import Duration
 
         if isinstance(other, Duration):
             return self._from_untrusted_duration(self.__duration + other)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     @typing.overload
     def __sub__(self, other: Instant) -> Duration: ...
@@ -173,7 +175,7 @@ class Instant(metaclass=_InstantMeta):
             return self.__duration - other.__duration
         if isinstance(other, Duration):
             return self._from_trusted_duration(self.__duration - other)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     @property
     def _days_since_epoch(self) -> int:

--- a/pyoda_time/_local_date.py
+++ b/pyoda_time/_local_date.py
@@ -10,7 +10,8 @@ from ._calendar_ordinal import _CalendarOrdinal
 from ._calendar_system import CalendarSystem
 from ._iso_day_of_week import IsoDayOfWeek
 from .calendars import Era
-from .utility import _Preconditions, _sealed
+from .utility._csharp_compatibility import _sealed
+from .utility._preconditions import _Preconditions
 
 if typing.TYPE_CHECKING:
     from . import LocalDateTime, LocalTime, Period, YearMonth
@@ -26,7 +27,7 @@ class _LocalDateMeta(type):
     def max_iso_value(self) -> LocalDate:
         """The maximum (latest) date representable in the ISO calendar system."""
         from ._year_month_day_calendar import _YearMonthDayCalendar
-        from .calendars import _GregorianYearMonthDayCalculator
+        from .calendars._gregorian_year_month_day_calculator import _GregorianYearMonthDayCalculator
 
         return LocalDate._ctor(
             year_month_day_calendar=_YearMonthDayCalendar._ctor(
@@ -41,7 +42,7 @@ class _LocalDateMeta(type):
     def min_iso_value(self) -> LocalDate:
         """The minimum (earliest) date representable in the ISO calendar system."""
         from ._year_month_day_calendar import _YearMonthDayCalendar
-        from .calendars import _GregorianYearMonthDayCalculator
+        from .calendars._gregorian_year_month_day_calculator import _GregorianYearMonthDayCalculator
 
         return LocalDate._ctor(
             year_month_day_calendar=_YearMonthDayCalendar._ctor(
@@ -118,7 +119,7 @@ class LocalDate(metaclass=_LocalDateMeta):
         days_since_epoch: int | None = None,
         calendar: CalendarSystem | None = None,
     ) -> LocalDate:
-        from .calendars import _GregorianYearMonthDayCalculator
+        from .calendars._gregorian_year_month_day_calculator import _GregorianYearMonthDayCalculator
 
         self = super().__new__(cls)
         if year_month_day_calendar is not None:
@@ -228,7 +229,7 @@ class LocalDate(metaclass=_LocalDateMeta):
             return self.plus_years(other.years).plus_months(other.months).plus_weeks(other.weeks).plus_days(other.days)
         if isinstance(other, LocalTime):
             return LocalDateTime._ctor(local_date=self, local_time=other)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, LocalDate):
@@ -248,7 +249,7 @@ class LocalDate(metaclass=_LocalDateMeta):
                 "Only values in the same calendar can be compared",
             )
             return self.__trusted_compare_to(other) < 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __le__(self, other: LocalDate) -> bool:
         if isinstance(other, LocalDate):
@@ -267,7 +268,7 @@ class LocalDate(metaclass=_LocalDateMeta):
                 "Only values in the same calendar can be compared",
             )
             return self.__trusted_compare_to(other) > 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __ge__(self, other: LocalDate) -> bool:
         if isinstance(other, LocalDate):
@@ -315,7 +316,7 @@ class LocalDate(metaclass=_LocalDateMeta):
         :param years: The number of years to add.
         :return: The current value plus the given number of years.
         """
-        from .fields import _DatePeriodFields
+        from .fields._date_period_fields import _DatePeriodFields
 
         return _DatePeriodFields._years_field.add(self, years)
 
@@ -332,17 +333,17 @@ class LocalDate(metaclass=_LocalDateMeta):
         :param months: The number of months to add
         :return: The current date plus the given number of months
         """
-        from .fields import _DatePeriodFields
+        from .fields._date_period_fields import _DatePeriodFields
 
         return _DatePeriodFields._months_field.add(self, months)
 
     def plus_days(self, days: int) -> LocalDate:
-        from .fields import _DatePeriodFields
+        from .fields._date_period_fields import _DatePeriodFields
 
         return _DatePeriodFields._days_field.add(self, days)
 
     def plus_weeks(self, weeks: int) -> LocalDate:
-        from .fields import _DatePeriodFields
+        from .fields._date_period_fields import _DatePeriodFields
 
         return _DatePeriodFields._weeks_field.add(self, weeks)
 

--- a/pyoda_time/_local_date_time.py
+++ b/pyoda_time/_local_date_time.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import typing
 
 from ._calendar_system import CalendarSystem
-from .utility import _Preconditions, _sealed
+from .utility._csharp_compatibility import _sealed
+from .utility._preconditions import _Preconditions
 
 if typing.TYPE_CHECKING:
     from . import Period
@@ -224,32 +225,32 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
         return LocalDateTime._ctor(local_date=self.__date.plus_weeks(weeks), local_time=self.__time)
 
     def plus_hours(self, hours: int) -> LocalDateTime:
-        from .fields import _TimePeriodField
+        from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._hours._add_local_date_time(self, hours)
 
     def plus_minutes(self, minutes: int) -> LocalDateTime:
-        from .fields import _TimePeriodField
+        from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._minutes._add_local_date_time(self, minutes)
 
     def plus_seconds(self, seconds: int) -> LocalDateTime:
-        from .fields import _TimePeriodField
+        from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._seconds._add_local_date_time(self, seconds)
 
     def plus_milliseconds(self, milliseconds: int) -> LocalDateTime:
-        from .fields import _TimePeriodField
+        from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._milliseconds._add_local_date_time(self, milliseconds)
 
     def plus_ticks(self, ticks: int) -> LocalDateTime:
-        from .fields import _TimePeriodField
+        from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._ticks._add_local_date_time(self, ticks)
 
     def plus_nanoseconds(self, nanoseconds: int) -> LocalDateTime:
-        from .fields import _TimePeriodField
+        from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._nanoseconds._add_local_date_time(self, nanoseconds)
 
@@ -290,7 +291,7 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
                 self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
             )
             return self.compare_to(other) < 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __le__(self, other: LocalDateTime) -> bool:
         if isinstance(other, LocalDateTime):
@@ -298,7 +299,7 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
                 self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
             )
             return self.compare_to(other) <= 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __gt__(self, other: LocalDateTime) -> bool:
         if isinstance(other, LocalDateTime):
@@ -306,7 +307,7 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
                 self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
             )
             return self.compare_to(other) > 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __ge__(self, other: LocalDateTime) -> bool:
         if isinstance(other, LocalDateTime):
@@ -314,7 +315,7 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
                 self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
             )
             return self.compare_to(other) >= 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def compare_to(self, other: LocalDateTime) -> int:
         # This will check calendars...
@@ -328,13 +329,13 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
 
         if isinstance(other, Period):
             return self.plus(other)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def plus(self, period: Period) -> LocalDateTime:
         _Preconditions._check_not_null(period, "period")
         extra_days = 0
         time = self.time_of_day
-        from .fields import _TimePeriodField
+        from .fields._time_period_field import _TimePeriodField
 
         time, plus_extra_days = _TimePeriodField._hours._add_local_time_with_extra_days(time, period.hours)
         extra_days += plus_extra_days

--- a/pyoda_time/_local_instant.py
+++ b/pyoda_time/_local_instant.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from .utility import _sealed
+from .utility._csharp_compatibility import _sealed
 
 if typing.TYPE_CHECKING:
     from . import Duration, Instant, Offset
@@ -111,12 +111,12 @@ class _LocalInstant:
     def __lt__(self, other: _LocalInstant) -> bool:
         if isinstance(other, _LocalInstant):
             return self.__duration < other.__duration
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __le__(self, other: _LocalInstant) -> bool:
         if isinstance(other, _LocalInstant):
             return self.__duration <= other.__duration
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     # endregion
 

--- a/pyoda_time/_local_time.py
+++ b/pyoda_time/_local_time.py
@@ -8,7 +8,8 @@ import functools
 import typing
 
 from ._pyoda_constants import PyodaConstants
-from .utility import _csharp_modulo, _int32_overflow, _Preconditions, _sealed, _towards_zero_division
+from .utility._csharp_compatibility import _csharp_modulo, _int32_overflow, _sealed, _towards_zero_division
+from .utility._preconditions import _Preconditions
 
 if typing.TYPE_CHECKING:
     from . import LocalDateTime

--- a/pyoda_time/_offset.py
+++ b/pyoda_time/_offset.py
@@ -9,7 +9,8 @@ import typing
 
 from ._compatibility._culture_info import CultureInfo
 from ._pyoda_constants import PyodaConstants
-from .utility import _Preconditions, _sealed, _towards_zero_division
+from .utility._csharp_compatibility import _sealed, _towards_zero_division
+from .utility._preconditions import _Preconditions
 
 
 class _OffsetMeta(type):
@@ -151,7 +152,7 @@ class Offset(metaclass=_OffsetMeta):
         """
         if isinstance(other, Offset):
             return self.from_seconds(self.seconds + other.seconds)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     @staticmethod
     def add(left: Offset, right: Offset) -> Offset:
@@ -182,7 +183,7 @@ class Offset(metaclass=_OffsetMeta):
         """
         if isinstance(other, Offset):
             return self.from_seconds(self.seconds - other.seconds)
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     @staticmethod
     def subtract(minuend: Offset, subtrahend: Offset) -> Offset:

--- a/pyoda_time/_period.py
+++ b/pyoda_time/_period.py
@@ -9,8 +9,9 @@ import typing
 
 from ._period_units import PeriodUnits
 from ._pyoda_constants import PyodaConstants
-from .fields import _TimePeriodField
-from .utility import _csharp_modulo, _Preconditions, _private, _sealed, _towards_zero_division
+from .fields._time_period_field import _TimePeriodField
+from .utility._csharp_compatibility import _csharp_modulo, _private, _sealed, _towards_zero_division
+from .utility._preconditions import _Preconditions
 
 if typing.TYPE_CHECKING:
     from . import Duration, LocalDate, LocalDateTime, LocalTime, PeriodBuilder, YearMonth
@@ -228,7 +229,7 @@ class Period(metaclass=_PeriodMeta):
                 ticks=self.ticks + other.ticks,
                 nanoseconds=self.nanoseconds + other.nanoseconds,
             )
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def add(self, other: Period) -> Period:
         """Return the sum of the two periods.
@@ -253,7 +254,7 @@ class Period(metaclass=_PeriodMeta):
                 ticks=self.ticks - other.ticks,
                 nanoseconds=self.nanoseconds - other.nanoseconds,
             )
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def subtract(self, other: Period) -> Period:
         """Subtracts one period from another, by simply subtracting each property value.
@@ -324,7 +325,7 @@ class Period(metaclass=_PeriodMeta):
         from ._local_date import LocalDate
         from ._local_date_time import LocalDateTime
         from ._local_time import LocalTime
-        from .fields import _DatePeriodFields
+        from .fields._date_period_fields import _DatePeriodFields
 
         # public static Period Between(LocalDateTime start, LocalDateTime end, PeriodUnits units)
         if isinstance(start, LocalDateTime) and isinstance(end, LocalDateTime):
@@ -494,7 +495,7 @@ class Period(metaclass=_PeriodMeta):
             match units:
                 case PeriodUnits.HOURS:
                     return cls.from_hours(_towards_zero_division(remaining_, PyodaConstants.NANOSECONDS_PER_HOUR))
-                case PeriodUnits.HOURS:
+                case PeriodUnits.MINUTES:
                     return cls.from_minutes(_towards_zero_division(remaining_, PyodaConstants.NANOSECONDS_PER_MINUTE))
                 case PeriodUnits.SECONDS:
                     return cls.from_seconds(_towards_zero_division(remaining_, PyodaConstants.NANOSECONDS_PER_SECOND))
@@ -551,7 +552,7 @@ class Period(metaclass=_PeriodMeta):
             end_date_: LocalDate = end._start_date
 
             # Optimization for single field
-            from .fields import _DatePeriodFields
+            from .fields._date_period_fields import _DatePeriodFields
 
             match units:
                 case PeriodUnits.YEARS:
@@ -570,7 +571,8 @@ class Period(metaclass=_PeriodMeta):
     def __date_components_between(
         cls, start: LocalDate, end: LocalDate, units: PeriodUnits
     ) -> tuple[LocalDate, int, int, int, int]:
-        from .fields import _DatePeriodFields, _IDatePeriodField
+        from .fields._date_period_fields import _DatePeriodFields
+        from .fields._i_date_period_field import _IDatePeriodField
 
         def units_between(
             masked_units: PeriodUnits, start_date: LocalDate, end_date: LocalDate, date_field: _IDatePeriodField
@@ -777,6 +779,11 @@ class Period(metaclass=_PeriodMeta):
         )
 
     def equals(self, other: Period) -> bool:
+        return self == other
+
+    def __eq__(self, other: object) -> bool:
+        if self is other:
+            return True
         if isinstance(other, Period):
             return (
                 self.years == other.years
@@ -790,13 +797,6 @@ class Period(metaclass=_PeriodMeta):
                 and self.ticks == other.ticks
                 and self.nanoseconds == other.nanoseconds
             )
-        return NotImplemented
-
-    def __eq__(self, other: object) -> bool:
-        if self is other:
-            return True
-        if isinstance(other, Period):
-            return self.equals(other)
         return NotImplemented
 
     def __ne__(self, other: object) -> bool:

--- a/pyoda_time/_period_builder.py
+++ b/pyoda_time/_period_builder.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import typing
 
 from ._period_units import PeriodUnits
-from .utility import _Preconditions, _sealed
+from .utility._csharp_compatibility import _sealed
+from .utility._preconditions import _Preconditions
 
 if typing.TYPE_CHECKING:
     from ._period import Period

--- a/pyoda_time/_year_month.py
+++ b/pyoda_time/_year_month.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import typing
 
 from ._calendar_system import CalendarSystem
-from .utility import _Preconditions, _sealed
+from .utility._csharp_compatibility import _sealed
+from .utility._preconditions import _Preconditions
 
 if typing.TYPE_CHECKING:
     from ._calendar_ordinal import _CalendarOrdinal
@@ -187,7 +188,7 @@ class YearMonth:
                 "Only values in the same calendar can be compared",
             )
             return self.__trusted_compare_to(other) < 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __le__(self, other: YearMonth | None) -> bool:
         if other is None:
@@ -199,7 +200,7 @@ class YearMonth:
                 "Only values in the same calendar can be compared",
             )
             return self.__trusted_compare_to(other) <= 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __gt__(self, other: YearMonth | None) -> bool:
         if other is None:
@@ -211,7 +212,7 @@ class YearMonth:
                 "Only values in the same calendar can be compared",
             )
             return self.__trusted_compare_to(other) > 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __ge__(self, other: YearMonth | None) -> bool:
         if other is None:
@@ -223,7 +224,7 @@ class YearMonth:
                 "Only values in the same calendar can be compared",
             )
             return self.__trusted_compare_to(other) >= 0
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __hash__(self) -> int:
         return hash(self.__start_of_month)

--- a/pyoda_time/_year_month_day.py
+++ b/pyoda_time/_year_month_day.py
@@ -8,7 +8,7 @@ import typing
 
 from ._calendar_ordinal import _CalendarOrdinal
 from ._year_month_day_calendar import _YearMonthDayCalendar
-from .utility import _sealed
+from .utility._csharp_compatibility import _sealed
 
 if typing.TYPE_CHECKING:
     from . import CalendarSystem
@@ -93,19 +93,19 @@ class _YearMonthDay:
     def __lt__(self, other: _YearMonthDay) -> bool:
         if isinstance(other, _YearMonthDay):
             return self.__value < other.__value
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __le__(self, other: _YearMonthDay) -> bool:
         if isinstance(other, _YearMonthDay):
             return self.__value <= other.__value
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __gt__(self, other: _YearMonthDay) -> bool:
         if isinstance(other, _YearMonthDay):
             return self.__value > other.__value
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]
 
     def __ge__(self, other: _YearMonthDay) -> bool:
         if isinstance(other, _YearMonthDay):
             return self.__value >= other.__value
-        return NotImplemented
+        return NotImplemented  # type: ignore[unreachable]

--- a/pyoda_time/_year_month_day_calendar.py
+++ b/pyoda_time/_year_month_day_calendar.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import typing
 
 from ._calendar_ordinal import _CalendarOrdinal
-from .utility import _int32_overflow, _sealed
+from .utility._csharp_compatibility import _int32_overflow, _sealed
 
 if typing.TYPE_CHECKING:
     from ._year_month_day import _YearMonthDay

--- a/pyoda_time/_zoned_date_time.py
+++ b/pyoda_time/_zoned_date_time.py
@@ -16,7 +16,7 @@ if typing.TYPE_CHECKING:
         OffsetDateTime,
     )
 
-from .utility import _Preconditions
+from .utility._preconditions import _Preconditions
 
 __all__ = ["ZonedDateTime"]
 

--- a/pyoda_time/calendars/__init__.py
+++ b/pyoda_time/calendars/__init__.py
@@ -12,32 +12,12 @@ __all__: list[str] = [
     "WeekYearRules",
 ]
 
-from ._badi_year_month_day_calculator import _BadiYearMonthDayCalculator  # noqa: F401
 from ._calendar_week_rule import CalendarWeekRule
-from ._coptic_year_month_day_calculator import _CopticYearMonthDayCalculator  # noqa: F401
 from ._era import (
     Era,
-    _EraMeta,  # noqa: F401
 )
-from ._era_calculator import _EraCalculator  # noqa: F401
-from ._fixed_month_year_month_day_calculator import _FixedMonthYearMonthDayCalculator  # noqa: F401
-from ._g_j_era_calculator import _GJEraCalculator  # noqa: F401
-from ._g_j_year_month_day_calculator import _GJYearMonthDayCalculator  # noqa: F401
-from ._gregorian_year_month_day_calculator import _GregorianYearMonthDayCalculator  # noqa: F401
-from ._hebrew_month_converter import _HebrewMonthConverter  # noqa: F401
 from ._hebrew_month_numbering import HebrewMonthNumbering
-from ._hebrew_scriptural_calculator import _HebrewScripturalCalculator  # noqa: F401
-from ._hebrew_year_month_day_calculator import _HebrewYearMonthDayCalculator  # noqa: F401
 from ._i_week_year_rule import IWeekYearRule
 from ._islamic_epoch import IslamicEpoch
 from ._islamic_leap_year_pattern import IslamicLeapYearPattern
-from ._islamic_year_month_day_calculator import _IslamicYearMonthDayCalculator  # noqa: F401
-from ._julian_year_month_day_calculator import _JulianYearMonthDayCalculator  # noqa: F401
-from ._persian_year_month_day_calculator import _PersianYearMonthDayCalculator  # noqa: F401
-from ._regular_year_month_day_calculator import _RegularYearMonthDayCalculator  # noqa: F401
-from ._simple_week_year_rule import _SimpleWeekYearRule  # noqa: F401
-from ._single_era_calculator import _SingleEraCalculator  # noqa: F401
-from ._um_al_qura_year_month_day_calculator import _UmAlQuraYearMonthDayCalculator  # noqa: F401
 from ._week_year_rules import WeekYearRules
-from ._year_month_day_calculator import _YearMonthDayCalculator  # noqa: F401
-from ._year_start_cache_entry import _YearStartCacheEntry  # noqa: F401

--- a/pyoda_time/calendars/_badi_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_badi_year_month_day_calculator.py
@@ -8,7 +8,8 @@ import base64
 import typing
 
 from .._year_month_day import _YearMonthDay
-from ..utility import _Preconditions, _sealed, _towards_zero_division
+from ..utility._csharp_compatibility import _sealed, _towards_zero_division
+from ..utility._preconditions import _Preconditions
 from ._year_month_day_calculator import _YearMonthDayCalculator
 
 

--- a/pyoda_time/calendars/_era.py
+++ b/pyoda_time/calendars/_era.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import functools
 import typing
 
-from ..utility import _private, _sealed
+from ..utility._csharp_compatibility import _private, _sealed
 
 
 class _EraMeta(type):

--- a/pyoda_time/calendars/_fixed_month_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_fixed_month_year_month_day_calculator.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import abc
 import typing
 
-from ..utility import _towards_zero_division
+from ..utility._csharp_compatibility import _towards_zero_division
 from ._regular_year_month_day_calculator import _RegularYearMonthDayCalculator
 
 if typing.TYPE_CHECKING:

--- a/pyoda_time/calendars/_g_j_era_calculator.py
+++ b/pyoda_time/calendars/_g_j_era_calculator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from ..utility import _Preconditions
+from ..utility._preconditions import _Preconditions
 from ._era import Era
 from ._era_calculator import _EraCalculator
 from ._year_month_day_calculator import _YearMonthDayCalculator

--- a/pyoda_time/calendars/_g_j_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_g_j_year_month_day_calculator.py
@@ -9,13 +9,13 @@ import typing
 
 if typing.TYPE_CHECKING:
     from .._year_month_day import _YearMonthDay
-from ..utility import _towards_zero_division
+from ..utility._csharp_compatibility import _towards_zero_division
 from ._regular_year_month_day_calculator import _RegularYearMonthDayCalculator
 
 
 class _GJYearMonthDayCalculator(_RegularYearMonthDayCalculator, abc.ABC):
-    _NON_LEAP_DAYS_PER_MONTH: typing.Final[tuple] = (0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
-    _LEAP_DAYS_PER_MONTH: typing.Final[tuple] = (0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    _NON_LEAP_DAYS_PER_MONTH: typing.Final[list[int]] = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    _LEAP_DAYS_PER_MONTH: typing.Final[list[int]] = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
     @staticmethod
     def __generate_total_days_by_month(*month_lengths: int) -> list[int]:

--- a/pyoda_time/calendars/_gregorian_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_gregorian_year_month_day_calculator.py
@@ -9,7 +9,7 @@ import typing
 if typing.TYPE_CHECKING:
     from .._year_month_day import _YearMonthDay
 from .._year_month_day_calendar import _YearMonthDayCalendar
-from ..utility import _towards_zero_division
+from ..utility._csharp_compatibility import _towards_zero_division
 from ._g_j_year_month_day_calculator import _GJYearMonthDayCalculator
 
 

--- a/pyoda_time/calendars/_hebrew_scriptural_calculator.py
+++ b/pyoda_time/calendars/_hebrew_scriptural_calculator.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import typing
 
-from ..utility import _csharp_modulo, _Preconditions, _towards_zero_division
+from ..utility._csharp_compatibility import _csharp_modulo, _towards_zero_division
+from ..utility._preconditions import _Preconditions
 from ._year_start_cache_entry import _YearStartCacheEntry
 
 if typing.TYPE_CHECKING:

--- a/pyoda_time/calendars/_hebrew_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_hebrew_year_month_day_calculator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from ..utility import _csharp_modulo, _sealed, _towards_zero_division
+from ..utility._csharp_compatibility import _csharp_modulo, _sealed, _towards_zero_division
 from ._hebrew_month_converter import _HebrewMonthConverter
 from ._hebrew_month_numbering import HebrewMonthNumbering
 from ._hebrew_scriptural_calculator import _HebrewScripturalCalculator

--- a/pyoda_time/calendars/_islamic_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_islamic_year_month_day_calculator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from ..utility import _csharp_modulo, _sealed, _towards_zero_division
+from ..utility._csharp_compatibility import _csharp_modulo, _sealed, _towards_zero_division
 from ._islamic_epoch import IslamicEpoch
 from ._islamic_leap_year_pattern import IslamicLeapYearPattern
 from ._regular_year_month_day_calculator import _RegularYearMonthDayCalculator

--- a/pyoda_time/calendars/_julian_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_julian_year_month_day_calculator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from ..utility import _sealed
+from ..utility._csharp_compatibility import _sealed
 from ._g_j_year_month_day_calculator import _GJYearMonthDayCalculator
 
 

--- a/pyoda_time/calendars/_persian_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_persian_year_month_day_calculator.py
@@ -8,7 +8,7 @@ import abc
 import base64
 import typing
 
-from ..utility import _csharp_modulo, _towards_zero_division
+from ..utility._csharp_compatibility import _csharp_modulo, _towards_zero_division
 from ._regular_year_month_day_calculator import _RegularYearMonthDayCalculator
 
 if typing.TYPE_CHECKING:

--- a/pyoda_time/calendars/_regular_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_regular_year_month_day_calculator.py
@@ -9,7 +9,7 @@ import typing
 
 if typing.TYPE_CHECKING:
     from .._year_month_day import _YearMonthDay
-from ..utility import _towards_zero_division
+from ..utility._csharp_compatibility import _towards_zero_division
 from ._year_month_day_calculator import _YearMonthDayCalculator
 
 

--- a/pyoda_time/calendars/_simple_week_year_rule.py
+++ b/pyoda_time/calendars/_simple_week_year_rule.py
@@ -10,9 +10,10 @@ if typing.TYPE_CHECKING:
     from .._calendar_system import CalendarSystem
     from .._local_date import LocalDate
 from .._iso_day_of_week import IsoDayOfWeek
-from ..utility import _Preconditions, _sealed, _towards_zero_division
-from ._hebrew_year_month_day_calculator import _YearMonthDayCalculator
+from ..utility._csharp_compatibility import _sealed, _towards_zero_division
+from ..utility._preconditions import _Preconditions
 from ._i_week_year_rule import IWeekYearRule
+from ._year_month_day_calculator import _YearMonthDayCalculator
 
 
 @_sealed

--- a/pyoda_time/calendars/_single_era_calculator.py
+++ b/pyoda_time/calendars/_single_era_calculator.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import typing
 
-from ..utility import _Preconditions, _private, _sealed
+from ..utility._csharp_compatibility import _private, _sealed
+from ..utility._preconditions import _Preconditions
 from ._era import Era
 from ._era_calculator import _EraCalculator
 from ._year_month_day_calculator import _YearMonthDayCalculator

--- a/pyoda_time/calendars/_um_al_qura_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_um_al_qura_year_month_day_calculator.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import base64
 import typing
 
-from ..utility import _Preconditions
+from ..utility._preconditions import _Preconditions
 from ._regular_year_month_day_calculator import _RegularYearMonthDayCalculator
 
 if typing.TYPE_CHECKING:

--- a/pyoda_time/calendars/_year_month_day_calculator.py
+++ b/pyoda_time/calendars/_year_month_day_calculator.py
@@ -9,7 +9,8 @@ import typing
 
 if typing.TYPE_CHECKING:
     from .._year_month_day import _YearMonthDay
-from ..utility import _Preconditions, _towards_zero_division
+from ..utility._csharp_compatibility import _towards_zero_division
+from ..utility._preconditions import _Preconditions
 from ._year_start_cache_entry import _YearStartCacheEntry
 
 

--- a/pyoda_time/fields/__init__.py
+++ b/pyoda_time/fields/__init__.py
@@ -3,10 +3,3 @@
 # as found in the LICENSE.txt file.
 
 __all__: list[str] = []
-
-from ._date_period_fields import _DatePeriodFields  # noqa: F401
-from ._fixed_length_date_period_field import _FixedLengthDatePeriodField  # noqa: F401
-from ._i_date_period_field import _IDatePeriodField  # noqa: F401
-from ._months_period_field import _MonthsPeriodField  # noqa: F401
-from ._time_period_field import _TimePeriodField  # noqa: F401
-from ._years_period_field import _YearsPeriodField  # noqa: F401

--- a/pyoda_time/fields/_fixed_length_date_period_field.py
+++ b/pyoda_time/fields/_fixed_length_date_period_field.py
@@ -11,7 +11,7 @@ from .._year_month_day_calendar import _YearMonthDayCalendar
 if typing.TYPE_CHECKING:
     from .._local_date import LocalDate
 
-from ..utility import _sealed, _towards_zero_division
+from ..utility._csharp_compatibility import _sealed, _towards_zero_division
 from ._i_date_period_field import _IDatePeriodField
 
 

--- a/pyoda_time/fields/_months_period_field.py
+++ b/pyoda_time/fields/_months_period_field.py
@@ -9,7 +9,7 @@ import typing
 if typing.TYPE_CHECKING:
     from .._local_date import LocalDate
 
-from ..utility import _sealed
+from ..utility._csharp_compatibility import _sealed
 from ._i_date_period_field import _IDatePeriodField
 
 

--- a/pyoda_time/fields/_time_period_field.py
+++ b/pyoda_time/fields/_time_period_field.py
@@ -13,7 +13,7 @@ from .._duration import Duration
 from .._local_date_time import LocalDateTime
 from .._local_time import LocalTime
 from .._pyoda_constants import PyodaConstants
-from ..utility import _csharp_modulo, _towards_zero_division
+from ..utility._csharp_compatibility import _csharp_modulo, _towards_zero_division
 
 
 class _TimePeriodFieldMeta(type):

--- a/pyoda_time/fields/_years_period_field.py
+++ b/pyoda_time/fields/_years_period_field.py
@@ -9,7 +9,8 @@ import typing
 if typing.TYPE_CHECKING:
     from .._local_date import LocalDate
 
-from ..utility import _Preconditions, _sealed
+from ..utility._csharp_compatibility import _sealed
+from ..utility._preconditions import _Preconditions
 from ._i_date_period_field import _IDatePeriodField
 
 

--- a/pyoda_time/globalization/__init__.py
+++ b/pyoda_time/globalization/__init__.py
@@ -1,5 +1,3 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-
-from ._pyoda_format_info import _PyodaFormatInfo  # noqa: F401

--- a/pyoda_time/globalization/_pyoda_format_info.py
+++ b/pyoda_time/globalization/_pyoda_format_info.py
@@ -26,8 +26,8 @@ if typing.TYPE_CHECKING:
     from .._year_month import YearMonth
     from .._zoned_date_time import ZonedDateTime
     from ..text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
-from ..utility import _Preconditions
 from ..utility._csharp_compatibility import _sealed
+from ..utility._preconditions import _Preconditions
 from ._pattern_resources import _PatternResources
 
 
@@ -107,7 +107,7 @@ class _PyodaFormatInfo(metaclass=_PyodaFormatInfoMeta):
 
         with self.__FIELD_LOCK:
             if self.__long_month_names is not None:
-                return
+                return  # type: ignore[unreachable]
             # Turn month names into 1-based read-only lists
             self.__long_month_names = self.__convert_month_array(self.date_time_format.month_names)
             self.__short_month_names = self.__convert_month_array(self.date_time_format.abbreviated_month_names)
@@ -132,7 +132,7 @@ class _PyodaFormatInfo(metaclass=_PyodaFormatInfoMeta):
 
         with self.__FIELD_LOCK:
             if self.__long_day_names is not None:
-                return
+                return  # type: ignore[unreachable]
             self.__long_day_names = self.__convert_day_array(self.date_time_format.day_names)
             self.__short_day_names = self.__convert_day_array(self.date_time_format.abbreviated_day_names)
 

--- a/pyoda_time/text/__init__.py
+++ b/pyoda_time/text/__init__.py
@@ -8,10 +8,6 @@ __all__: list[str] = [
     "UnparsableValueError",
 ]
 
-from . import patterns  # noqa: F401
 from ._invalid_pattern_exception import InvalidPatternError
-from ._parse_bucket import _ParseBucket  # noqa: F401
 from ._parse_result import ParseResult
-from ._text_cursor import _TextCursor  # noqa: F401
 from ._unparsable_value_error import UnparsableValueError
-from ._value_cursor import _ValueCursor  # noqa: F401

--- a/pyoda_time/text/_composite_pattern_builder.py
+++ b/pyoda_time/text/_composite_pattern_builder.py
@@ -4,10 +4,12 @@
 from typing import Callable, Final, Generic, Sequence, TypeVar, cast, final
 
 from pyoda_time._compatibility._string_builder import StringBuilder
-from pyoda_time.text import ParseResult, _ValueCursor
+from pyoda_time.text import ParseResult
 from pyoda_time.text._i_partial_pattern import _IPartialPattern
 from pyoda_time.text._i_pattern import IPattern
-from pyoda_time.utility import _Preconditions, _sealed
+from pyoda_time.text._value_cursor import _ValueCursor
+from pyoda_time.utility._csharp_compatibility import _sealed
+from pyoda_time.utility._preconditions import _Preconditions
 
 T = TypeVar("T")
 

--- a/pyoda_time/text/_fixed_format_info_pattern_parser.py
+++ b/pyoda_time/text/_fixed_format_info_pattern_parser.py
@@ -4,8 +4,8 @@
 
 from typing import Final, Generic, TypeVar, final
 
-from ..globalization import _PyodaFormatInfo
-from ..utility import _sealed
+from ..globalization._pyoda_format_info import _PyodaFormatInfo
+from ..utility._csharp_compatibility import _sealed
 from ._i_pattern import IPattern
 from .patterns._i_pattern_parser import _IPatternParser
 

--- a/pyoda_time/text/_i_partial_pattern.py
+++ b/pyoda_time/text/_i_partial_pattern.py
@@ -3,8 +3,9 @@
 # as found in the LICENSE.txt file.
 from abc import abstractmethod
 
-from pyoda_time.text import ParseResult, _ValueCursor
+from pyoda_time.text import ParseResult
 from pyoda_time.text._i_pattern import IPattern, T
+from pyoda_time.text._value_cursor import _ValueCursor
 
 
 class _IPartialPattern(IPattern[T]):

--- a/pyoda_time/text/_invalid_pattern_exception.py
+++ b/pyoda_time/text/_invalid_pattern_exception.py
@@ -4,7 +4,7 @@
 
 from typing import Any, final
 
-from ..utility import _sealed
+from ..utility._csharp_compatibility import _sealed
 
 
 @final

--- a/pyoda_time/text/_offset_pattern.py
+++ b/pyoda_time/text/_offset_pattern.py
@@ -10,13 +10,14 @@ from typing import Final, _ProtocolMeta, cast, final
 from pyoda_time import Offset
 from pyoda_time._compatibility._culture_info import CultureInfo
 from pyoda_time._compatibility._string_builder import StringBuilder
-from pyoda_time.globalization import _PyodaFormatInfo
+from pyoda_time.globalization._pyoda_format_info import _PyodaFormatInfo
 from pyoda_time.text import ParseResult
 from pyoda_time.text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
 from pyoda_time.text._i_partial_pattern import _IPartialPattern
 from pyoda_time.text._i_pattern import IPattern
-from pyoda_time.text.patterns import _PatternBclSupport
-from pyoda_time.utility import _Preconditions, _sealed
+from pyoda_time.text.patterns._pattern_bcl_support import _PatternBclSupport
+from pyoda_time.utility._csharp_compatibility import _sealed
+from pyoda_time.utility._preconditions import _Preconditions
 
 
 class _OffsetPatternMeta(type):
@@ -113,8 +114,6 @@ class OffsetPattern(IPattern[Offset], metaclass=_CombinedMeta):
         """
         _Preconditions._check_not_null(pattern_text, "pattern_text")
         _Preconditions._check_not_null(format_info, "format_info")
-        if isinstance(format_info, CultureInfo):
-            format_info = _PyodaFormatInfo._get_format_info(format_info)
         pattern = cast(_IPartialPattern[Offset], format_info._offset_pattern_parser._parse_pattern(pattern_text))
         return OffsetPattern(pattern_text, pattern)
 

--- a/pyoda_time/text/_offset_pattern_parser.py
+++ b/pyoda_time/text/_offset_pattern_parser.py
@@ -9,17 +9,20 @@ from typing import Callable, Final, Mapping, final
 from pyoda_time import PyodaConstants
 from pyoda_time._compatibility._string_builder import StringBuilder
 from pyoda_time._offset import Offset
-from pyoda_time.globalization import _PyodaFormatInfo
-from pyoda_time.text import InvalidPatternError, ParseResult, _ValueCursor
+from pyoda_time.globalization._pyoda_format_info import _PyodaFormatInfo
+from pyoda_time.text import InvalidPatternError, ParseResult
 from pyoda_time.text._composite_pattern_builder import CompositePatternBuilder
 from pyoda_time.text._i_partial_pattern import _IPartialPattern
 from pyoda_time.text._i_pattern import IPattern
 from pyoda_time.text._parse_bucket import _ParseBucket
 from pyoda_time.text._text_error_messages import TextErrorMessages
-from pyoda_time.text.patterns import _PatternCursor, _PatternFields
+from pyoda_time.text._value_cursor import _ValueCursor
 from pyoda_time.text.patterns._i_pattern_parser import _IPatternParser
+from pyoda_time.text.patterns._pattern_cursor import _PatternCursor
+from pyoda_time.text.patterns._pattern_fields import _PatternFields
 from pyoda_time.text.patterns._stepped_pattern_builder import _SteppedPatternBuilder
-from pyoda_time.utility import _csharp_modulo, _Preconditions, _sealed, _towards_zero_division
+from pyoda_time.utility._csharp_compatibility import _csharp_modulo, _sealed, _towards_zero_division
+from pyoda_time.utility._preconditions import _Preconditions
 
 
 @_sealed

--- a/pyoda_time/text/_parse_result.py
+++ b/pyoda_time/text/_parse_result.py
@@ -9,12 +9,13 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, final, overlo
 
 from .._calendar_system import CalendarSystem
 from ..calendars._era import Era
-from ..utility import _Preconditions, _private, _sealed
+from ..utility._csharp_compatibility import _private, _sealed
+from ..utility._preconditions import _Preconditions
 from ._text_error_messages import TextErrorMessages
 from ._unparsable_value_error import UnparsableValueError
 
 if TYPE_CHECKING:
-    from . import _ValueCursor
+    from ._value_cursor import _ValueCursor
 
 
 T = TypeVar("T")
@@ -24,7 +25,7 @@ TTarget = TypeVar("TTarget")
 class _ParseResultMeta(type):
     @property
     @functools.cache
-    def _format_only_pattern(cls) -> ParseResult:
+    def _format_only_pattern(cls) -> ParseResult[Any]:
         """This isn't really an issue with the value so much as the pattern...
 
         but the result is the same.
@@ -218,7 +219,7 @@ class ParseResult(Generic[T], metaclass=_ParseResultMeta):
     def _for_invalid_value(
         cls, cursor_or_exception_provider: _ValueCursor | Callable[[], Exception], *args: Any
     ) -> ParseResult[T]:
-        from . import _ValueCursor
+        from ._value_cursor import _ValueCursor
 
         exception_provider: Callable[[], Exception]
 

--- a/pyoda_time/text/_text_error_messages.py
+++ b/pyoda_time/text/_text_error_messages.py
@@ -4,7 +4,7 @@
 
 from typing import Final, final
 
-from ..utility import _private, _sealed
+from ..utility._csharp_compatibility import _private, _sealed
 
 
 @final

--- a/pyoda_time/text/_unparsable_value_error.py
+++ b/pyoda_time/text/_unparsable_value_error.py
@@ -4,7 +4,7 @@
 
 from typing import final
 
-from pyoda_time.utility import _sealed
+from pyoda_time.utility._csharp_compatibility import _sealed
 
 
 @_sealed

--- a/pyoda_time/text/_value_cursor.py
+++ b/pyoda_time/text/_value_cursor.py
@@ -2,9 +2,9 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 import math
-from typing import final
+from typing import Any, final
 
-from ..utility import _CsharpConstants, _sealed
+from ..utility._csharp_compatibility import _CsharpConstants, _sealed
 from ._parse_result import ParseResult
 from ._text_cursor import _TextCursor
 
@@ -75,7 +75,7 @@ class _ValueCursor(_TextCursor):
             result = (remaining[: len(match)] > match) - (remaining[: len(match)] < match)
             return result
 
-    def _parse_int64(self) -> tuple[ParseResult | None, int]:
+    def _parse_int64(self) -> tuple[ParseResult[None] | None, int]:
         """Parses digits at the current point in the string as a signed 64-bit integer value. Currently this method only
         supports cultures whose negative sign is "-" (and using ASCII digits).
 
@@ -123,7 +123,7 @@ class _ValueCursor(_TextCursor):
             result = -result
         return None, result
 
-    def __build_number_out_of_range_result(self, start_index: int) -> ParseResult:
+    def __build_number_out_of_range_result(self, start_index: int) -> ParseResult[Any]:
         self.move(start_index)
         if self.current == "-":
             self.move_next()

--- a/pyoda_time/text/patterns/__init__.py
+++ b/pyoda_time/text/patterns/__init__.py
@@ -1,7 +1,3 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-
-from ._pattern_bcl_support import _PatternBclSupport  # noqa: F401
-from ._pattern_cursor import _PatternCursor  # noqa: F401
-from ._pattern_fields import _PatternFields  # noqa: F401

--- a/pyoda_time/text/patterns/_i_pattern_parser.py
+++ b/pyoda_time/text/patterns/_i_pattern_parser.py
@@ -3,7 +3,7 @@
 # as found in the LICENSE.txt file.
 from typing import Protocol, TypeVar
 
-from ...globalization import _PyodaFormatInfo
+from ...globalization._pyoda_format_info import _PyodaFormatInfo
 from .._i_pattern import IPattern
 
 T = TypeVar("T")

--- a/pyoda_time/text/patterns/_pattern_bcl_support.py
+++ b/pyoda_time/text/patterns/_pattern_bcl_support.py
@@ -6,7 +6,7 @@ from typing import Callable, Final, Generic, TypeVar, final
 
 from ..._compatibility._i_format_provider import IFormatProvider
 from ...globalization._pyoda_format_info import _PyodaFormatInfo
-from ...utility import _sealed
+from ...utility._csharp_compatibility import _sealed
 from .._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
 from .._i_pattern import IPattern
 

--- a/pyoda_time/text/patterns/_pattern_cursor.py
+++ b/pyoda_time/text/patterns/_pattern_cursor.py
@@ -5,7 +5,7 @@
 from typing import Final, final
 
 from ..._compatibility._string_builder import StringBuilder
-from ...utility import _sealed
+from ...utility._csharp_compatibility import _sealed
 from .._invalid_pattern_exception import InvalidPatternError
 from .._text_cursor import _TextCursor
 from .._text_error_messages import TextErrorMessages

--- a/pyoda_time/time_zones/__init__.py
+++ b/pyoda_time/time_zones/__init__.py
@@ -4,5 +4,4 @@
 
 __all__ = ["ZoneInterval"]
 
-from ._fixed_date_time_zone import _FixedDateTimeZone  # noqa: F401
 from ._zone_interval import ZoneInterval

--- a/pyoda_time/time_zones/_fixed_date_time_zone.py
+++ b/pyoda_time/time_zones/_fixed_date_time_zone.py
@@ -11,7 +11,7 @@ if typing.TYPE_CHECKING:
     from . import ZoneInterval
 
 from .._date_time_zone import DateTimeZone
-from ..utility import _sealed
+from ..utility._csharp_compatibility import _sealed
 
 
 @_sealed

--- a/pyoda_time/time_zones/_zone_interval.py
+++ b/pyoda_time/time_zones/_zone_interval.py
@@ -17,7 +17,9 @@ if typing.TYPE_CHECKING:
         _LocalInstant,
     )
 
-from pyoda_time.utility import _hash_code_helper, _Preconditions, _sealed
+from pyoda_time.utility._csharp_compatibility import _sealed
+from pyoda_time.utility._hash_code_helper import _hash_code_helper
+from pyoda_time.utility._preconditions import _Preconditions
 
 __all__ = ["ZoneInterval"]
 

--- a/pyoda_time/utility/__init__.py
+++ b/pyoda_time/utility/__init__.py
@@ -3,17 +3,3 @@
 # as found in the LICENSE.txt file.
 
 __all__: list[str] = []
-
-
-from ._csharp_compatibility import (  # noqa: F401
-    _csharp_modulo,
-    _CsharpConstants,
-    _int32_overflow,
-    _private,
-    _sealed,
-    _to_ticks,
-    _towards_zero_division,
-)
-from ._hash_code_helper import _hash_code_helper  # noqa: F401
-from ._preconditions import _Preconditions  # noqa: F401
-from ._tick_arithmetic import _TickArithmetic  # noqa: F401

--- a/pyoda_time/utility/_cache.py
+++ b/pyoda_time/utility/_cache.py
@@ -5,7 +5,7 @@ from collections import deque
 from threading import Lock
 from typing import Callable, Final, Generic, TypeVar, final
 
-from pyoda_time.utility import _sealed
+from pyoda_time.utility._csharp_compatibility import _sealed
 
 TKey = TypeVar("TKey")
 TValue = TypeVar("TValue")
@@ -25,7 +25,7 @@ class _Cache(Generic[TKey, TValue]):
         self.__size: Final[int] = size
         self.__value_factory: Final[Callable[[TKey], TValue]] = value_factory
         self.__lock: Final[Lock] = Lock()
-        self.__key_list: Final[deque] = deque()  # For eviction tracking
+        self.__key_list: Final[deque[TKey]] = deque()  # For eviction tracking
         self.__dictionary: Final[dict[TKey, TValue]] = {}  # Main storage
 
     def get_or_add(self, key: TKey) -> TValue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,15 @@ wrap-descriptions = 120
 
 [tool.mypy]
 disallow_untyped_defs = true
-# strict mode sounds good, but at time of writing it just warns about pytest.mark.parametrize
-# strict = true
+implicit_reexport = false
+pretty = true
+strict = true
+warn_no_return = true
+warn_redundant_casts = true
 warn_return_any = true
+warn_unreachable = true
 warn_unused_configs = true
+warn_unused_ignores = true
 
 [tool.poetry]
 name = "pyoda-time"

--- a/tests/calendars/test_badi_calendar_system.py
+++ b/tests/calendars/test_badi_calendar_system.py
@@ -18,8 +18,9 @@ from pyoda_time import (
     PeriodUnits,
     PyodaConstants,
 )
-from pyoda_time.calendars import Era, _BadiYearMonthDayCalculator
-from pyoda_time.utility import _Preconditions
+from pyoda_time.calendars import Era
+from pyoda_time.calendars._badi_year_month_day_calculator import _BadiYearMonthDayCalculator
+from pyoda_time.utility._preconditions import _Preconditions
 
 
 class TestBadiCalendarSystem:

--- a/tests/calendars/test_era.py
+++ b/tests/calendars/test_era.py
@@ -6,7 +6,8 @@ import inspect
 
 import pytest
 
-from pyoda_time.calendars import Era, _EraMeta
+from pyoda_time.calendars import Era
+from pyoda_time.calendars._era import _EraMeta
 
 ALL_ERAS = [getattr(Era, name) for name, member in inspect.getmembers(_EraMeta) if isinstance(member, property)]
 

--- a/tests/calendars/test_hebrew_calendar_system.py
+++ b/tests/calendars/test_hebrew_calendar_system.py
@@ -6,7 +6,9 @@ import pytest
 
 from pyoda_time import CalendarSystem, LocalDate
 from pyoda_time._year_month_day import _YearMonthDay
-from pyoda_time.calendars import HebrewMonthNumbering, _HebrewScripturalCalculator, _HebrewYearMonthDayCalculator
+from pyoda_time.calendars import HebrewMonthNumbering
+from pyoda_time.calendars._hebrew_scriptural_calculator import _HebrewScripturalCalculator
+from pyoda_time.calendars._hebrew_year_month_day_calculator import _HebrewYearMonthDayCalculator
 
 
 class TestHebrewCalendarSystem:

--- a/tests/calendars/test_hebrew_month_converter.py
+++ b/tests/calendars/test_hebrew_month_converter.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from pyoda_time.calendars import _HebrewMonthConverter
+from pyoda_time.calendars._hebrew_month_converter import _HebrewMonthConverter
 
 
 class TestHebrewMonthConverter:

--- a/tests/calendars/test_islamic_calendar_system.py
+++ b/tests/calendars/test_islamic_calendar_system.py
@@ -5,7 +5,8 @@
 import pytest
 
 from pyoda_time import CalendarSystem, IsoDayOfWeek, LocalDate, LocalDateTime
-from pyoda_time.calendars import Era, IslamicEpoch, IslamicLeapYearPattern, _IslamicYearMonthDayCalculator
+from pyoda_time.calendars import Era, IslamicEpoch, IslamicLeapYearPattern
+from pyoda_time.calendars._islamic_year_month_day_calculator import _IslamicYearMonthDayCalculator
 
 
 class TestIslamicCalendarSystem:
@@ -273,7 +274,7 @@ class TestIslamicCalendarSystem:
     def test_get_instance_caching(self) -> None:
         from collections import deque
 
-        queue: deque = deque()
+        queue: deque[CalendarSystem] = deque()
         set_: set[CalendarSystem] = set()
         ids: set[str] = set()
         for leap_year_pattern in IslamicLeapYearPattern:

--- a/tests/calendars/test_iso_calendar.py
+++ b/tests/calendars/test_iso_calendar.py
@@ -16,7 +16,7 @@ from pyoda_time import (
 )
 from pyoda_time._local_instant import _LocalInstant
 from pyoda_time.calendars import Era, WeekYearRules
-from pyoda_time.utility import _towards_zero_division
+from pyoda_time.utility._csharp_compatibility import _towards_zero_division
 
 ISO: CalendarSystem = CalendarSystem.iso
 

--- a/tests/calendars/test_um_al_qura_year_month_day_calculator.py
+++ b/tests/calendars/test_um_al_qura_year_month_day_calculator.py
@@ -5,7 +5,7 @@
 import pytest
 
 from pyoda_time._year_month_day import _YearMonthDay
-from pyoda_time.calendars import _UmAlQuraYearMonthDayCalculator
+from pyoda_time.calendars._um_al_qura_year_month_day_calculator import _UmAlQuraYearMonthDayCalculator
 
 
 class TestUmAlQuraYearMonthDayCalculator:

--- a/tests/calendars/test_year_month_day_calculator.py
+++ b/tests/calendars/test_year_month_day_calculator.py
@@ -11,15 +11,15 @@ from pyoda_time.calendars import (
     HebrewMonthNumbering,
     IslamicEpoch,
     IslamicLeapYearPattern,
-    _CopticYearMonthDayCalculator,
-    _GregorianYearMonthDayCalculator,
-    _HebrewYearMonthDayCalculator,
-    _IslamicYearMonthDayCalculator,
-    _JulianYearMonthDayCalculator,
-    _PersianYearMonthDayCalculator,
-    _UmAlQuraYearMonthDayCalculator,
-    _YearMonthDayCalculator,
 )
+from pyoda_time.calendars._coptic_year_month_day_calculator import _CopticYearMonthDayCalculator
+from pyoda_time.calendars._gregorian_year_month_day_calculator import _GregorianYearMonthDayCalculator
+from pyoda_time.calendars._hebrew_year_month_day_calculator import _HebrewYearMonthDayCalculator
+from pyoda_time.calendars._islamic_year_month_day_calculator import _IslamicYearMonthDayCalculator
+from pyoda_time.calendars._julian_year_month_day_calculator import _JulianYearMonthDayCalculator
+from pyoda_time.calendars._persian_year_month_day_calculator import _PersianYearMonthDayCalculator
+from pyoda_time.calendars._um_al_qura_year_month_day_calculator import _UmAlQuraYearMonthDayCalculator
+from pyoda_time.calendars._year_month_day_calculator import _YearMonthDayCalculator
 
 NON_ISLAMIC_CALCULATORS: Final[list[_YearMonthDayCalculator]] = [
     _GregorianYearMonthDayCalculator(),

--- a/tests/culture_saver.py
+++ b/tests/culture_saver.py
@@ -8,7 +8,7 @@ from typing import ContextManager
 from pyoda_time._compatibility._culture_info import CultureInfo
 
 
-class _BothSaver(ContextManager):
+class _BothSaver(ContextManager[None]):
     """A context manager for temporarily changing cultures and which resets the culture on exit."""
 
     @property
@@ -60,7 +60,7 @@ class CultureSaver:
     @classmethod
     def set_cultures(
         cls, new_culture_info: CultureInfo, new_ui_culture_info: CultureInfo | None = None
-    ) -> ContextManager:
+    ) -> ContextManager[None]:
         """Sets both the UI and basic cultures of the current thread.
 
         :param new_culture_info: The new culture info.

--- a/tests/globalization/test_pyoda_format_info.py
+++ b/tests/globalization/test_pyoda_format_info.py
@@ -8,7 +8,7 @@ import pytest
 from pyoda_time._compatibility._culture_info import CultureInfo
 from pyoda_time._compatibility._date_time_format_info import DateTimeFormatInfo
 from pyoda_time.calendars import Era
-from pyoda_time.globalization import _PyodaFormatInfo
+from pyoda_time.globalization._pyoda_format_info import _PyodaFormatInfo
 
 from ..culture_saver import CultureSaver
 from ..globalization.failing_culture_info import FailingCultureInfo
@@ -20,7 +20,7 @@ EN_GB: Final[CultureInfo] = CultureInfo.get_culture_info("en-GB")
 
 class TestPyodaFormatInfo:
     @pytest.mark.parametrize(
-        "culture", sorted(Cultures.all_cultures, key=lambda c: c._name), ids=lambda culture: f"{culture=}"
+        "culture", sorted(Cultures.all_cultures, key=lambda c: str(c)), ids=lambda culture: f"{culture=}"
     )
     def test_convert_culture(self, culture: CultureInfo) -> None:
         """Just check we can actually build a NodaFormatInfo for every culture, outside text-specific tests."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Iterable, Protocol, Self, TypeVar
 import pytest
 
 from pyoda_time import Offset, PyodaConstants
-from pyoda_time.utility import _Preconditions
+from pyoda_time.utility._preconditions import _Preconditions
 
 
 class IEquatable(Protocol):
@@ -237,25 +237,25 @@ def assert_valid(func: Callable[..., TOut], *args: TArg) -> TOut:
     return func(*args)
 
 
-def assert_out_of_range(func: Callable[..., TOut], *args: TArg) -> TOut:
+def assert_out_of_range(func: Callable[..., TOut], *args: TArg) -> None:
     """Asserts that calling func with the specified value(s) raises ValueError."""
     # TODO: In Noda Time ArgumentOutOfRangeException is thrown
     with pytest.raises(ValueError):
-        return func(*args)
+        func(*args)
 
 
-def assert_invalid(func: Callable[..., TOut], *args: Any) -> TOut:
+def assert_invalid(func: Callable[..., TOut], *args: Any) -> None:
     """Asserts that calling func with the specified value(s) raises ValueError."""
     # TODO: In Noda Time ArgumentException is thrown
     with pytest.raises(ValueError):
-        return func(*args)
+        func(*args)
 
 
-def assert_argument_null(func: Callable[..., TOut], *args: Any) -> TOut:
+def assert_argument_null(func: Callable[..., TOut], *args: Any) -> None:
     """Asserts that calling func with the specified value(s) raises TypeError."""
     # TODO: In Noda Time ArgumentNullException is thrown
     with pytest.raises(TypeError):
-        return func(*args)
+        func(*args)
 
 
 def assert_overflow(func: Callable[[TArg], TOut], param: TArg) -> None:

--- a/tests/test_duration.py
+++ b/tests/test_duration.py
@@ -10,7 +10,7 @@ from typing import Callable, Final, TypeVar
 import pytest
 
 from pyoda_time import Duration, PyodaConstants
-from pyoda_time.utility import _CsharpConstants, _towards_zero_division
+from pyoda_time.utility._csharp_compatibility import _CsharpConstants, _towards_zero_division
 from tests import helpers
 
 T = TypeVar("T")

--- a/tests/test_instant.py
+++ b/tests/test_instant.py
@@ -14,7 +14,7 @@ from pyoda_time import (
     PyodaConstants,
 )
 from pyoda_time._local_instant import _LocalInstant
-from pyoda_time.utility import _CsharpConstants, _towards_zero_division
+from pyoda_time.utility._csharp_compatibility import _CsharpConstants, _towards_zero_division
 from tests import helpers
 
 

--- a/tests/test_period.py
+++ b/tests/test_period.py
@@ -18,7 +18,7 @@ from pyoda_time import (
     PyodaConstants,
     YearMonth,
 )
-from pyoda_time.utility import _CsharpConstants
+from pyoda_time.utility._csharp_compatibility import _CsharpConstants
 
 # June 19th 2010, 2:30:15am
 TEST_DATE_TIME_1: Final[LocalDateTime] = LocalDateTime(2010, 6, 19, 2, 30, 15)
@@ -295,8 +295,8 @@ class TestPeriod:
         assert not Period.from_minutes(15).equals(Period.from_seconds(15))
         assert not Period.from_hours(1).equals(Period.from_minutes(60))
         # TODO: In Pyoda Time these return False
-        assert Period.from_hours(1).equals(object()) is NotImplemented  # type: ignore
-        assert Period.from_hours(1).equals(None) is NotImplemented  # type: ignore
+        assert not Period.from_hours(1).equals(object())  # type: ignore
+        assert not Period.from_hours(1).equals(None)  # type: ignore
 
     def test_equality_operators(self) -> None:
         val1 = Period.from_hours(1)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -34,16 +34,5 @@ def test_public_api_does_not_leak_imports(namespace: types.ModuleType) -> None:
     public_symbols_not_included_in_all_list = [
         symbol for symbol in dir(namespace) if symbol not in namespace.__all__ and not symbol.startswith("_")
     ]
-    # Special case for top-level namespace as it is used to import submodules
-    if namespace is pyoda_time:
-        known_submodules = [
-            "calendars",
-            "fields",
-            "globalization",
-            "text",
-            "time_zones",
-            "utility",
-        ]
-        for mod in known_submodules:
-            public_symbols_not_included_in_all_list.remove(mod)
+
     assert not public_symbols_not_included_in_all_list

--- a/tests/text/pattern_test_data.py
+++ b/tests/text/pattern_test_data.py
@@ -8,9 +8,10 @@ import pytest
 
 from pyoda_time._compatibility._culture_info import CultureInfo
 from pyoda_time._compatibility._string_builder import StringBuilder
-from pyoda_time.text import InvalidPatternError, UnparsableValueError, _ValueCursor
+from pyoda_time.text import InvalidPatternError, UnparsableValueError
 from pyoda_time.text._i_partial_pattern import _IPartialPattern
 from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.text._value_cursor import _ValueCursor
 
 T = TypeVar("T")
 
@@ -32,7 +33,7 @@ class PatternTestData(Generic[T]):
         template: T | None = None,
         description: str | None = None,
         message: str | None = None,
-        parameters: list | None = None,
+        parameters: list[Any] | None = None,
     ) -> None:
         self.value: Final[T] = value
         self.culture: CultureInfo = culture

--- a/tests/text/patterns/test_pattern_cursor.py
+++ b/tests/text/patterns/test_pattern_cursor.py
@@ -3,8 +3,9 @@
 # as found in the LICENSE.txt file.
 import pytest
 
-from pyoda_time.text import InvalidPatternError, _TextCursor
-from pyoda_time.text.patterns import _PatternCursor
+from pyoda_time.text import InvalidPatternError
+from pyoda_time.text._text_cursor import _TextCursor
+from pyoda_time.text.patterns._pattern_cursor import _PatternCursor
 
 from ..text_cursor_test_base import TextCursorTestBase
 

--- a/tests/text/patterns/test_pattern_field_extensions.py
+++ b/tests/text/patterns/test_pattern_field_extensions.py
@@ -3,7 +3,7 @@
 # as found in the LICENSE.txt file.
 
 
-from pyoda_time.text.patterns import _PatternFields
+from pyoda_time.text.patterns._pattern_fields import _PatternFields
 
 
 class TestPatternFieldExtensions:

--- a/tests/text/patterns/test_stepped_pattern_builder.py
+++ b/tests/text/patterns/test_stepped_pattern_builder.py
@@ -7,18 +7,19 @@ import pytest
 
 from pyoda_time import LocalDate, Offset
 from pyoda_time._compatibility._string_builder import StringBuilder
-from pyoda_time.globalization import _PyodaFormatInfo
+from pyoda_time.globalization._pyoda_format_info import _PyodaFormatInfo
 from pyoda_time.text import (
     InvalidPatternError,
     ParseResult,
     UnparsableValueError,
-    _ParseBucket,
-    _TextCursor,
-    _ValueCursor,
 )
 from pyoda_time.text._i_partial_pattern import _IPartialPattern
 from pyoda_time.text._offset_pattern_parser import _OffsetPatternParser
-from pyoda_time.text.patterns import _PatternCursor, _PatternFields
+from pyoda_time.text._parse_bucket import _ParseBucket
+from pyoda_time.text._text_cursor import _TextCursor
+from pyoda_time.text._value_cursor import _ValueCursor
+from pyoda_time.text.patterns._pattern_cursor import _PatternCursor
+from pyoda_time.text.patterns._pattern_fields import _PatternFields
 from pyoda_time.text.patterns._stepped_pattern_builder import _SteppedPatternBuilder
 
 

--- a/tests/text/test_offset_pattern.py
+++ b/tests/text/test_offset_pattern.py
@@ -4,7 +4,6 @@
 
 import pytest
 from _pytest.fixtures import FixtureRequest
-from _pytest.mark import ParameterSet
 
 from pyoda_time import Offset
 from pyoda_time._compatibility._culture_info import CultureInfo
@@ -348,22 +347,26 @@ FORMAT_DATA = FORMAT_ONLY_DATA + FORMAT_AND_PARSE_DATA
 
 
 @pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=}") for data in INVALID_PATTERN_DATA])
-def invalid_pattern_data(request: FixtureRequest) -> ParameterSet:
+def invalid_pattern_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
     return request.param
 
 
 @pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=}") for data in PARSE_FAILURE_DATA])
-def parse_failure_data(request: FixtureRequest) -> ParameterSet:
+def parse_failure_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
     return request.param
 
 
 @pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=}") for data in PARSE_DATA])
-def parse_data(request: FixtureRequest) -> ParameterSet:
+def parse_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
     return request.param
 
 
 @pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=} {data.culture=}") for data in FORMAT_DATA])
-def format_data(request: FixtureRequest) -> ParameterSet:
+def format_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
     return request.param
 
 

--- a/tests/text/test_parse_result.py
+++ b/tests/text/test_parse_result.py
@@ -4,7 +4,8 @@
 
 import pytest
 
-from pyoda_time.text import ParseResult, UnparsableValueError, _ValueCursor
+from pyoda_time.text import ParseResult, UnparsableValueError
+from pyoda_time.text._value_cursor import _ValueCursor
 
 
 class TestParseResult:

--- a/tests/text/test_value_cursor.py
+++ b/tests/text/test_value_cursor.py
@@ -4,8 +4,10 @@
 
 import pytest
 
-from pyoda_time.text import UnparsableValueError, _TextCursor, _ValueCursor
-from pyoda_time.utility import _CsharpConstants
+from pyoda_time.text import UnparsableValueError
+from pyoda_time.text._text_cursor import _TextCursor
+from pyoda_time.text._value_cursor import _ValueCursor
+from pyoda_time.utility._csharp_compatibility import _CsharpConstants
 
 from .text_cursor_test_base import TextCursorTestBase
 

--- a/tests/text/text_cursor_test_base.py
+++ b/tests/text/text_cursor_test_base.py
@@ -4,7 +4,7 @@
 
 from abc import ABC, abstractmethod
 
-from pyoda_time.text import _TextCursor
+from pyoda_time.text._text_cursor import _TextCursor
 
 
 class TextCursorTestBase(ABC):

--- a/tests/utility/test_csharp_compatibility.py
+++ b/tests/utility/test_csharp_compatibility.py
@@ -8,7 +8,7 @@ from typing import Annotated
 
 import pytest
 
-from pyoda_time.utility import _private, _sealed
+from pyoda_time.utility._csharp_compatibility import _private, _sealed
 
 
 def test_foo() -> None:


### PR DESCRIPTION
Enables strict mode in mypy.

This introduces its own challenges, particularly with the Python implementation of SteppedPatternBuilder. Those will be addressed in a subsequent PR.