### PR TITLE
feat: refine `LocalDate` and `LocalTime` constructors

### DIFF
--- a/pyoda_time/_local_date_time.py
+++ b/pyoda_time/_local_date_time.py
@@ -39,6 +39,19 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
         millisecond: int = 0,
         calendar: CalendarSystem = CalendarSystem.iso,
     ) -> None:
+        """Initializes a new instance of the ``LocalDateTime`` class.
+
+        :param year: The year. This is the "absolute year", so, for the ISO calendar, a value of 0 means 1 BC, for
+            example.
+        :param month: The month of year.
+        :param day: The day of month.
+        :param hour: The hour.
+        :param minute: The minute.
+        :param second: The second.
+        :param millisecond: The millisecond.
+        :param calendar: The calendar.
+        :raises ValueError: The parameters do not form a valid date and time.
+        """
         from ._local_date import LocalDate
         from ._local_time import LocalTime
 

--- a/pyoda_time/_local_time.py
+++ b/pyoda_time/_local_time.py
@@ -5,14 +5,20 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, final, overload
+from typing import TYPE_CHECKING, Generator, final, overload
 
 from ._pyoda_constants import PyodaConstants
-from .utility._csharp_compatibility import _csharp_modulo, _int32_overflow, _sealed, _towards_zero_division
+from .utility._csharp_compatibility import (
+    _csharp_modulo,
+    _int32_overflow,
+    _int64_overflow,
+    _sealed,
+    _towards_zero_division,
+)
 from .utility._preconditions import _Preconditions
 
 if TYPE_CHECKING:
-    from . import LocalDateTime
+    from . import LocalDateTime, Offset, OffsetTime, Period
     from ._local_date import LocalDate
 
 __all__ = ["LocalTime"]
@@ -53,16 +59,15 @@ class LocalTime(metaclass=_LocalTimeMeta):
     """LocalTime is an immutable struct representing a time of day, with no reference to a particular calendar, time
     zone or date."""
 
-    @overload
-    def __init__(self, *, hour: int, minute: int) -> None: ...
+    def __init__(self, hour: int = 0, minute: int = 0, second: int = 0, millisecond: int = 0) -> None:
+        """Initialises a ``LocalTime`` at the given hour, minute, second and millisecond.
 
-    @overload
-    def __init__(self, *, hour: int, minute: int, second: int) -> None: ...
-
-    @overload
-    def __init__(self, *, hour: int, minute: int, second: int, millisecond: int) -> None: ...
-
-    def __init__(self, *, hour: int, minute: int, second: int = 0, millisecond: int = 0):
+        :param hour: The hour of day.
+        :param minute: The minute of the hour.
+        :param second: The second of the minute.
+        :param millisecond: The millisecond of the second.
+        :raises ValueError: The parameters do not form a valid time.
+        """
         if (
             hour < 0
             or hour > PyodaConstants.HOURS_PER_DAY - 1
@@ -87,17 +92,20 @@ class LocalTime(metaclass=_LocalTimeMeta):
         )
 
     @classmethod
-    def _ctor(cls, *, nanoseconds: int) -> LocalTime:
-        """Constructor only called from other parts of Noda Time - trusted to be the range [0, NanosecondsPerDay)."""
-        # TODO: _Preconditions._check_debug_argument_range()
-        self = super().__new__(cls)
-        self.__nanoseconds = nanoseconds
-        return self
-
-    @classmethod
     def from_hour_minute_second_millisecond_tick(
         cls, hour: int, minute: int, second: int, millisecond: int, tick_within_millisecond: int
     ) -> LocalTime:
