### PR TITLE
feat: implement `LocalDatePattern`

### DIFF
--- a/pyoda_time/_compatibility/_culture_data.py
+++ b/pyoda_time/_compatibility/_culture_data.py
@@ -1152,6 +1152,11 @@ class _CultureData(metaclass=_CultureDataMeta):
 
         return "".join(buffer) if changed else name, collation_start
 
+    def _month_day(self, calendar_id: _CalendarId) -> str:
+        month_day = self._get_calendar(calendar_id)._sMonthDay
+        assert month_day is not None
+        return month_day
+
 
 class LocaleStringData(IntEnum):
     # localized name of locale, eg "German (Germany)" in UI language (corresponds to LOCALE_SLOCALIZEDDISPLAYNAME)

--- a/pyoda_time/_compatibility/_date_time_format_info.py
+++ b/pyoda_time/_compatibility/_date_time_format_info.py
@@ -54,7 +54,7 @@ class DateTimeFormatInfo(metaclass=_CombinedMeta):
         self.__day_names: Sequence[str] | None = None
         self.__abbreviated_day_names: Sequence[str] | None = None
         self.__m_era_names: list[str] | None = None
-        self.__month_names: list[str] | None = None
+        self.__month_names: Sequence[str] | None = None
         self.__abbreviated_month_names: Sequence[str] | None = None
         self.__genitive_month_names: Sequence[str] | None = None
         self.__m_genitive_abbreviated_month_names: Sequence[str] | None = None
@@ -70,6 +70,7 @@ class DateTimeFormatInfo(metaclass=_CombinedMeta):
         self.__general_short_time_pattern: str | None = None
         self.__full_date_time_pattern: str | None = None
         self.__date_time_offset_pattern: str | None = None
+        self.__month_day_pattern: str | None = None
 
     @classmethod
     def _ctor(cls, culture_data: _CultureData, cal: Calendar) -> DateTimeFormatInfo:
@@ -103,6 +104,7 @@ class DateTimeFormatInfo(metaclass=_CombinedMeta):
         self.__general_short_time_pattern = None
         self.__full_date_time_pattern = None
         self.__date_time_offset_pattern = None
+        self.__month_day_pattern = None
 
         return self
 
@@ -290,7 +292,10 @@ class DateTimeFormatInfo(metaclass=_CombinedMeta):
 
     @property
     def month_day_pattern(self) -> str:
-        raise NotImplementedError
+        if self.__month_day_pattern is None:
+            self.__month_day_pattern = self._culture_data._month_day(self.calendar._id)
+        assert self.__month_day_pattern is not None
+        return self.__month_day_pattern
 
     @property
     def time_separator(self) -> str:
@@ -425,15 +430,15 @@ class DateTimeFormatInfo(metaclass=_CombinedMeta):
         self.__day_names = value
 
     @property
-    def abbreviated_month_names(self) -> list[str]:
+    def abbreviated_month_names(self) -> Sequence[str]:
         """Gets or sets the culture-specific abbreviated names of the months.
 
         :return:
         """
-        return list(self.__internal_get_abbreviated_month_names())
+        return self.__internal_get_abbreviated_month_names()
 
     @abbreviated_month_names.setter
-    def abbreviated_month_names(self, value: list[str]) -> None:
+    def abbreviated_month_names(self, value: Sequence[str]) -> None:
         self.__verify_writable()
         if value is None:
             raise TypeError("value cannot be None")
@@ -445,7 +450,7 @@ class DateTimeFormatInfo(metaclass=_CombinedMeta):
         self.__abbreviated_month_names = value
 
     @property
-    def month_names(self) -> list[str]:
+    def month_names(self) -> Sequence[str]:
         """Gets or sets the culture-specific full names of the months.
 
         In a 12-month calendar, the 13th element of the array is an empty string.
@@ -454,12 +459,12 @@ class DateTimeFormatInfo(metaclass=_CombinedMeta):
         "February", "March", "April", "May", "June", "July", "August", "September",
         "October", "November", "December", and "".
 
-        :return: A list containing the culture-specific full names of the months.
+        :return: The culture-specific full names of the months.
         """
-        return list(self.__internal_get_month_names())
+        return self.__internal_get_month_names()
 
     @month_names.setter
-    def month_names(self, value: list[str]) -> None:
+    def month_names(self, value: Sequence[str]) -> None:
         self.__verify_writable()
         if value is None:
             raise TypeError("value cannot be None")

--- a/pyoda_time/_compatibility/_day_of_week.py
+++ b/pyoda_time/_compatibility/_day_of_week.py
@@ -1,0 +1,17 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from enum import IntEnum
+
+
+class DayOfWeek(IntEnum):
+    """Specifies the day of the week."""
+
+    Sunday = 0
+    Monday = 1
+    Tuesday = 2
+    Wednesday = 3
+    Thursday = 4
+    Friday = 5
+    Saturday = 6

--- a/pyoda_time/_local_date.py
+++ b/pyoda_time/_local_date.py
@@ -359,6 +359,10 @@ class LocalDate(metaclass=_LocalDateMeta):
 
     # region Formatting
 
-    # TODO: def __str__(self): [requires LocalDatePattern.BclSupport]
+    def __repr__(self) -> str:
+        from ._compatibility._culture_info import CultureInfo
+        from .text import LocalDatePattern
+
+        return LocalDatePattern._bcl_support.format(self, None, CultureInfo.current_culture)
 
     # endregion

--- a/pyoda_time/text/_format_helper.py
+++ b/pyoda_time/text/_format_helper.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 from pyoda_time._compatibility._string_builder import StringBuilder
-from pyoda_time.utility._csharp_compatibility import _csharp_modulo, _towards_zero_division
+from pyoda_time.utility._csharp_compatibility import _csharp_modulo, _CsharpConstants, _towards_zero_division
 
 
 class FormatHelper:
@@ -35,8 +35,8 @@ class FormatHelper:
             output_buffer.append("-")
         output_buffer.append(f"{value:04}")
 
