### PR TITLE
fix: move version.py out of package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,4 +28,4 @@ tests:
   - "tests/**"
 
 release:
-  - "pyoda_time/version.py"
+  - "version.py"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from sphinx.application import Sphinx
 
-from pyoda_time.version import __version__ as pyoda_time_version
+from pyoda_time import __version__ as pyoda_time_version
 
 # Project information
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information

--- a/pyoda_time/__init__.py
+++ b/pyoda_time/__init__.py
@@ -2,6 +2,8 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 
+__version__ = "0.6.0"
+
 __all__: list[str] = [
     "calendars",
     "fields",

--- a/pyoda_time/version.py
+++ b/pyoda_time/version.py
@@ -1,5 +1,0 @@
-# Copyright 2024 The Pyoda Time Authors. All rights reserved.
-# Use of this source code is governed by the Apache License 2.0,
-# as found in the LICENSE.txt file.
-
-__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ include = [
     "LICENSE.txt",
     "NOTICE.txt",
     "py.typed",
-    "version.py",
 ]
 
 [tool.poetry.dependencies]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -35,11 +35,4 @@ def test_public_api_does_not_leak_imports(namespace: types.ModuleType) -> None:
         symbol for symbol in dir(namespace) if symbol not in namespace.__all__ and not symbol.startswith("_")
     ]
 
-    # TODO:
-    #  Since implementing the `test_comparison_operator_consistency.py` test module, 'version.py' started
-    #  causing this to fail. Must have only been detected as of the advent of that test module, because
-    #  it uses inspect to walk the package recursively, looking for classes. Needs investigation.
-    if namespace is pyoda_time:
-        public_symbols_not_included_in_all_list.remove("version")
-
     assert not public_symbols_not_included_in_all_list

--- a/version.py
+++ b/version.py
@@ -1,0 +1,8 @@
+"""Contains the current release version.
+
+The __version__ attribute is updated automatically by release-please-action when it raises a pull request.
+The only reason this exists is so that the labeler action knows to tag those auto-generated PRs as "release".
+See also: `.github/workflows/labeler.yml`
+"""
+
+__version__ = "0.6.0"


### PR DESCRIPTION
Our public api test, which enforces the shape of the public api exposes only/all public members/classes, had to have a temporary exemption added to it because the `/pyoda_time/version.py` module wasn't included in the `__all__` list in `/pyoda_time/__init__.py`.

That exclusion had to be added in #95, when we added a separate, unrelated test that inspected packages in a different way.

Now, the only reason that `pyoda_time/version.py` exists really is so that the "labeler" action can watch that file for changes, and can mark pull requests with the "release" tag if changes are detected. (In other words, if the `__version__` attribute in that module has been updated.)

To remove that exclusion from the test, I have moved the version.py out of the package altogether, to the top level of the repo. There is no need for it to be under the `pyoda_time` package as it is only really useful for "labeler" purposes.

I have also added the `__version__` attribute to `pyoda_time/__init__.py`. This should be updated automatically by release-please-action.