+        """Factory method to create a local time at the given hour, minute, second, millisecond and tick within
+        millisecond.
+
+        :param hour: The hour of day.
+        :param minute: The minute of the hour.
+        :param second: The second of the minute.
+        :param millisecond: The millisecond of the second.
+        :param tick_within_millisecond: The tick within the millisecond.
+        :return: The resulting time.
+        :raises ValueError: The parameters do not form a valid time.
+        """
         # Avoid the method calls which give a decent exception unless we're actually going to fail.
         if (
             hour < 0
@@ -130,6 +138,77 @@ class LocalTime(metaclass=_LocalTimeMeta):
         return LocalTime._ctor(nanoseconds=nanoseconds)
 
     @classmethod
+    def from_hour_minute_second_tick(cls, hour: int, minute: int, second: int, tick_within_second: int) -> LocalTime:
+        """Factory method for creating a local time from the hour of day, minute of hour, second of minute, and tick of
+        second.
+
+        :param hour: The hour of day in the desired time, in the range [0, 23].
+        :param minute: The minute of hour in the desired time, in the range [0, 59].
+        :param second: The second of minute in the desired time, in the range [0, 59].
+        :param tick_within_second: The tick within the second in the desired time, in the range [0, 9999999].
+        :return: The resulting time.
+        :raises ValueError: The parameters do not form a valid time.
+        """
+        # Avoid the method calls which give a decent exception unless we're actually going to fail.
+        if (
+            hour < 0
+            or hour > PyodaConstants.HOURS_PER_DAY - 1
+            or minute < 0
+            or minute > PyodaConstants.MINUTES_PER_HOUR - 1
+            or second < 0
+            or second > PyodaConstants.SECONDS_PER_MINUTE - 1
+            or tick_within_second < 0
+            or tick_within_second > PyodaConstants.TICKS_PER_SECOND - 1
+        ):
+            _Preconditions._check_argument_range("hour", hour, 0, PyodaConstants.HOURS_PER_DAY - 1)
+            _Preconditions._check_argument_range("minute", minute, 0, PyodaConstants.MINUTES_PER_HOUR - 1)
+            _Preconditions._check_argument_range("second", second, 0, PyodaConstants.SECONDS_PER_MINUTE - 1)
+            _Preconditions._check_argument_range(
+                "tick_within_second", tick_within_second, 0, PyodaConstants.TICKS_PER_SECOND - 1
+            )
+
+        nanoseconds = (
+            hour * PyodaConstants.NANOSECONDS_PER_HOUR
+            + minute * PyodaConstants.NANOSECONDS_PER_MINUTE
+            + second * PyodaConstants.NANOSECONDS_PER_SECOND
+            + tick_within_second * PyodaConstants.NANOSECONDS_PER_TICK
+        )
+        return LocalTime._ctor(nanoseconds=nanoseconds)
+
+    @classmethod
+    def from_hour_minute_second_nanosecond(
+        cls, hour: int, minute: int, second: int, nanosecond_within_second: int
+    ) -> LocalTime:
+        """Factory method for creating a local time from the hour of day, minute of hour, second of minute, and
+        nanosecond of second.
+
+        :param hour: The hour of day in the desired time, in the range [0, 23].
+        :param minute: The minute of hour in the desired time, in the range [0, 59].
+        :param second: The second of minute in the desired time, in the range [0, 59].
+        :param nanosecond_within_second: The nanosecond within the second in the desired time, in the range [0,
+            999999999].
+        :return: The resulting time.
+        :raises ValueError: The parameters do not form a valid time.
+        """
+        if (
+            hour < 0
+            or hour > PyodaConstants.HOURS_PER_DAY - 1
+            or minute < 0
+            or minute > PyodaConstants.MINUTES_PER_HOUR - 1
+            or second < 0
+            or second > PyodaConstants.SECONDS_PER_MINUTE - 1
+            or nanosecond_within_second < 0
+            or nanosecond_within_second > PyodaConstants.NANOSECONDS_PER_SECOND - 1
+        ):
+            _Preconditions._check_argument_range("hour", hour, 0, PyodaConstants.HOURS_PER_DAY - 1)
+            _Preconditions._check_argument_range("minute", minute, 0, PyodaConstants.MINUTES_PER_HOUR - 1)
+            _Preconditions._check_argument_range("second", second, 0, PyodaConstants.SECONDS_PER_MINUTE - 1)
+            _Preconditions._check_argument_range(
+                "nanoseconds_within_second", nanosecond_within_second, 0, PyodaConstants.NANOSECONDS_PER_SECOND - 1
+            )
+        return cls._from_hour_minute_second_nanosecond_trusted(hour, minute, second, nanosecond_within_second)
+
+    @classmethod
     def _from_hour_minute_second_nanosecond_trusted(
         cls,
         hour: int,
@@ -145,6 +224,14 @@ class LocalTime(metaclass=_LocalTimeMeta):
             + second * PyodaConstants.NANOSECONDS_PER_SECOND
             + nanosecond_within_second
         )
+
+    @classmethod
+    def _ctor(cls, *, nanoseconds: int) -> LocalTime:
+        """Constructor only called from other parts of Noda Time - trusted to be the range [0, NanosecondsPerDay)."""
+        # TODO: _Preconditions._check_debug_argument_range()
+        self = super().__new__(cls)
+        self.__nanoseconds = nanoseconds
+        return self
 
     @classmethod
     def from_nanoseconds_since_midnight(cls, nanoseconds: int) -> LocalTime:
@@ -168,7 +255,8 @@ class LocalTime(metaclass=_LocalTimeMeta):
         # Avoid the method calls which give a decent exception unless we're actually going to fail.
         if ticks < 0 or ticks > PyodaConstants.TICKS_PER_DAY - 1:
             _Preconditions._check_argument_range("ticks", ticks, 0, PyodaConstants.TICKS_PER_DAY - 1)
-        return LocalTime._ctor(nanoseconds=_int32_overflow(ticks * PyodaConstants.NANOSECONDS_PER_TICK))
+        # TODO: unchecked
+        return LocalTime._ctor(nanoseconds=_int64_overflow(ticks * PyodaConstants.NANOSECONDS_PER_TICK))
 
     @classmethod
     def from_milliseconds_since_midnight(cls, milliseconds: int) -> LocalTime:
@@ -182,7 +270,7 @@ class LocalTime(metaclass=_LocalTimeMeta):
             _Preconditions._check_argument_range(
                 "milliseconds", milliseconds, 0, PyodaConstants.MILLISECONDS_PER_DAY - 1
             )
-        return cls._ctor(nanoseconds=_int32_overflow(milliseconds * PyodaConstants.NANOSECONDS_PER_MILLISECOND))
+        return cls._ctor(nanoseconds=_int64_overflow(milliseconds * PyodaConstants.NANOSECONDS_PER_MILLISECOND))
 
     @classmethod
     def from_seconds_since_midnight(cls, seconds: int) -> LocalTime:
@@ -194,7 +282,7 @@ class LocalTime(metaclass=_LocalTimeMeta):
         # Avoid the method calls which give a decent exception unless we're actually going to fail.
         if seconds < 0 or seconds > PyodaConstants.SECONDS_PER_DAY - 1:
             _Preconditions._check_argument_range("seconds", seconds, 0, PyodaConstants.SECONDS_PER_DAY - 1)
-        return cls._ctor(nanoseconds=_int32_overflow(seconds * PyodaConstants.NANOSECONDS_PER_SECOND))
+        return cls._ctor(nanoseconds=_int64_overflow(seconds * PyodaConstants.NANOSECONDS_PER_SECOND))
 
     @classmethod
     def from_minutes_since_midnight(cls, minutes: int) -> LocalTime:
@@ -206,7 +294,7 @@ class LocalTime(metaclass=_LocalTimeMeta):
         # Avoid the method calls which give a decent exception unless we're actually going to fail.
         if minutes < 0 or minutes > PyodaConstants.MINUTES_PER_DAY - 1:
             _Preconditions._check_argument_range("minutes", minutes, 0, PyodaConstants.MINUTES_PER_DAY - 1)
-        return cls._ctor(nanoseconds=_int32_overflow(minutes * PyodaConstants.NANOSECONDS_PER_MINUTE))
+        return cls._ctor(nanoseconds=_int64_overflow(minutes * PyodaConstants.NANOSECONDS_PER_MINUTE))
 
     @classmethod
     def from_hours_since_midnight(cls, hours: int) -> LocalTime:
@@ -218,7 +306,7 @@ class LocalTime(metaclass=_LocalTimeMeta):
         # Avoid the method calls which give a decent exception unless we're actually going to fail.
         if hours < 0 or hours > PyodaConstants.HOURS_PER_DAY - 1:
             _Preconditions._check_argument_range("hours", hours, 0, PyodaConstants.HOURS_PER_DAY - 1)
-        return cls._ctor(nanoseconds=_int32_overflow(hours * PyodaConstants.NANOSECONDS_PER_HOUR))
+        return cls._ctor(nanoseconds=_int64_overflow(hours * PyodaConstants.NANOSECONDS_PER_HOUR))
 
     @property
     def hour(self) -> int:
@@ -280,6 +368,34 @@ class LocalTime(metaclass=_LocalTimeMeta):
         """The nanosecond of this local time within the day, in the range 0 to 86,399,999,999,999 inclusive."""
         return self.__nanoseconds
 
+    @overload
+    def __sub__(self, local_time: LocalTime) -> Period: ...
+
+    @overload
+    def __sub__(self, period: Period) -> LocalTime: ...
+
+    def __sub__(self, other: LocalTime | Period) -> LocalTime | Period:
+        from ._period import Period
+
+        if isinstance(other, Period):
+            _Preconditions._check_not_null(other, "other")
+            _Preconditions._check_argument(
+                not other.has_date_component, "other", "Cannot subtract a period with a date component from a time"
+            )
+            return (
+                self.plus_hours(-other.hours)
+                .plus_minutes(-other.minutes)
+                .plus_seconds(-other.seconds)
+                .plus_milliseconds(-other.milliseconds)
+                .plus_ticks(-other.ticks)
+                .plus_nanoseconds(-other.nanoseconds)
+            )
+
+        if isinstance(other, LocalTime):
+            return Period.between(self, other)
+
+        return NotImplemented  # type: ignore[unreachable]
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, LocalTime):
             return NotImplemented