-    @staticmethod
-    def left_pad(value: int, length: int, output_buffer: StringBuilder) -> None:
+    @classmethod
+    def left_pad(cls, value: int, length: int, output_buffer: StringBuilder) -> None:
         """Formats the given value left padded with zeros.
 
         Left pads with zeros the value into a field of ``length`` characters. If the value
@@ -48,7 +48,19 @@ class FormatHelper:
         :param output_buffer: The output buffer to add the digits to.
         :return:
         """
-        raise NotImplementedError
+        # TODO: Preconditions.DebugCheckArgumentRange(nameof(length), length, 1, MaximumPaddingLength);
+        # TODO: unchecked
+        if value >= 0:
+            cls.left_pad_non_negative(value, length, output_buffer)
+            return
+        output_buffer.append("-")
+        # Special case, as we can't use Math.Abs.
+        if value == _CsharpConstants.INT_MIN_VALUE:
+            if length > 10:
+                output_buffer.append("000000"[16 - length :])
+            output_buffer.append("2147483648")
+            return
+        cls.left_pad_non_negative(-value, length, output_buffer)
 
     @staticmethod
     def left_pad_non_negative(value: int, length: int, output_buffer: StringBuilder) -> None:

--- a/pyoda_time/text/_local_date_pattern.py
+++ b/pyoda_time/text/_local_date_pattern.py
@@ -3,8 +3,10 @@
 # as found in the LICENSE.txt file.
 from __future__ import annotations
 
-from typing import Final, cast, final
+from typing import Final, _ProtocolMeta, cast, final
 
+from pyoda_time._calendar_system import CalendarSystem
+from pyoda_time._compatibility._culture_info import CultureInfo
 from pyoda_time._compatibility._string_builder import StringBuilder
 from pyoda_time._local_date import LocalDate
 from pyoda_time.globalization._pyoda_format_info import _PyodaFormatInfo
@@ -12,14 +14,57 @@ from pyoda_time.text._i_partial_pattern import _IPartialPattern
 from pyoda_time.text._i_pattern import IPattern
 from pyoda_time.text._local_date_pattern_parser import _LocalDatePatternParser
 from pyoda_time.text._parse_result import ParseResult
+from pyoda_time.text.patterns._pattern_bcl_support import _PatternBclSupport
 from pyoda_time.utility._csharp_compatibility import _private, _sealed
 from pyoda_time.utility._preconditions import _Preconditions
+
+
+class __LocalDatePatternMeta(_ProtocolMeta):
+    __DEFAULT_FORMAT_PATTERN: Final[str] = "D"  # Long
+
+    @property
+    def _bcl_support(self) -> _PatternBclSupport[LocalDate]:
+        return _PatternBclSupport(self.__DEFAULT_FORMAT_PATTERN, lambda fi: fi._local_date_pattern_parser)
+
+    @property
+    def iso(self) -> LocalDatePattern:
+        """Gets an invariant local date pattern which is ISO-8601 compatible and which round trips values, but doesn't
+        include the calendar system. This corresponds to the text pattern "uuuu'-'MM'-'dd".
+
+        This pattern corresponds to the 'R' standard pattern.
+
+        :return: An invariant local date pattern which is ISO-8601 compatible.
+        """
+        return self._Patterns._iso_pattern_impl
+
+    @property
+    def full_roundtrip(self) -> LocalDatePattern:
+        """Gets an invariant local date pattern which round trips values including the calendar system. This corresponds
+        to the text pattern "uuuu'-'MM'-'dd '('c')'".
+
+        This pattern corresponds to the 'r' standard pattern.
+
+        :return: An invariant local date pattern which round trips values including the calendar system.
+        """
+        return self._Patterns._full_roundtrip_pattern_impl
+
+    class __PatternsMeta(type):
+        @property
+        def _iso_pattern_impl(self) -> LocalDatePattern:
+            return LocalDatePattern.create_with_invariant_culture("uuuu'-'MM'-'dd")
+
+        @property
+        def _full_roundtrip_pattern_impl(self) -> LocalDatePattern:
+            return LocalDatePattern.create_with_invariant_culture("uuuu'-'MM'-'dd '('c')'")
+
+    class _Patterns(metaclass=__PatternsMeta):
+        pass
 
 
 @final
 @_sealed
 @_private
-class LocalDatePattern(IPattern[LocalDate]):
+class LocalDatePattern(IPattern[LocalDate], metaclass=__LocalDatePatternMeta):
     """Represents a pattern for parsing and formatting ``Instant`` values."""
 
     _DEFAULT_TWO_DIGIT_YEAR_MAX: Final[int] = 30