@@ -315,6 +431,85 @@ class LocalTime(metaclass=_LocalTimeMeta):
             return 1
         return self.__nanoseconds - other.__nanoseconds
 
+    def plus_hours(self, hours: int) -> LocalTime:
+        """Returns a new LocalTime representing the current value with the given number of hours added.
+
+        If the value goes past the start or end of the day, it wraps - so 11pm plus two hours is 1am, for example.
+
+        :param hours: The number of hours to add
+        :return: The current value plus the given number of hours.
+        """
+        from pyoda_time.fields._time_period_field import _TimePeriodField
+
+        return _TimePeriodField._hours._add_local_time(self, hours)
+
+    def plus_minutes(self, minutes: int) -> LocalTime:
+        """Returns a new LocalTime representing the current value with the given number of minutes added.
+
+        If the value goes past the start or end of the day, it wraps - so 11pm plus 120 minutes is 1am, for example.
+
+        :param minutes: The number of minutes to add
+        :return: The current value plus the given number of minutes.
+        """
+        from pyoda_time.fields._time_period_field import _TimePeriodField
+
+        return _TimePeriodField._minutes._add_local_time(self, minutes)
+
+    def plus_seconds(self, seconds: int) -> LocalTime:
+        """Returns a new LocalTime representing the current value with the given number of seconds added.
+
+        If the value goes past the start or end of the day, it wraps - so 11:59pm plus 120 seconds is
+        12:01am, for example.
+
+        :param seconds: The number of seconds to add
+        :return: The current value plus the given number of seconds.
+        """
+        from pyoda_time.fields._time_period_field import _TimePeriodField
+
+        return _TimePeriodField._seconds._add_local_time(self, seconds)
+
+    def plus_milliseconds(self, milliseconds: int) -> LocalTime:
+        """Returns a new LocalTime representing the current value with the given number of milliseconds added.
+
+        :param milliseconds: The number of milliseconds to add
+        :return: The current value plus the given number of milliseconds.
+        """
+        from pyoda_time.fields._time_period_field import _TimePeriodField
+
+        return _TimePeriodField._milliseconds._add_local_time(self, milliseconds)
+
+    def plus_ticks(self, ticks: int) -> LocalTime:
+        """Returns a new LocalTime representing the current value with the given number of ticks added.
+
+        :param ticks: The number of ticks to add
+        :return: The current value plus the given number of ticks.
+        """
+        from pyoda_time.fields._time_period_field import _TimePeriodField
+
+        return _TimePeriodField._ticks._add_local_time(self, ticks)
+
+    def plus_nanoseconds(self, nanoseconds: int) -> LocalTime:
+        """Returns a new LocalTime representing the current value with the given number of nanoseconds added.
+
+        :param nanoseconds: The number of nanoseconds to add
+        :return: The current value plus the given number of ticks.
+        """
+        from .fields._time_period_field import _TimePeriodField
+
+        return _TimePeriodField._nanoseconds._add_local_time(self, nanoseconds)
+
+    def with_offset(self, offset: Offset) -> OffsetTime:
+        """Returns an ``OffsetTime`` for this time-of-day with the given offset.
+
+        This method is purely a convenient alternative to calling the ``OffsetTime`` constructor directly.
+
+        :param offset: The offset to apply.
+        :return: The result of this time-of-day offset by the given amount.
+        """
+        from ._offset_time import OffsetTime
+
+        return OffsetTime(self, offset)
+
     def on(self, date: LocalDate) -> LocalDateTime:
         """Combines this ``LocalTime`` with the given ``LocalDate`` into a single ``LocalDateTime``.
 
@@ -324,3 +519,32 @@ class LocalTime(metaclass=_LocalTimeMeta):
         :return: The ``LocalDateTime`` representation of the given time on this date.
         """
         return date + self
+
+    def __iter__(self) -> Generator[int, None, None]:
+        """Deconstruct this time into its components.
+
+        :return: A generator yielding integers representing the hour, minute, and second components of the time.
+        """
+        yield self.hour
+        yield self.minute
+        yield self.second
+
+    @staticmethod
+    def max(x: LocalTime, y: LocalTime) -> LocalTime:
+        """Returns the later time of the given two.
+
+        :param x: The first time to compare.
+        :param y: The second time to compare.
+        :return: The later time of ``x`` or ``y``.
+        """
+        return x if x > y else y
+
+    @staticmethod
+    def min(x: LocalTime, y: LocalTime) -> LocalTime:
+        """Returns the earlier time of the given two.
+
+        :param x: The first time to compare.
+        :param y: The second time to compare.
+        :return: The earlier time of ``x`` or ``y``.
+        """
+        return x if x < y else y

--- a/pyoda_time/_offset_time.py
+++ b/pyoda_time/_offset_time.py
@@ -4,11 +4,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final, overload
+from typing import Final, overload
 
-if TYPE_CHECKING:
-    from . import LocalTime
-    from ._offset import Offset
+from ._local_time import LocalTime
+from ._offset import Offset
 
 __all__ = ["OffsetTime"]
 
@@ -49,6 +48,22 @@ class OffsetTime:
         return self
 
     @property
+    def time_of_day(self) -> LocalTime:
+        """Gets the time-of-day represented by this value.
+
+        :return: The time-of-day represented by this value.
+        """
+        return LocalTime._ctor(nanoseconds=self.nanosecond_of_day)
+
+    @property
+    def offset(self) -> Offset:
+        """Gets the offset from UTC of this value.
+
+        :return: The offset from UTC of this value.
+        """
+        return Offset._ctor(seconds=self.__nanoseconds_and_offset >> self.__NANOSECONDS_BITS)
+
+    @property
     def _offset_nanoseconds(self) -> int:
         """Returns the number of nanoseconds in the offset, without going via an Offset."""
         return self.__nanoseconds_and_offset >> self.__NANOSECONDS_BITS
@@ -56,3 +71,8 @@ class OffsetTime:
     @property
     def nanosecond_of_day(self) -> int:
         return self.__nanoseconds_and_offset & self.__NANOSECONDS_MASK
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, OffsetTime):
+            return NotImplemented
+        return self.time_of_day == other.time_of_day and self.offset == other.offset

--- a/tests/calendars/test_iso_calendar.py
+++ b/tests/calendars/test_iso_calendar.py
@@ -123,7 +123,7 @@ class TestIsoCalendarSystem:
 
     def test_before_common_era_by_specifying_era(self) -> None:
         # Year -1 in absolute terms is 2BCE