@@ -56,6 +101,16 @@ class LocalDatePattern(IPattern[LocalDate]):
         """
         return self.__template_value
 
+    @property
+    def two_digit_year_max(self) -> int:
+        """Maximum two-digit-year in the template to treat as the current century. If the value parsed is higher than
+        this, the result is adjusted to the previous century. This value defaults to 30. To create a pattern with a
+        different value, use ``with_two_digit_year_max``.
+
+        :return: The value used for the maximum two-digit-year, in the range 0-99 inclusive.
+        """
+        return self.__two_digit_year_max
+
     @classmethod
     def __ctor(
         cls,
@@ -74,13 +129,33 @@ class LocalDatePattern(IPattern[LocalDate]):
         return self
 
     def parse(self, text: str) -> ParseResult[LocalDate]:
-        raise NotImplementedError
+        """Parses the given text value according to the rules of this pattern.
+
+        This method never throws an exception (barring a bug in Pyoda Time itself). Even errors such as the argument
+        being null are wrapped in a parse result.
+
+        :param text: The text value to parse.
+        :return: The result of parsing, which may be successful or unsuccessful.
+        """
+        return self._underlying_pattern.parse(text)
 
     def format(self, value: LocalDate) -> str:
-        raise NotImplementedError
+        """Formats the given local date as text according to the rules of this pattern.
+
+        :param value: The local date to format.
+        :return: The local date formatted according to this pattern.
+        """
+        return self._underlying_pattern.format(value)
 
     def append_format(self, value: LocalDate, builder: StringBuilder) -> StringBuilder:
-        raise NotImplementedError
+        """Formats the given value as text according to the rules of this pattern, appending to the given
+        ``StringBuilder``.
+
+        :param value: The value to format.
+        :param builder: The ``StringBuilder`` to append to.
+        :return: The builder passed in as ``builder``.
+        """
+        return self._underlying_pattern.append_format(value, builder)
 
     @classmethod
     def _create(
@@ -108,3 +183,107 @@ class LocalDatePattern(IPattern[LocalDate]):
             pattern = pattern._underlying_pattern
         partial_pattern = cast(_IPartialPattern[LocalDate], pattern)
         return LocalDatePattern.__ctor(pattern_text, format_info, template_value, two_digit_year_max, partial_pattern)
+
+    @classmethod
+    def create(
+        cls, pattern_text: str, culture_info: CultureInfo, template_value: LocalDate | None = None
+    ) -> LocalDatePattern:
+        """Creates a pattern for the given pattern text, culture, and template value.
+
+        If no template value is provided, the default template value of 2000-01-01 will be used.
+
+        See the user guide for the available pattern text options.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :param culture_info: The culture to use in the pattern
+        :param template_value: Maximum two-digit-year in the template to treat as the current century.
+        :return: A pattern for parsing and formatting local dates. :exception InvalidPatternError: The pattern text was
+            invalid.
+        """
+        if template_value is None:
+            template_value = cls._DEFAULT_TEMPLATE_VALUE
+        return cls._create(
+            pattern_text,
+            _PyodaFormatInfo._get_format_info(culture_info),
+            template_value,
+            cls._DEFAULT_TWO_DIGIT_YEAR_MAX,
+        )
+
+    @classmethod
+    def create_with_current_culture(cls, pattern_text: str) -> LocalDatePattern:
+        """Creates a pattern for the given pattern text in the current thread's current culture.
+
+        See the user guide for the available pattern text options. Note that the current culture
+        is captured at the time this method is called - it is not captured at the point of parsing
+        or formatting values.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :return: A pattern for parsing and formatting local dates.
+        :exception InvalidPatternError: The pattern text was invalid.
+        """
+        return cls._create(
+            pattern_text, _PyodaFormatInfo.current_info, cls._DEFAULT_TEMPLATE_VALUE, cls._DEFAULT_TWO_DIGIT_YEAR_MAX
+        )
+
+    @classmethod
+    def create_with_invariant_culture(cls, pattern_text: str) -> LocalDatePattern:
+        """Creates a pattern for the given pattern text in the invariant culture.
+
+        See the user guide for the available pattern text options. Note that the current culture
+        is captured at the time this method is called - it is not captured at the point of parsing
+        or formatting values.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :return: A pattern for parsing and formatting local dates.
+        """
+        return cls._create(
+            pattern_text, _PyodaFormatInfo.invariant_info, cls._DEFAULT_TEMPLATE_VALUE, cls._DEFAULT_TWO_DIGIT_YEAR_MAX
+        )
+
+    def __with_format_info(self, format_info: _PyodaFormatInfo) -> LocalDatePattern:
+        """Creates a pattern for the same original pattern text as this pattern, but with the specified localization
+        information.
+
+        :param format_info: The localization information to use in the new pattern.
+        :return: A new pattern with the given localization information.
+        """
+        return self._create(self.pattern_text, format_info, self.template_value, self.two_digit_year_max)
+
+    def with_culture(self, culture_info: CultureInfo) -> LocalDatePattern:
+        """Creates a pattern for the same original pattern text as this pattern, but with the specified culture.
+
+        :param culture_info: The culture to use in the new pattern.
+        :return: A new pattern with the given culture.
+        """
+        return self.__with_format_info(_PyodaFormatInfo._get_format_info(culture_info))
+
+    def with_template_value(self, new_template_value: LocalDate) -> LocalDatePattern:
+        """Creates a pattern like this one, but with the specified template value.
+
+        :param new_template_value: The template value for the new pattern, used to fill in unspecified fields.
+        :return: A new pattern with the given template value.
+        """
+        return self._create(self.pattern_text, self.__format_info, new_template_value, self.two_digit_year_max)
+
+    def with_calendar(self, calendar: CalendarSystem) -> LocalDatePattern:
+        """Creates a pattern like this one, but with the template value modified to use the specified calendar system.
+
+        Care should be taken in two (relatively rare) scenarios. Although the default template value is supported by all
+        Noda Time calendar systems, if a pattern is created with a different template value and then this method is
+        called with a calendar system which doesn't support that date, an exception will be thrown. Additionally, if the
+        pattern only specifies some date fields, it's possible that the new template value will not be suitable for all
+        values.
+
+        :param calendar: The calendar system to convert the template value into.
+        :return: A new pattern with a template value in the specified calendar system.
+        """
+        return self.with_template_value(self.template_value.with_calendar(calendar))
+
+    def with_two_digit_year_max(self, two_digit_year_max: int) -> LocalDatePattern:
+        """Creates a pattern like this one, but with a different ``two_digit_year_max`` value.
+
+        :param two_digit_year_max: The value to use for ``two_digit_year_max`` in the new pattern, in the range 0-99
+            inclusive.
+        :return: A new pattern with the specified maximum two-digit-year.
+        """
+        return self._create(self.pattern_text, self.__format_info, self.template_value, two_digit_year_max)

--- a/tests/text/cultures.py
+++ b/tests/text/cultures.py
@@ -1,15 +1,19 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Sequence
 
 from pyoda_time._compatibility._culture_info import CultureInfo
 from pyoda_time._compatibility._culture_types import CultureTypes
 from pyoda_time._compatibility._date_time_format_info import DateTimeFormatInfo
+from pyoda_time._compatibility._day_of_week import DayOfWeek
 
 
 class _CulturesMeta(type):
     __awkward_am_pm_designator_culture: CultureInfo | None = None
+    __awkward_day_of_week_culture: CultureInfo | None = None
+    __genitive_name_test_culture: CultureInfo | None = None
+    __genitive_name_test_culture_with_leading_names: CultureInfo | None = None
 
     @property
     def all_cultures(cls) -> Iterable[CultureInfo]:
@@ -76,6 +80,85 @@ class _CulturesMeta(type):
         date_format = clone.date_time_format
         date_format.am_designator = "Foo"
         date_format.pm_designator = "FooBar"
+        return clone
+
+    @property
+    def _genitive_name_test_culture(cls) -> CultureInfo:
+        if cls.__genitive_name_test_culture is None:
+            cls.__genitive_name_test_culture = cls.__create_genitive_name_test_culture()
+        return cls.__genitive_name_test_culture
+
+    @classmethod
+    def __create_genitive_name_test_culture(cls) -> CultureInfo:
+        """.NET 3.5 doesn't contain any cultures where the abbreviated month names differ from the non-abbreviated month
+        names.
+
+        As we're testing under .NET 3.5, we'll need to create our own. This is just a clone of the invariant culture,
+        with month 1 changed.
+        """
+        clone = CultureInfo.invariant_culture.clone()
+        dtf: DateTimeFormatInfo = clone.date_time_format
+        dtf.month_names = cls.__replace_first_element(dtf.month_names, "FullNonGenName")
+        dtf.month_genitive_names = cls.__replace_first_element(dtf.month_genitive_names, "FullGenName")
+        dtf.abbreviated_month_names = cls.__replace_first_element(dtf.abbreviated_month_names, "AbbrNonGenName")
+        dtf.abbreviated_month_genitive_names = cls.__replace_first_element(
+            dtf.abbreviated_month_genitive_names, "AbbrGenName"
+        )
+        # Note: Do *not* use CultureInfo.ReadOnly here, as it's broken in .NET 3.5 and lower; the month names
+        # get reset to the original values, making the customization pointless :(
+        return clone
+
+    @property
+    def _genitive_name_test_culture_with_leading_names(self) -> CultureInfo:
+        if self.__genitive_name_test_culture_with_leading_names is None:
+            self.__genitive_name_test_culture_with_leading_names = (
+                self.__create_genitive_name_test_culture_with_leading_names()
+            )
+        return self.__genitive_name_test_culture_with_leading_names
+
+    @classmethod
+    def __create_genitive_name_test_culture_with_leading_names(cls) -> CultureInfo:
+        clone = CultureInfo.invariant_culture.clone()
+        dtf: DateTimeFormatInfo = clone.date_time_format
+        dtf.month_names = cls.__replace_first_element(dtf.month_names, "MonthName")
+        dtf.month_genitive_names = cls.__replace_first_element(dtf.month_genitive_names, "MonthName-Genitive")
+        dtf.abbreviated_month_names = cls.__replace_first_element(dtf.abbreviated_month_names, "MN")
+        dtf.abbreviated_month_genitive_names = cls.__replace_first_element(
+            dtf.abbreviated_month_genitive_names, "MN-Gen"
+        )
+        # Note: Do *not* use CultureInfo.ReadOnly here, as it's broken in .NET 3.5 and lower; the month names
+        # get reset to the original values, making the customization pointless :(
+        return clone
+
+    @classmethod
+    def __replace_first_element(cls, elements: Sequence[str], new_element: str) -> Sequence[str]:
+        # Cloning so we don't accidentally *really* change any read-only cultures, to work around a bug in Mono.
+        clone = list(elements)
+        clone[0] = new_element
+        return clone
+
+    @property
+    def _awkward_day_of_week_culture(self) -> CultureInfo:
+        if self.__awkward_day_of_week_culture is None:
+            self.__awkward_day_of_week_culture = self.__create_awkward_day_of_week_culture()
+        return self.__awkward_day_of_week_culture
+
+    def __create_awkward_day_of_week_culture(cls) -> CultureInfo:
+        """Like the invariant culture, but Thursday is called "FooBa" (or "Foobaz" for short, despite being longer), and
+        Friday is called "FooBar" (or "Foo" for short).
+
+        This is expected to confuse our parser if we're not careful.
+        """
+        clone = CultureInfo.invariant_culture.clone()
+        dtf: DateTimeFormatInfo = clone.date_time_format
+        long_day_names = dtf.day_names
+        short_day_names = dtf.abbreviated_day_names
+        long_day_names[int(DayOfWeek.Thursday)] = "FooBa"
+        short_day_names[int(DayOfWeek.Thursday)] = "FooBaz"
+        long_day_names[int(DayOfWeek.Friday)] = "FooBar"
+        short_day_names[int(DayOfWeek.Friday)] = "Foo"
+        dtf.day_names = long_day_names
+        dtf.abbreviated_day_names = short_day_names
         return clone
 
 

--- a/tests/text/test_local_date_pattern.py
+++ b/tests/text/test_local_date_pattern.py
@@ -1,0 +1,668 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Any, Final
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from pyoda_time import CalendarSystem, LocalDate
+from pyoda_time._compatibility._culture_info import CultureInfo
+from pyoda_time.text import LocalDatePattern
+from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.text._text_error_messages import _TextErrorMessages
+from pyoda_time.utility._csharp_compatibility import _CsharpConstants
+
+from ..culture_saver import CultureSaver
+from .cultures import Cultures
+from .pattern_test_base import PatternTestBase
+from .pattern_test_data import PatternTestData
+
+
+class Data(PatternTestData[LocalDate]):
+    @property
+    def default_template(self) -> LocalDate:
+        # Default to the start of the year 2000.
+        return LocalDatePattern._DEFAULT_TEMPLATE_VALUE
+
+    def __init__(
+        self,
+        *,
+        value: LocalDate = LocalDatePattern._DEFAULT_TEMPLATE_VALUE,
+        text: str | None = None,
+        pattern: str | None = None,
+        message: str | None = None,
+        parameters: list[Any] | None = None,
+        culture: CultureInfo | None = CultureInfo.invariant_culture,
+        template: LocalDate | None = None,
+        standard_pattern: IPattern[LocalDate] | None = None,
+    ) -> None:
+        super().__init__(
+            value,
+            text=text,
+            pattern=pattern,
+            message=message,
+            parameters=parameters,
+            culture=culture or CultureInfo.invariant_culture,
+            template=template,
+            standard_pattern=standard_pattern,
+        )
+
+    def create_pattern(self) -> IPattern[LocalDate]:
+        assert self.pattern is not None
+        return (
+            LocalDatePattern.create_with_invariant_culture(self.pattern)
+            .with_template_value(self.template)
+            .with_culture(self.culture)
+        )
+
+
+SAMPLE_LOCAL_DATE: Final[LocalDate] = LocalDate(year=1976, month=6, day=19)
+
+INVALID_PATTERN_DATA: list[Data] = [
+    Data(pattern="", message=_TextErrorMessages.FORMAT_STRING_EMPTY),
+    Data(pattern="!", message=_TextErrorMessages.UNKNOWN_STANDARD_FORMAT, parameters=["!", LocalDate.__name__]),
+    Data(pattern="%", message=_TextErrorMessages.UNKNOWN_STANDARD_FORMAT, parameters=["%", LocalDate.__name__]),
+    Data(pattern="\\", message=_TextErrorMessages.UNKNOWN_STANDARD_FORMAT, parameters=["\\", LocalDate.__name__]),
+    Data(pattern="%%", message=_TextErrorMessages.PERCENT_DOUBLED),
+    Data(pattern="%\\", message=_TextErrorMessages.ESCAPE_AT_END_OF_STRING),
+    Data(pattern="MMMMM", message=_TextErrorMessages.REPEAT_COUNT_EXCEEDED, parameters=["M", 4]),
+    Data(pattern="ddddd", message=_TextErrorMessages.REPEAT_COUNT_EXCEEDED, parameters=["d", 4]),
+    Data(pattern="M%", message=_TextErrorMessages.PERCENT_AT_END_OF_STRING),
+    Data(pattern="yyyyy", message=_TextErrorMessages.REPEAT_COUNT_EXCEEDED, parameters=["y", 4]),
+    Data(pattern="uuuuu", message=_TextErrorMessages.REPEAT_COUNT_EXCEEDED, parameters=["u", 4]),
+    Data(pattern="ggg", message=_TextErrorMessages.REPEAT_COUNT_EXCEEDED, parameters=["g", 2]),
+    Data(pattern="'qwe", message=_TextErrorMessages.MISSING_END_QUOTE, parameters=["'"]),
+    Data(pattern="'qwe\\", message=_TextErrorMessages.ESCAPE_AT_END_OF_STRING),
+    Data(pattern="'qwe\\'", message=_TextErrorMessages.MISSING_END_QUOTE, parameters=["'"]),
+    # Note incorrect use of "u" (year) instead of "y" (year of era)
+    Data(pattern="dd MM uuuu gg", message=_TextErrorMessages.ERA_WITHOUT_YEAR_OF_ERA),
+    # Era specifier and calendar specifier in the same pattern.
+    Data(pattern="dd MM yyyy gg c", message=_TextErrorMessages.CALENDAR_AND_ERA),
+    # Invalid patterns directly after the uuuu specifier. This will detect the issue early, but then
+    # continue and reject it in the normal path.
+    Data(pattern="uuuu'", message=_TextErrorMessages.MISSING_END_QUOTE, parameters=["'"]),
+    Data(pattern="uuuu\\", message=_TextErrorMessages.ESCAPE_AT_END_OF_STRING),
+    # Common typo, which is caught in 2.0...
+    Data(pattern="uuuu-mm-dd", message=_TextErrorMessages.UNQUOTED_LITERAL, parameters=["m"]),
+    # T isn't valid in a date pattern
+    Data(pattern="uuuu-MM-ddT00:00:00", message=_TextErrorMessages.UNQUOTED_LITERAL, parameters=["T"]),
+    # These became invalid in v2.0, when we decided that y and yyy weren't sensible.
+    Data(pattern="y M d", message=_TextErrorMessages.INVALID_REPEAT_COUNT, parameters=["y", 1]),
+    Data(pattern="yyy M d", message=_TextErrorMessages.INVALID_REPEAT_COUNT, parameters=["y", 3]),
+]
+
+PARSE_FAILURE_DATA: list[Data] = [
+    Data(pattern="yyyy gg", text="2011 PyodaEra", message=_TextErrorMessages.MISMATCHED_TEXT, parameters=["g"]),
+    Data(
+        pattern="yyyy uuuu gg",
+        text="0010 0009 B.C.",
+        message=_TextErrorMessages.INCONSISTENT_VALUES_2,
+        parameters=["g", "u", LocalDate.__name__],
+    ),
+    Data(
+        pattern="uuuu MM dd dddd",
+        text="2011 10 09 Saturday",
+        message=_TextErrorMessages.INCONSISTENT_DAY_OF_WEEK_TEXT_VALUE,
+    ),
+    Data(
+        pattern="uuuu MM dd ddd", text="2011 10 09 Sat", message=_TextErrorMessages.INCONSISTENT_DAY_OF_WEEK_TEXT_VALUE
+    ),
+    Data(
+        pattern="uuuu MM dd MMMM", text="2011 10 09 January", message=_TextErrorMessages.INCONSISTENT_MONTH_TEXT_VALUE
+    ),
+    Data(
+        pattern="uuuu MM dd ddd", text="2011 10 09 FooBar", message=_TextErrorMessages.MISMATCHED_TEXT, parameters=["d"]
+    ),
+    Data(
+        pattern="uuuu MM dd dddd",
+        text="2011 10 09 FooBar",
+        message=_TextErrorMessages.MISMATCHED_TEXT,
+        parameters=["d"],
+    ),
+    Data(pattern="uuuu/MM/dd", text="2011/02-29", message=_TextErrorMessages.DATE_SEPARATOR_MISMATCH),
+    # Don't match a short name against a long pattern
+    Data(pattern="uuuu MMMM dd", text="2011 Oct 09", message=_TextErrorMessages.MISMATCHED_TEXT, parameters=["M"]),
+    # Or vice versa... although this time we match the "Oct" and then fail as we're expecting a space
+    Data(
+        pattern="uuuu MMM dd", text="2011 October 09", message=_TextErrorMessages.MISMATCHED_CHARACTER, parameters=[" "]
+    ),
+    # Invalid month even when we've got genitive and non-genitive names to pick from
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="MMMM",
+        text="BogusName",
+        culture=Cultures._genitive_name_test_culture,
+        message=_TextErrorMessages.MISMATCHED_TEXT,
+        parameters=["M"],
+    ),
+    # Invalid year-of-era, month, day
+    Data(
+        pattern="yyyy MM dd",
+        text="0000 01 01",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=[0, "y", LocalDate.__name__],
+    ),
+    Data(
+        pattern="yyyy MM dd",
+        text="2011 15 29",
+        message=_TextErrorMessages.MONTH_OUT_OF_RANGE,
+        parameters=[15, 2011],
+    ),
+    Data(
+        pattern="yyyy MM dd",
+        text="2011 02 35",
+        message=_TextErrorMessages.DAY_OF_MONTH_OUT_OF_RANGE,
+        parameters=[35, 2, 2011],
+    ),
+    # Year of era can't be negative...
+    Data(
+        pattern="yyyy MM dd",
+        text="-15 01 01",
+        message=_TextErrorMessages.UNEXPECTED_NEGATIVE,
+    ),
+    # Invalid leap years
+    Data(
+        pattern="uuuu MM dd",
+        text="2011 02 29",
+        message=_TextErrorMessages.DAY_OF_MONTH_OUT_OF_RANGE,
+        parameters=[29, 2, 2011],
+    ),
+    Data(
+        pattern="uuuu MM dd",
+        text="1900 02 29",
+        message=_TextErrorMessages.DAY_OF_MONTH_OUT_OF_RANGE,
+        parameters=[29, 2, 1900],
+    ),
+    # Year of era and two-digit year, but they don't match
+    Data(
+        pattern="yyyy uu",
+        text="2011 10",
+        message=_TextErrorMessages.INCONSISTENT_VALUES_2,
+        parameters=["y", "u", LocalDate.__name__],
+    ),
+    # Invalid calendar name
+    Data(
+        pattern="c uuuu MM dd",
+        text="2015 01 01",
+        message=_TextErrorMessages.NO_MATCHING_CALENDAR_SYSTEM,
+    ),
+    # Invalid year
+    Data(
+        template=LocalDate(year=1, month=1, day=1, calendar=CalendarSystem.islamic_bcl),
+        pattern="uuuu",
+        text="9999",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=[9999, "u", LocalDate.__name__],
+    ),
+    Data(
+        template=LocalDate(year=1, month=1, day=1, calendar=CalendarSystem.islamic_bcl),
+        pattern="yyyy",
+        text="9999",
+        message=_TextErrorMessages.YEAR_OF_ERA_OUT_OF_RANGE,
+        parameters=[9999, "EH", "Hijri"],
+    ),
+    # https://github.com/nodatime/nodatime/issues/414
+    Data(
+        pattern="yyyy-MM-dd",
+        text="1984-00-15",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=[0, "M", LocalDate.__name__],
+    ),
+    Data(
+        pattern="M/d/yyyy",
+        text="00/15/1984",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=[0, "M", LocalDate.__name__],
+    ),
+    # Calendar ID parsing is now ordinal, case-sensitive
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="uuuu MM dd c",
+        text="2011 10 19 iso",
+        message=_TextErrorMessages.NO_MATCHING_CALENDAR_SYSTEM,
+    ),
+]
+
+PARSE_ONLY_DATA: list[Data] = [
+    # Alternative era names
+    Data(
+        value=LocalDate(year=0, month=10, day=3),
+        pattern="yyyy MM dd gg",
+        text="0001 10 03 BCE",
+    ),
+    # Valid leap years
+    Data(
+        value=LocalDate(year=2000, month=2, day=29),
+        pattern="uuuu MM dd",
+        text="2000 02 29",
+    ),
+    Data(
+        value=LocalDate(year=2004, month=2, day=29),
+        pattern="uuuu MM dd",
+        text="2004 02 29",
+    ),
+    # Month parsing should be case-insensitive
+    Data(
+        value=LocalDate(year=2011, month=10, day=3),
+        pattern="uuuu MMM dd",
+        text="2011 OcT 03",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=3),
+        pattern="uuuu MMMM dd",
+        text="2011 OcToBeR 03",
+    ),
+    # Day-of-week parsing should be case-insensitive
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="uuuu MM dd ddd",
+        text="2011 10 09 sUN",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="uuuu MM dd dddd",
+        text="2011 10 09 SuNDaY",
+    ),
+    # Genitive name is an extension of the non-genitive name; parse longer first.
+    Data(
+        value=LocalDate(year=2011, month=1, day=10),
+        pattern="uuuu MMMM dd",
+        text="2011 MonthName-Genitive 10",
+        culture=Cultures._genitive_name_test_culture_with_leading_names,
+    ),
+    Data(
+        value=LocalDate(year=2011, month=1, day=10),
+        pattern="uuuu MMMM dd",
+        text="2011 MonthName 10",
+        culture=Cultures._genitive_name_test_culture_with_leading_names,
+    ),
+    Data(
+        value=LocalDate(year=2011, month=1, day=10),
+        pattern="uuuu MMM dd",
+        text="2011 MN-Gen 10",
+        culture=Cultures._genitive_name_test_culture_with_leading_names,
+    ),
+    Data(
+        value=LocalDate(year=2011, month=1, day=10),
+        pattern="uuuu MMM dd",
+        text="2011 MN 10",
+        culture=Cultures._genitive_name_test_culture_with_leading_names,
+    ),
+]
+
+FORMAT_ONLY_DATA: list[Data] = [
+    # Would parse back to 2011
+    Data(
+        value=LocalDate(year=1811, month=7, day=3),
+        pattern="yy M d",
+        text="11 7 3",
+    ),
+    # Tests for the documented 2-digit formatting of BC years
+    # (Less of an issue since yy became "year of era")
+    Data(
+        value=LocalDate(year=-94, month=7, day=3),
+        pattern="yy M d",
+        text="95 7 3",
+    ),
+    Data(
+        value=LocalDate(year=-93, month=7, day=3),
+        pattern="yy M d",
+        text="94 7 3",
+    ),
+]
+
+FORMAT_AND_PARSE_DATA: list[Data] = [
+    # Standard patterns
+    # Invariant culture uses the crazy MM/dd/yyyy format. Blech.
+    Data(
+        value=LocalDate(year=2011, month=10, day=20),
+        pattern="d",
+        text="10/20/2011",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=20),
+        pattern="D",
+        text="Thursday, 20 October 2011",
+    ),
+    # Year comes from the template
+    Data(
+        value=LocalDate(year=2000, month=10, day=20),
+        pattern="M",
+        text="October 20",
+    ),
+    # ISO pattern uses a sensible format
+    Data(
+        value=LocalDate(year=2011, month=10, day=20),
+        standard_pattern=LocalDatePattern.iso,
+        pattern="R",
+        text="2011-10-20",
+    ),
+    # Round trip with calendar system
+    Data(
+        value=LocalDate(year=2011, month=10, day=20, calendar=CalendarSystem.coptic),
+        standard_pattern=LocalDatePattern.full_roundtrip,
+        pattern="r",
+        text="2011-10-20 (Coptic)",
+    ),
+    # Custom patterns
+    Data(
+        value=LocalDate(year=2011, month=10, day=3),
+        pattern="uuuu/MM/dd",
+        text="2011/10/03",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=3),
+        pattern="uuuu/MM/dd",
+        text="2011-10-03",
+        culture=Cultures.fr_ca,
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=3),
+        pattern="uuuuMMdd",
+        text="20111003",
+    ),
+    # 2-digit year-of-era patterns
+    Data(
+        value=LocalDate(year=2001, month=7, day=3),
+        pattern="yy M d",
+        text="01 7 3",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=7, day=3),
+        pattern="yy M d",
+        text="11 7 3",
+    ),
+    Data(
+        value=LocalDate(year=2030, month=7, day=3),
+        pattern="yy M d",
+        text="30 7 3",
+    ),
+    # Cutoff defaults to 30 (at the moment...)
+    Data(
+        value=LocalDate(year=1931, month=7, day=3),
+        pattern="yy M d",
+        text="31 7 3",
+    ),
+    Data(
+        value=LocalDate(year=1976, month=7, day=3),
+        pattern="yy M d",
+        text="76 7 3",
+    ),
+    # In the first century, we don't skip back a century for "high" two-digit year numbers.
+    Data(
+        value=LocalDate(year=25, month=7, day=3),
+        pattern="uu M d",
+        text="25 7 3",
+        template=LocalDate(year=50, month=1, day=1),
+    ),
+    Data(
+        value=LocalDate(year=35, month=7, day=3),
+        pattern="uu M d",
+        text="35 7 3",
+        template=LocalDate(year=50, month=1, day=1),
+    ),
+    Data(
+        value=LocalDate(year=2000, month=10, day=3),
+        pattern="MM/dd",
+        text="10/03",
+    ),
+    Data(
+        value=LocalDate(year=1885, month=10, day=3),
+        pattern="MM/dd",
+        text="10/03",
+        template=LocalDate(year=1885, month=10, day=1),
+    ),
+    # When we parse in all of the below tests, we'll use the month and day-of-month if it's provided;
+    # the template value is specified to allow simple roundtripping.
+    # (Day of week doesn't affect what value is parsed; it just validates.)
+    # Non-genitive month name when there's no "day of month", even if there's a "day of week"
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="MMMM",
+        text="FullNonGenName",
+        culture=Cultures._genitive_name_test_culture,
+        template=LocalDate(year=2011, month=5, day=3),
+    ),
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="MMMM dddd",
+        text="FullNonGenName Monday",
+        culture=Cultures._genitive_name_test_culture,
+        template=LocalDate(year=2011, month=5, day=3),
+    ),
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="MMM",
+        text="AbbrNonGenName",
+        culture=Cultures._genitive_name_test_culture,
+        template=LocalDate(year=2011, month=5, day=3),
+    ),
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="MMM ddd",
+        text="AbbrNonGenName Mon",
+        culture=Cultures._genitive_name_test_culture,
+        template=LocalDate(year=2011, month=5, day=3),
+    ),
+    # Genitive month name when the pattern includes "day of month"
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="MMMM dd",
+        text="FullGenName 03",
+        culture=Cultures._genitive_name_test_culture,
+        template=LocalDate(year=2011, month=5, day=3),
+    ),
+    # TODO: Check whether or not this is actually appropriate
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="MMM dd",
+        text="AbbrGenName 03",
+        culture=Cultures._genitive_name_test_culture,
+        template=LocalDate(year=2011, month=5, day=3),
+    ),
+    # Era handling
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="yyyy MM dd gg",
+        text="2011 01 03 A.D.",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=1, day=3),
+        pattern="uuuu yyyy MM dd gg",
+        text="2011 2011 01 03 A.D.",
+    ),
+    Data(
+        value=LocalDate(year=-1, month=1, day=3),
+        pattern="yyyy MM dd gg",
+        text="0002 01 03 B.C.",
+    ),
+    # Day of week handling
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="uuuu MM dd dddd",
+        text="2011 10 09 Sunday",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="uuuu MM dd ddd",
+        text="2011 10 09 Sun",
+    ),
+    # Month handling
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="uuuu MMMM dd",
+        text="2011 October 09",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="uuuu MMM dd",
+        text="2011 Oct 09",
+    ),
+    # Year and two-digit year-of-era in the same format. Note that the year
+    # gives the full year information, so we're not stuck in the 20th/21st century
+    Data(
+        value=LocalDate(year=1825, month=10, day=9),
+        pattern="uuuu yy MM/dd",
+        text="1825 25 10/09",
+    ),
+    # Negative years
+    Data(
+        value=LocalDate(year=-43, month=3, day=15),
+        pattern="uuuu MM dd",
+        text="-0043 03 15",
+    ),
+    # Calendar handling
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="c uuuu MM dd",
+        text="ISO 2011 10 09",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=9),
+        pattern="uuuu MM dd c",
+        text="2011 10 09 ISO",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=9, calendar=CalendarSystem.coptic),
+        pattern="c uuuu MM dd",
+        text="Coptic 2011 10 09",
+    ),
+    Data(
+        value=LocalDate(year=2011, month=10, day=9, calendar=CalendarSystem.coptic),
+        pattern="uuuu MM dd c",
+        text="2011 10 09 Coptic",
+    ),
+    Data(
+        value=LocalDate(year=180, month=15, day=19, calendar=CalendarSystem.badi),
+        pattern="uuuu MM dd c",
+        text="0180 15 19 Badi",
+    ),
+    # Awkward day-of-week handling
+    # December 14th 2012 was a Friday. Friday is "Foo" or "FooBar" in AwkwardDayOfWeekCulture.
+    Data(
+        value=LocalDate(year=2012, month=12, day=14),
+        pattern="ddd uuuu MM dd",
+        text="Foo 2012 12 14",
+        culture=Cultures._awkward_day_of_week_culture,
+    ),
+    Data(
+        value=LocalDate(year=2012, month=12, day=14),
+        pattern="dddd uuuu MM dd",
+        text="FooBar 2012 12 14",
+        culture=Cultures._awkward_day_of_week_culture,
+    ),
+    # December 13th 2012 was a Thursday. Friday is "FooBaz" or "FooBa" in AwkwardDayOfWeekCulture.
+    Data(
+        value=LocalDate(year=2012, month=12, day=13),
+        pattern="ddd uuuu MM dd",
+        text="FooBaz 2012 12 13",
+        culture=Cultures._awkward_day_of_week_culture,
+    ),
+    Data(
+        value=LocalDate(year=2012, month=12, day=13),
+        pattern="dddd uuuu MM dd",
+        text="FooBa 2012 12 13",
+        culture=Cultures._awkward_day_of_week_culture,
+    ),
+    # 3 digit year patterns (odd, but valid)
+    Data(
+        value=LocalDate(year=12, month=1, day=2),
+        pattern="uuu MM dd",
+        text="012 01 02",
+    ),
+    Data(
+        value=LocalDate(year=-12, month=1, day=2),
+        pattern="uuu MM dd",
+        text="-012 01 02",
+    ),
+    Data(
+        value=LocalDate(year=123, month=1, day=2),
+        pattern="uuu MM dd",
+        text="123 01 02",
+    ),
+    Data(
+        value=LocalDate(year=-123, month=1, day=2),
+        pattern="uuu MM dd",
+        text="-123 01 02",
+    ),
+    Data(
+        value=LocalDate(year=1234, month=1, day=2),
+        pattern="uuu MM dd",
+        text="1234 01 02",
+    ),
+    Data(
+        value=LocalDate(year=-1234, month=1, day=2),
+        pattern="uuu MM dd",
+        text="-1234 01 02",
+    ),
+]
+
+PARSE_DATA = PARSE_ONLY_DATA + FORMAT_AND_PARSE_DATA
+FORMAT_DATA = FORMAT_ONLY_DATA + FORMAT_AND_PARSE_DATA
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=}") for data in INVALID_PATTERN_DATA])
+def invalid_pattern_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=}") for data in PARSE_FAILURE_DATA])
+def parse_failure_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=}") for data in PARSE_DATA])
+def parse_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=} {data.culture=}") for data in FORMAT_DATA])
+def format_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
+    return request.param
+
+
+class TestLocalDatePattern(PatternTestBase[LocalDate]):
+    # TODO:
+    #  public void BclLongDatePatternGivesSameResultsInNoda(CultureInfo culture)
+    #  public void BclShortDatePatternGivesSameResultsInNoda(CultureInfo culture)
+
+    def test_create_with_current_culture(self) -> None:
+        date = LocalDate(year=2017, month=8, day=23)
+        with CultureSaver.set_cultures(Cultures.fr_fr):
+            pattern = LocalDatePattern.create_with_current_culture("d")
+            assert pattern.format(date) == "23/08/2017"
+        with CultureSaver.set_cultures(Cultures.fr_ca):
+            pattern = LocalDatePattern.create_with_current_culture("d")
+            assert pattern.format(date) == "2017-08-23"
+
+    def test_parse_null(self) -> None:
+        self.assert_parse_null(LocalDatePattern.iso)
+
+    @pytest.mark.parametrize(
+        "two_digit_year_max,text,expected_year",
+        [
+            (0, "00-01-01", 2000),
+            (0, "01-01-01", 1901),
+            (50, "49-01-01", 2049),
+            (50, "50-01-01", 2050),
+            (50, "51-01-01", 1951),
+            (99, "00-01-01", 2000),
+            (99, "99-01-01", 2099),
+        ],
+    )
+    def test_with_two_digit_year_max(self, two_digit_year_max: int, text: str, expected_year: int) -> None:
+        pattern = LocalDatePattern.create_with_invariant_culture("yy-MM-dd").with_two_digit_year_max(two_digit_year_max)
+        value = pattern.parse(text).value
+        assert value.year == expected_year
+
+    @pytest.mark.parametrize(
+        "two_digit_year_max", [-1, 100, _CsharpConstants.INT_MIN_VALUE, _CsharpConstants.INT_MAX_VALUE]
+    )
+    def test_with_two_digit_year_max_invalid(self, two_digit_year_max: int) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalDatePattern.iso.with_two_digit_year_max(two_digit_year_max)


### PR DESCRIPTION
Similar to #85, the only aspect of this that isn't included in these changes is the BCL equivalence tests... Will come back to that.