-        local_date = LocalDate(era=Era.before_common, year_of_era=2, month=1, day=1)
+        local_date = LocalDate(2, 1, 1, era=Era.before_common)
         assert local_date.era == Era.before_common
         assert local_date.year == -1
         assert local_date.year_of_era == 2

--- a/tests/test_comparison_operator_consistency.py
+++ b/tests/test_comparison_operator_consistency.py
@@ -18,6 +18,7 @@ from pyoda_time import (
     LocalDate,
     LocalTime,
     Offset,
+    OffsetTime,
     Period,
     YearMonth,
 )
@@ -38,6 +39,7 @@ VALUES = [
     LocalTime.max_value,
     LocalDate.max_iso_value + LocalTime.max_value,
     Offset.zero,
+    OffsetTime(LocalTime.midnight, Offset.zero),
     Period.zero,
     YearMonth(year=1, month=1),
     _YearMonthDay._ctor(raw_value=1),

--- a/tests/test_local_date.py
+++ b/tests/test_local_date.py
@@ -1,8 +1,11 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
+import pytest
 
-from pyoda_time import CalendarSystem, LocalDate, LocalDateTime, LocalTime
+from pyoda_time import CalendarSystem, IsoDayOfWeek, LocalDate, LocalDateTime, LocalTime
+from pyoda_time.calendars import Era
+from pyoda_time.calendars._gregorian_year_month_day_calculator import _GregorianYearMonthDayCalculator
 
 
 class TestLocalDate:
@@ -13,9 +16,178 @@ class TestLocalDate:
     def test_combination_with_time(self) -> None:
         # Test all three approaches in the same test - they're logically equivalent.
         calendar = CalendarSystem.julian
-        date = LocalDate(year=2014, month=3, day=28, calendar=calendar)
-        time = LocalTime(hour=20, minute=17, second=30)
-        expected = LocalDateTime(year=2014, month=3, day=28, hour=20, minute=17, second=30, calendar=calendar)
+        date = LocalDate(2014, 3, 28, calendar)
+        time = LocalTime(20, 17, 30)
+        expected = LocalDateTime(2014, 3, 28, 20, 17, 30, calendar=calendar)
         assert date + time == expected
         assert date.at(time) == expected
         assert time.on(date) == expected
+
+    # TODO:
+    #  def test_xml_serializtion_iso(self):
+    #  def test_xml_serializtion_non_iso(self):
+    #  def test_xml_serializtion_invalid(self):
+
+    def test_construction_null_calendar_throws(self) -> None:
+        with pytest.raises(TypeError):
+            LocalDate(2017, 11, 7, calendar=None)  # type: ignore
+
+        with pytest.raises(TypeError):
+            LocalDate(era=Era.common, year_of_era=2017, month=11, day=7, calendar=None)  # type: ignore
+
+    def test_max_iso_value(self) -> None:
+        value: LocalDate = LocalDate.max_iso_value
+        assert value.calendar == CalendarSystem.iso
+        with pytest.raises(OverflowError):
+            value.plus_days(1)
+
+    def test_min_iso_value(self) -> None:
+        value: LocalDate = LocalDate.min_iso_value
+        assert value.calendar == CalendarSystem.iso
+        with pytest.raises(OverflowError):
+            value.plus_days(-1)
+
+    def test_deconstruction(self) -> None:
+        value = LocalDate(2017, 11, 7)
+        expected_year = 2017
+        expected_month = 11
+        expected_day = 7
+        actual_year, actual_month, actual_day = value
+
+        assert actual_year == expected_year
+        assert actual_month == expected_month
+        assert actual_day == expected_day
+
+    # TODO: def test_deconstruction_including_calendar(self) -> None:
+
+
+class TestLocalDateConstruction:
+    @pytest.mark.parametrize(
+        "year",
+        [
+            1620,  # Leap year in non-optimized period
+            1621,  # Non-leap year in non-optimized period
+            1980,  # Leap year in optimized period
+            1981,  # Non-leap year in optimized period
+        ],
+    )
+    def test_constructor_with_days(self, year: int) -> None:
+        start = LocalDate(year, 1, 1)
+        start_days = start._days_since_epoch
+        for i in range(366):
+            assert LocalDate._ctor(days_since_epoch=start_days + i) == start.plus_days(i)
+
+    @pytest.mark.parametrize(
+        "year",
+        [
+            1620,  # Leap year in non-optimized period
+            1621,  # Non-leap year in non-optimized period
+            1980,  # Leap year in optimized period
+            1981,  # Non-leap year in optimized period
+        ],
+    )
+    def test_constructor_with_days_and_calendar(self, year: int) -> None:
+        start = LocalDate(year, 1, 1)
+        start_days = start._days_since_epoch
+        for i in range(366):
+            assert LocalDate._ctor(days_since_epoch=start_days + i, calendar=CalendarSystem.iso) == start.plus_days(i)
+
+    def test_constructor_calendar_defaults_to_iso(self) -> None:
+        date = LocalDate(2000, 1, 1)
+        assert date.calendar == CalendarSystem.iso
+
+    def test_constructor_properties_round_trip(self) -> None:
+        date = LocalDate(2023, 7, 27)
+        assert date.year == 2023
+        assert date.month == 7
+        assert date.day == 27
+
+    def test_constructor_properties_round_trip_custom_calendar(self) -> None:
+        date = LocalDate(2023, 7, 27, CalendarSystem.julian)
+        assert date.year == 2023
+        assert date.month == 7
+        assert date.day == 27
+
+    @pytest.mark.parametrize(
+        "year,month,day",
+        [
+            (_GregorianYearMonthDayCalculator._MAX_GREGORIAN_YEAR + 1, 1, 1),
+            (_GregorianYearMonthDayCalculator._MIN_GREGORIAN_YEAR - 1, 1, 1),
+            (2010, 13, 1),
+            (2010, 0, 1),
+            (2010, 1, 100),
+            (2010, 2, 30),
+            (2010, 1, 0),
+        ],
+    )
+    def test_constructor_invalid(self, year: int, month: int, day: int) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalDate(year, month, day)
+
+    @pytest.mark.parametrize(
+        "year,month,day",
+        [
+            (_GregorianYearMonthDayCalculator._MAX_GREGORIAN_YEAR + 1, 1, 1),
+            (_GregorianYearMonthDayCalculator._MIN_GREGORIAN_YEAR - 1, 1, 1),
+            (2010, 13, 1),
+            (2010, 0, 1),
+            (2010, 1, 100),
+            (2010, 2, 30),
+            (2010, 1, 0),
+        ],
+    )
+    def test_constructor_invalid_with_calendar(self, year: int, month: int, day: int) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalDate(year, month, day, CalendarSystem.iso)
+
+    def test_constructor_invalid_year_of_era(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalDate(0, 1, 1, era=Era.common)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalDate(0, 1, 1, era=Era.before_common)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalDate(10000, 1, 1, era=Era.common)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalDate(10000, 1, 1, era=Era.before_common)
+
+    def test_constructor_with_year_of_era_bc(self) -> None:
+        absolute = LocalDate(-10, 1, 1)
+        with_era = LocalDate(11, 1, 1, era=Era.before_common)
+        assert with_era == absolute
+
+    def test_constructor_with_year_of_era_ad(self) -> None:
+        absolute = LocalDate(50, 6, 19)
+        with_era = LocalDate(50, 6, 19, era=Era.common)
+        assert with_era == absolute
+
+    def test_constructor_with_year_of_era_non_iso_calendar(self) -> None:
+        calendar = CalendarSystem.coptic
+        absolute = LocalDate(50, 6, 19, calendar)
+        with_era = LocalDate(50, 6, 19, calendar, Era.anno_martyrum)
+        assert with_era == absolute
+
+    # Most tests are in IsoBasedWeekYearRuleTest.
+    def test_from_week_year_and_day_invalid_week_53(self) -> None:
+        # Week year 2005 only has 52 weeks
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalDate.from_week_year_week_and_day(2005, 53, IsoDayOfWeek.SUNDAY)
+
+    @pytest.mark.parametrize(
+        "year,month,occurrence,day_of_week,expected_day",
+        [
+            (2014, 8, 3, IsoDayOfWeek.SUNDAY, 17),
+            (2014, 8, 3, IsoDayOfWeek.FRIDAY, 15),
+            # Needs "rewind" logic as August 1st 2014 is a Friday
+            (2014, 8, 3, IsoDayOfWeek.THURSDAY, 21),
+            (2014, 8, 5, IsoDayOfWeek.SUNDAY, 31),
+            # Only 4 Mondays in August in 2014.
+            (2014, 8, 5, IsoDayOfWeek.MONDAY, 25),
+        ],
+    )
+    def test_from_year_month_week_and_day(
+        self, year: int, month: int, occurrence: int, day_of_week: IsoDayOfWeek, expected_day: int
+    ) -> None:
+        date = LocalDate.from_year_month_week_and_day(year, month, occurrence, day_of_week)
+        assert date.year == year
+        assert date.month == month
+        assert date.day == date.day

--- a/tests/test_local_date_time.py
+++ b/tests/test_local_date_time.py
@@ -1,0 +1,12 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from pyoda_time import LocalDateTime
+
+
+class TestLocalDateTime:
+    def test_default_constructor(self) -> None:
+        """Using the default constructor is equivalent to January 1st 1970, midnight, UTC, ISO calendar."""
+        actual = LocalDateTime()
+        assert actual == LocalDateTime(1, 1, 1, 0, 0)

--- a/tests/test_local_time.py
+++ b/tests/test_local_time.py
@@ -1,0 +1,250 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import pytest
+
+from pyoda_time import LocalTime, Offset, OffsetTime, Period, PyodaConstants
+
+
+class TestLocalTime:
+    def test_min_value_equal_to_midnight(self) -> None:
+        assert LocalTime.min_value == LocalTime.midnight
+
+    def test_max_value(self) -> None:
+        assert LocalTime.max_value.nanosecond_of_day == PyodaConstants.NANOSECONDS_PER_DAY - 1
+
+    def test_clock_hour_of_half_day(self) -> None:
+        assert LocalTime(0, 0).clock_hour_of_half_day == 12
+        assert LocalTime(1, 0).clock_hour_of_half_day == 1
+        assert LocalTime(12, 0).clock_hour_of_half_day == 12
+        assert LocalTime(13, 0).clock_hour_of_half_day == 1
+        assert LocalTime(23, 0).clock_hour_of_half_day == 11
+
+    def test_default_constructor(self) -> None:
+        actual = LocalTime()
+        assert actual == LocalTime.midnight
+
+    # TODO:
+    #  def test_xml_serialization(self):
+    #  def test_xml_serialization_invalid(self):
+
+    def test_max(self) -> None:
+        x = LocalTime(5, 10)
+        y = LocalTime(6, 20)
+        assert LocalTime.max(x, y) == y
+        assert LocalTime.max(y, x) == y
+        assert LocalTime.max(x, LocalTime.min_value) == x
+        assert LocalTime.max(LocalTime.min_value, x) == x
+        assert LocalTime.max(LocalTime.max_value, x) == LocalTime.max_value
+        assert LocalTime.max(x, LocalTime.max_value) == LocalTime.max_value
+
+    def test_min(self) -> None:
+        x = LocalTime(5, 10)
+        y = LocalTime(6, 20)
+        assert LocalTime.min(x, y) == x
+        assert LocalTime.min(y, x) == x
+        assert LocalTime.min(x, LocalTime.min_value) == LocalTime.min_value
+        assert LocalTime.min(LocalTime.min_value, x) == LocalTime.min_value
+        assert LocalTime.min(LocalTime.max_value, x) == x
+        assert LocalTime.min(x, LocalTime.max_value) == x
+
+    def test_deconstruction(self) -> None:
+        value = LocalTime(15, 8, 20)
+        expected_hour = 15
+        expected_minute = 8
+        expected_second = 20
+
+        actual_hour, actual_minute, actual_second = value
+
+        assert actual_hour == expected_hour
+        assert actual_minute == expected_minute
+        assert actual_second == expected_second
+
+    def test_with_offset(self) -> None:
+        time = LocalTime(3, 45, 12, 34)
+        offset = Offset.from_hours(5)
+        expected = OffsetTime(time, offset)
+        assert time.with_offset(offset) == expected
+
+
+class TestLocalTimeConstruction:
+    @pytest.mark.parametrize(
+        "hour,minute",
+        [
+            (-1, 0),
+            (24, 0),
+            (0, -1),
+            (0, 60),
+        ],
+    )
+    def test_invalid_construction_to_minute(self, hour: int, minute: int) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime(hour, minute)
+
+    @pytest.mark.parametrize(
+        "hour,minute,second",
+        [
+            (-1, 0, 0),
+            (24, 0, 0),
+            (0, -1, 0),
+            (0, 60, 0),
+            (0, 0, 60),
+            (0, 0, -1),
+        ],
+    )
+    def test_invalid_construction_to_second(self, hour: int, minute: int, second: int) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime(hour, minute, second)
+
+    @pytest.mark.parametrize(
+        "hour,minute,second,millisecond",
+        [
+            (-1, 0, 0, 0),
+            (24, 0, 0, 0),
+            (0, -1, 0, 0),
+            (0, 60, 0, 0),
+            (0, 0, 60, 0),
+            (0, 0, -1, 0),
+            (0, 0, 0, -1),
+            (0, 0, 0, 1000),
+        ],
+    )
+    def test_invalid_construction_to_millisecond(self, hour: int, minute: int, second: int, millisecond: int) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime(hour, minute, second, millisecond)
+
+    @pytest.mark.parametrize(
+        "hour,minute,second,millisecond,tick",
+        [
+            (-1, 0, 0, 0, 0),
+            (24, 0, 0, 0, 0),
+            (0, -1, 0, 0, 0),
+            (0, 60, 0, 0, 0),
+            (0, 0, 60, 0, 0),
+            (0, 0, -1, 0, 0),
+            (0, 0, 0, -1, 0),
+            (0, 0, 0, 1000, 0),
+            (0, 0, 0, 0, -1),
+            (0, 0, 0, 0, PyodaConstants.TICKS_PER_MILLISECOND),
+        ],
+    )
+    def test_from_hour_minute_second_millisecond_tick_invalid(
+        self, hour: int, minute: int, second: int, millisecond: int, tick: int
+    ) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_hour_minute_second_millisecond_tick(hour, minute, second, millisecond, tick)
+
+    @pytest.mark.parametrize(
+        "hour,minute,second,tick",
+        [
+            (-1, 0, 0, 0),
+            (24, 0, 0, 0),
+            (0, -1, 0, 0),
+            (0, 60, 0, 0),
+            (0, 0, 60, 0),
+            (0, 0, -1, 0),
+            (0, 0, 0, -1),
+            (0, 0, 0, PyodaConstants.TICKS_PER_SECOND),
+        ],
+    )
+    def test_from_hour_minute_second_tick_invalid(self, hour: int, minute: int, second: int, tick: int) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_hour_minute_second_tick(hour, minute, second, tick)
+
+    def test_from_hour_minute_second_tick_valid(self) -> None:
+        result = LocalTime.from_hour_minute_second_tick(1, 2, 3, PyodaConstants.TICKS_PER_SECOND - 1)
+        assert result.hour == 1
+        assert result.minute == 2
+        assert result.second == 3
+        assert result.tick_of_second == PyodaConstants.TICKS_PER_SECOND - 1
+
+    @pytest.mark.parametrize(
+        "hour,minute,second,nanosecond",
+        [
+            (-1, 0, 0, 0),
+            (24, 0, 0, 0),
+            (0, -1, 0, 0),
+            (0, 60, 0, 0),
+            (0, 0, 60, 0),
+            (0, 0, -1, 0),
+            (0, 0, 0, -1),
+            (0, 0, 0, PyodaConstants.NANOSECONDS_PER_SECOND),
+        ],
+    )
+    def test_from_hour_minute_second_nanosecond_invalid(
+        self, hour: int, minute: int, second: int, nanosecond: int
+    ) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_hour_minute_second_nanosecond(hour, minute, second, nanosecond)
+
+    def test_from_nanoseconds_since_midnight_valid(self) -> None:
+        assert LocalTime.from_nanoseconds_since_midnight(0) == LocalTime.midnight
+        assert LocalTime.from_nanoseconds_since_midnight(
+            PyodaConstants.NANOSECONDS_PER_DAY - 1
+        ) == LocalTime.midnight.plus_nanoseconds(-1)
+
+    def test_from_nanoseconds_since_midnight_range_checks(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_nanoseconds_since_midnight(-1)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_nanoseconds_since_midnight(PyodaConstants.NANOSECONDS_PER_DAY)
+
+    def test_from_ticks_since_midnight_valid(self) -> None:
+        assert LocalTime.from_ticks_since_midnight(0) == LocalTime.midnight
+        assert LocalTime.from_ticks_since_midnight(
+            PyodaConstants.TICKS_PER_DAY - 1
+        ) == LocalTime.midnight - Period.from_ticks(1)
+
+    def test_from_ticks_since_midnight_range_checks(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_ticks_since_midnight(-1)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_ticks_since_midnight(PyodaConstants.TICKS_PER_DAY)
+
+    def test_from_milliseconds_since_midnight_valid(self) -> None:
+        assert LocalTime.from_milliseconds_since_midnight(0) == LocalTime.midnight
+        assert LocalTime.from_milliseconds_since_midnight(
+            PyodaConstants.MILLISECONDS_PER_DAY - 1
+        ) == LocalTime.midnight - Period.from_milliseconds(1)
+
+    def test_from_milliseconds_since_midnight_range_checks(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_milliseconds_since_midnight(-1)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_milliseconds_since_midnight(PyodaConstants.MILLISECONDS_PER_DAY)
+
+    def test_from_seconds_since_midnight_valid(self) -> None:
+        assert LocalTime.from_seconds_since_midnight(0) == LocalTime.midnight
+        assert LocalTime.from_seconds_since_midnight(
+            PyodaConstants.SECONDS_PER_DAY - 1
+        ) == LocalTime.midnight - Period.from_seconds(1)
+
+    def test_from_seconds_since_midnight_range_checks(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_seconds_since_midnight(-1)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_seconds_since_midnight(PyodaConstants.SECONDS_PER_DAY)
+
+    def test_from_minutes_since_midnight_valid(self) -> None:
+        assert LocalTime.from_minutes_since_midnight(0) == LocalTime.midnight
+        assert LocalTime.from_minutes_since_midnight(
+            PyodaConstants.MINUTES_PER_DAY - 1
+        ) == LocalTime.midnight - Period.from_minutes(1)
+
+    def test_from_minutes_since_midnight_range_checks(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_minutes_since_midnight(-1)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_minutes_since_midnight(PyodaConstants.MINUTES_PER_DAY)
+
+    def test_from_hours_since_midnight_valid(self) -> None:
+        assert LocalTime.from_hours_since_midnight(0) == LocalTime.midnight
+        assert LocalTime.from_hours_since_midnight(
+            PyodaConstants.HOURS_PER_DAY - 1
+        ) == LocalTime.midnight - Period.from_hours(1)
+
+    def test_from_hours_since_midnight_range_checks(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_hours_since_midnight(-1)
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            LocalTime.from_hours_since_midnight(PyodaConstants.HOURS_PER_DAY)


### PR DESCRIPTION
Some refinement of public constructors for `LocalDate`/`LocalTime`/`LocalDateTime`.

The main impetus behind these changes was to make the `LocalDate.__init__` more ergonomic than it was previously.

It used to enforce keyword-only arguments due to the way that it faithfully emulated Noda Time's various public `LocalDate` constructors. (More specifically, the way it copied the _order_ of their arguments like `era`.)

This change allows the probably very common constructor usage like `LocalDate(year=2024, month=5, day=5)` to be expressed as `LocalDate(2024, 5, 5)`, just as you would be able to in Noda Time (and also as you probably would be used to from Python's `datetime.datetime`).

Also added a bunch of tests around initialisers and alternate classmethod constructors.