### PR TITLE
feat: port `time_zones.cldr` and `time_zones.io` namespaces

### DIFF
--- a/pyoda_time/_date_time_zone.py
+++ b/pyoda_time/_date_time_zone.py
@@ -6,19 +6,19 @@ from __future__ import annotations
 
 import abc
 import functools
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, _ProtocolMeta
 
+from .time_zones._i_zone_interval_map import _IZoneIntervalMap
 from .utility._preconditions import _Preconditions
 
 if TYPE_CHECKING:
     from . import Instant, Offset
-    from .time_zones import ZoneInterval
 
 
 __all__ = ["DateTimeZone"]
 
 
-class _DateTimeZoneMeta(abc.ABCMeta):
+class _DateTimeZoneMeta(_ProtocolMeta, type):
     @property
     @functools.cache
     def utc(cls) -> DateTimeZone:
@@ -36,7 +36,7 @@ class _DateTimeZoneMeta(abc.ABCMeta):
         return _FixedDateTimeZone(Offset.zero)
 
 
-class DateTimeZone(abc.ABC, metaclass=_DateTimeZoneMeta):
+class DateTimeZone(abc.ABC, _IZoneIntervalMap, metaclass=_DateTimeZoneMeta):
     """Represents a time zone - a mapping between UTC and local time.
     A time zone maps UTC instants to local times - or, equivalently, to the offset from UTC at any particular instant.
     """
@@ -89,9 +89,5 @@ class DateTimeZone(abc.ABC, metaclass=_DateTimeZoneMeta):
 
     def get_utc_offset(self, instant: Instant) -> Offset:
         return self.get_zone_interval(instant).wall_offset
-
-    @abc.abstractmethod
-    def get_zone_interval(self, instant: Instant) -> ZoneInterval:
-        raise NotImplementedError
 
     # endregion

--- a/pyoda_time/time_zones/__init__.py
+++ b/pyoda_time/time_zones/__init__.py
@@ -2,6 +2,9 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 
-__all__ = ["ZoneInterval"]
+__all__ = ["cldr", "io", "TzdbZone1970Location", "TzdbZoneLocation", "ZoneInterval"]
 
+from . import cldr, io
+from ._tzdb_zone_1970_location import TzdbZone1970Location
+from ._tzdb_zone_location import TzdbZoneLocation
 from ._zone_interval import ZoneInterval

--- a/pyoda_time/time_zones/_i_zone_interval_map.py
+++ b/pyoda_time/time_zones/_i_zone_interval_map.py
@@ -1,0 +1,26 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from abc import abstractmethod
+from typing import Protocol
+
+from pyoda_time._instant import Instant
+from pyoda_time._offset import Offset
+from pyoda_time.time_zones._zone_interval import ZoneInterval
+
+
+class _IZoneIntervalMap(Protocol):
+    """The core part of a DateTimeZone: mapping an Instant to an Interval.
+
+    Separating this out into an interface allows for flexible caching.
+    """
+
+    def get_zone_interval(self, instant: Instant) -> ZoneInterval: ...
+
+    @property
+    @abstractmethod
+    def min_offset(self) -> Offset: ...
+
+    @property
+    @abstractmethod
+    def max_offset(self) -> Offset: ...

--- a/pyoda_time/time_zones/_tzdb_zone_1970_location.py
+++ b/pyoda_time/time_zones/_tzdb_zone_1970_location.py
@@ -1,0 +1,209 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from pyoda_time.time_zones.io._i_date_time_zone_reader import _IDateTimeZoneReader
+from pyoda_time.time_zones.io._i_date_time_zone_writer import _IDateTimeZoneWriter
+from pyoda_time.utility import InvalidPyodaDataError
+from pyoda_time.utility._hash_code_helper import _hash_code_helper
+from pyoda_time.utility._preconditions import _Preconditions
+
+
+class TzdbZone1970Location:
+    """A location entry generated from the "zone1970.tab" file in a TZDB release.
+
+    This can be used to provide users with a choice of time zone, although it is not internationalized.
+    This is equivalent to ``TzdbZoneLocation``, except that multiple countries may be represented.
+    """
+
+    class Country:
+        """A country represented within an entry in the "zone1970.tab" file, with the English name mapped from the
+        "iso3166.tab" file.
+
+        Equality is defined component-wise: two values are considered equal if their country names are equal to
+        each other, and their country codes are equal to each other.
+        """
+
+        @property
+        def name(self) -> str:
+            """Gets the English name of the country.
+
+            :return: The English name of the country.
+            """
+            return self.__name
+
+        @property
+        def code(self) -> str:
+            """Gets the ISO-3166 2-letter country code for the country.
+
+            :return: The ISO-3166 2-letter country code for the country.
+            """
+            return self.__code
+
+        def __init__(self, name: str, code: str) -> None:
+            """Constructs a new country from its name and ISO-3166 2-letter code.
+
+            :param name: Country name; must not be empty.
+            :param code: 2-letter code
+            """
+            self.__name: str = _Preconditions._check_not_null(name, "name")
+            self.__code: str = _Preconditions._check_not_null(code, "code")
+            _Preconditions._check_argument(len(self.name) > 0, "name", "Country name cannot be empty")
+            _Preconditions._check_argument(len(self.code) == 2, "code", "Country code must be two characters")
+
+        def equals(self, other: TzdbZone1970Location.Country) -> bool:
+            """Compares countries for equality.
+
+            See the type documentation for a description of equality semantics.
+
+            :param other: The country to compare with this one.
+            :return: ``True`` if the given country has the same name and code as this one; ``False`` otherwise.
+            """
+            return self == other
+
+        def __eq__(self, other: object) -> bool:
+            """Compares countries for equality.
+
+            See the type documentation for a description of equality semantics.
+
+            :param other: The country to compare with this one.
+            :return: ``True`` if the given country has the same name and code as this one; ``False`` otherwise.
+            """
+            if not isinstance(other, TzdbZone1970Location.Country):
+                return NotImplemented
+            return self.code == other.code and self.name == other.name
+
+        def __hash__(self) -> int:
+            """Returns a hash code for this country.
+
+            :return: A hash code for this country.
+            """
+            return _hash_code_helper(self.name, self.code)
+
+        def __repr__(self) -> str:
+            """Returns a string representation of this country, including the code and name.
+
+            :return: A string representation of this country.
+            """
+            return f"{self.code} ({self.name})"
+
+    @property
+    def latitude(self) -> float:
+        """Gets the latitude in degrees; positive for North, negative for South.
+
+        The value will be in the range [-90, 90].
+
+        :return: The latitude in degrees; positive for North, negative for South.
+        """
+        return self.__latitude_seconds / 3600.0
+
+    @property
+    def longitude(self) -> float:
+        """Gets the longitude in degrees; positive for East, negative for West.
+
+        The value will be in the range [-180, 180].
+
+        :return: The longitude in degrees; positive for East, negative for West.
+        """
+        return self.__longitude_seconds / 3600.0
+
+    @property
+    def countries(self) -> Sequence[Country]:
+        """Gets the list of countries associated with this location.
+
+        The list is immutable, and will always contain at least one entry. The list is in the order specified in
+        "zone1970.tab", so the first entry is always the country containing the position indicated by the latitude and
+        longitude, and is the most populous country in the list. No entry in this list is ever null.
+
+        :return: The list of countries associated with this location
+        """
+        return self.__countries
+
+    @property
+    def zone_id(self) -> str:
+        """The ID of the time zone for this location.
+
+        If this mapping was fetched from a ``TzdbDateTimeZoneSource``, it will always be a valid ID within that source.
+
+        :return: The ID of the time zone for this location.
+        """
+        return self.__zone_id
+
+    @property
+    def comment(self) -> str:
+        """Gets the comment (in English) for the mapping, if any.
+
+        This is usually used to differentiate between locations in the same country. This will return an empty string if
+        no comment was provided in the original data.
+
+        :return: The comment (in English) for the mapping, if any.
+        """
+        return self.__comment
+
+    def __init__(
+        self,
+        latitude_seconds: int,
+        longitude_seconds: int,
+        countries: Iterable[Country],
+        zone_id: str,
+        comment: str,
+    ) -> None:
+        """Creates a new location.
+
+        This constructor is only public for the sake of testability. Non-test code should
+        usually obtain locations from a ``TzdbDateTimeZoneSource``.
+
+        :param latitude_seconds: Latitude of the location, in seconds.
+        :param longitude_seconds: Longitude of the location, in seconds.
+        :param countries: Countries associated with this location. Must not be null, must have at least
+            one entry, and all entries must be non-null.
+        :param zone_id: Time zone identifier of the location. Must not be null.
+        :param comment: Optional comment. Must not be null, but may be empty.
+        :raises ValueError: If ``latitude_seconds`` or ``longitude_seconds`` are invalid.
+        """
+        _Preconditions._check_argument_range("latitude_seconds", latitude_seconds, -90 * 3600, 90 * 3600)
+        _Preconditions._check_argument_range("longitude_seconds", longitude_seconds, -180 * 3600, 180 * 3600)
+        self.__latitude_seconds = latitude_seconds
+        self.__longitude_seconds = longitude_seconds
+        self.__countries = tuple(_Preconditions._check_not_null(countries, "country_name"))
+        _Preconditions._check_argument(
+            len(self.countries) > 0, "countries", "Collection must contain at least one entry."
+        )
+        for country in self.countries:
+            _Preconditions._check_argument(country is not None, "countries", "Collection must not contain null entries")
+        self.__zone_id = _Preconditions._check_not_null(zone_id, "zone_id")
+        self.__comment = _Preconditions._check_not_null(comment, "comment")
+
+    def _write(self, writer: _IDateTimeZoneWriter) -> None:
+        writer.write_signed_count(self.__latitude_seconds)
+        writer.write_signed_count(self.__longitude_seconds)
+        writer.write_count(len(self.countries))
+        # We considered writing out the ISO-3166 file as a separate field,
+        # so we can reuse objects, but we don't actually waste very much space this way,
+        # due to the string pool... and the increased code complexity isn't worth it.
+        for country in self.countries:
+            writer.write_string(country.name)
+            writer.write_string(country.code)
+        writer.write_string(self.zone_id)
+        writer.write_string(self.comment)
+
+    @staticmethod
+    def _read(reader: _IDateTimeZoneReader) -> TzdbZone1970Location:
+        latitude_seconds: int = reader.read_signed_count()
+        longitude_seconds: int = reader.read_signed_count()
+        country_count: int = reader.read_count()
+        countries: list[TzdbZone1970Location.Country] = [
+            TzdbZone1970Location.Country(reader.read_string(), code=reader.read_string()) for _ in range(country_count)
+        ]
+        zone_id: str = reader.read_string()
+        comment: str = reader.read_string()
+        # We could duplicate the validation, but there's no good reason to. It's odd
+        # to catch ArgumentException, but we're in pretty tight control of what's going on here.
+        try:
+            return TzdbZone1970Location(latitude_seconds, longitude_seconds, countries, zone_id, comment)
+        except ValueError as e:
+            raise InvalidPyodaDataError("Invalid zone location data in stream") from e

--- a/pyoda_time/time_zones/_tzdb_zone_location.py
+++ b/pyoda_time/time_zones/_tzdb_zone_location.py
@@ -1,0 +1,137 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import final
+
+from pyoda_time.time_zones.io._i_date_time_zone_reader import _IDateTimeZoneReader
+from pyoda_time.time_zones.io._i_date_time_zone_writer import _IDateTimeZoneWriter
+from pyoda_time.utility import InvalidPyodaDataError
+from pyoda_time.utility._csharp_compatibility import _sealed
+from pyoda_time.utility._preconditions import _Preconditions
+
+
+@final
+@_sealed
+class TzdbZoneLocation:
+    """A location entry generated from the "zone.tab" file in a TZDB release.
+
+    This can be used to provide users with a choice of time zone, although it is not internationalized.
+    """
+
+    @property
+    def latitude(self) -> float:
+        """Gets the latitude in degrees; positive for North, negative for South.
+
+        The value will be in the range [-90, 90].
+
+        :return: The latitude in degrees; positive for North, negative for South.
+        """
+        return self.__latitude_seconds / 3600.0
+
+    @property
+    def longitude(self) -> float:
+        """Gets the longitude in degrees; positive for East, negative for West.
+
+        The value will be in the range [-180, 180].
+
+        :return: The longitude in degrees; positive for East, negative for West.
+        """
+        return self.__longitude_seconds / 3600.0
+
+    @property
+    def country_name(self) -> str:
+        """Gets the English name of the country containing the location, which is never empty.
+
+        :return: The English name of the country containing the location.
+        """
+        return self.__country_name
+
+    @property
+    def country_code(self) -> str:
+        """Gets the ISO-3166 2-letter country code for the country containing the location.
+
+        :return: The ISO-3166 2-letter country code for the country containing the location.
+        """
+        return self.__country_code
+
+    @property
+    def zone_id(self) -> str:
+        """The ID of the time zone for this location.
+
+        If this mapping was fetched from a ``TzdbDateTimeZoneSource``, it will always be a valid ID within that source.
+
+        :return: The ID of the time zone for this location.
+        """
+        return self.__zone_id
+
+    @property
+    def comment(self) -> str:
+        """Gets the comment (in English) for the mapping, if any.
+
+        This is usually used to differentiate between locations in the same country. This will return an empty string if
+        no comment was provided in the original data.
+
+        :return: The comment (in English) for the mapping, if any.
+        """
+        return self.__comment
+
+    def __init__(
+        self,
+        latitude_seconds: int,
+        longitude_seconds: int,
+        country_name: str,
+        country_code: str,
+        zone_id: str,
+        comment: str,
+    ) -> None:
+        """Creates a new location.
+
+        This constructor is only public for the sake of testability. Non-test code should
+        usually obtain locations from a ``TzdbDateTimeZoneSource``.
+
+        :param latitude_seconds: Latitude of the location, in seconds.
+        :param longitude_seconds: Longitude of the location, in seconds.
+        :param country_name: English country name of the location, in degrees. Must not be null.
+        :param country_code: ISO-3166 country code of the location. Must not be null.
+        :param zone_id: Time zone identifier of the location. Must not be null.
+        :param comment: Optional comment. Must not be null, but may be empty.
+        :raises ValueError: If ``latitude_seconds`` or ``longitude_seconds`` are invalid.
+        """
+        _Preconditions._check_argument_range("latitude_seconds", latitude_seconds, -90 * 3600, 90 * 3600)
+        _Preconditions._check_argument_range("longitude_seconds", longitude_seconds, -180 * 3600, 180 * 3600)
+        self.__latitude_seconds = latitude_seconds
+        self.__longitude_seconds = longitude_seconds
+        self.__country_name = _Preconditions._check_not_null(country_name, "country_name")
+        self.__country_code = _Preconditions._check_not_null(country_code, "country_code")
+        _Preconditions._check_argument(len(self.country_name) > 0, "country_name", "Country name cannot be empty")
+        _Preconditions._check_argument(
+            len(self.country_code) == 2, "country_code", "Country code must be two characters"
+        )
+        self.__zone_id = _Preconditions._check_not_null(zone_id, "zone_id")
+        self.__comment = _Preconditions._check_not_null(comment, "comment")
+
+    def _write(self, writer: _IDateTimeZoneWriter) -> None:
+        writer.write_signed_count(self.__latitude_seconds)
+        writer.write_signed_count(self.__longitude_seconds)
+        writer.write_string(self.country_name)
+        writer.write_string(self.country_code)
+        writer.write_string(self.zone_id)
+        writer.write_string(self.comment)
+
+    @classmethod
+    def _read(cls, reader: _IDateTimeZoneReader) -> TzdbZoneLocation:
+        latitude_seconds: int = reader.read_signed_count()
+        longitude_seconds: int = reader.read_signed_count()
+        country_name: str = reader.read_string()
+        country_code: str = reader.read_string()
+        zone_id: str = reader.read_string()
+        comment: str = reader.read_string()
+        # We could duplicate the validation, but there's no good reason to. It's odd
+        # to catch ArgumentException, but we're in pretty tight control of what's going on here.
+        try:
+            return TzdbZoneLocation(latitude_seconds, longitude_seconds, country_name, country_code, zone_id, comment)
+        except ValueError as e:
+            raise InvalidPyodaDataError("Invalid zone location data in stream") from e

--- a/pyoda_time/time_zones/cldr/__init__.py
+++ b/pyoda_time/time_zones/cldr/__init__.py
@@ -2,6 +2,10 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 
-from ._invalid_pyoda_data_exception import InvalidPyodaDataError
+__all__: list[str] = [
+    "MapZone",
+    "WindowsZones",
+]
 
-__all__: list[str] = ["InvalidPyodaDataError"]
+from ._map_zone import MapZone
+from ._windows_zones import WindowsZones

--- a/pyoda_time/time_zones/cldr/_map_zone.py
+++ b/pyoda_time/time_zones/cldr/_map_zone.py
@@ -1,0 +1,154 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import Final, Sequence, final
+
+from pyoda_time.time_zones.io._i_date_time_zone_reader import _IDateTimeZoneReader
+from pyoda_time.time_zones.io._i_date_time_zone_writer import _IDateTimeZoneWriter
+from pyoda_time.utility._csharp_compatibility import _sealed
+from pyoda_time.utility._hash_code_helper import _hash_code_helper
+from pyoda_time.utility._preconditions import _Preconditions
+
+
+@final
+@_sealed
+class MapZone:
+    """Represents a single ``<mapZone>`` element in the CLDR Windows zone mapping file.
+
+    Equality is defined in a component-wise fashion. When comparing two values for equality, the ``tzdb_ids`` properties
+    must return the same IDs in the same order for the values to be considered equal.
+    """
+
+    PRIMARY_TERRITORY: Final[str] = "001"
+    """Identifier used for the primary territory of each Windows time zone.
+
+    A zone mapping with this territory will always have a single entry. The value of this constant is "001".
+    """
+
+    FIXED_OFFSET_TERRITORY: Final[str] = "ZZ"
+    """Identifier used for the "fixed offset" territory.
+
+    A zone mapping with this territory will always have a single entry. The value of this constant is "ZZ".
+    """
+
+    @property
+    def windows_id(self) -> str:
+        """Gets the Windows system time zone identifier for this mapping, such as "Central Standard Time".
+
+        Most Windows system time zone identifiers use the name for the "standard" part of the zone as the overall
+        identifier. Don't be fooled: just because a time zone includes "standard" in its identifier doesn't mean that it
+        doesn't observe daylight saving time.
+
+        :return: The Windows system time zone identifier for this mapping, such as "Central Standard Time".
+        """
+        return self.__windows_id
+
+    @property
+    def territory(self) -> str:
+        """Gets the territory code for this mapping.
+
+        This is typically either "001" to indicate that it's the primary territory for this ID, or "ZZ" to indicate a
+        fixed-offset ID, or a different two-character capitalized code which indicates the geographical territory.
+
+        :return: The territory code for this mapping.
+        """
+        return self.__territory
+
+    @property
+    def tzdb_ids(self) -> Sequence[str]:
+        """Gets a read-only non-empty collection of TZDB zone identifiers for this mapping, such as "America/Chicago"
+        and "America/Matamoros" (both of which are TZDB zones associated with the "Central Standard Time" Windows system
+        time zone).
+
+        For the primary and fixed-offset territory IDs ("001" and "ZZ") this always contains exactly one time zone ID.
+        The IDs returned are not necessarily canonical in TZDB.
+
+        :return: A read-only non-empty collection of TZDB zone identifiers for this mapping.
+        """
+        return self.__tzdb_ids
+
+    def __init__(self, windows_id: str, territory: str, tzdb_ids: Sequence[str]) -> None:
+        """Creates a new mapping entry.
+
+        This constructor is only public for the sake of testability.
+
+        :param windows_id: Windows system time zone identifier. Must not be null.
+        :param territory: Territory code. Must not be null.
+        :param tzdb_ids: List of territory codes. Must not be null, and must not contain null values.
+        """
+        self.__windows_id: str = _Preconditions._check_not_null(windows_id, "windows_id")
+        self.__territory: str = _Preconditions._check_not_null(territory, "territory")
+        self.__tzdb_ids: Sequence[str] = _Preconditions._check_not_null(tuple(tzdb_ids), "tzdb_ids")
+
+    @classmethod
+    def __ctor(cls, windows_id: str, territory: str, tzdb_ids: Sequence[str]) -> MapZone:
+        """Private constructor to avoid unnecessary list copying (and validation) when deserializing."""
+        self = super().__new__(cls)
+        self.__windows_id = windows_id
+        self.__territory = territory
+        self.__tzdb_ids = tzdb_ids
+        return self
+
+    @classmethod
+    def _read(cls, reader: _IDateTimeZoneReader) -> MapZone:
+        """Reads a mapping from a reader."""
+        windows_id: str = reader.read_string()
+        territory: str = reader.read_string()
+        count: int = reader.read_count()
+        tzdb_ids: Sequence[str] = tuple(reader.read_string() for _ in range(count))
+        return cls.__ctor(windows_id, territory, tzdb_ids)
+
+    def _write(self, writer: _IDateTimeZoneWriter) -> None:
+        """Writes this mapping to a writer."""
+        writer.write_string(self.windows_id)
+        writer.write_string(self.territory)
+        writer.write_count(len(self.tzdb_ids))
+        for tzdb_id in self.tzdb_ids:
+            writer.write_string(tzdb_id)
+
+    def equals(self, other: MapZone) -> bool:
+        """Compares two ``MapZone`` values for equality.
+
+        :param other: The value to compare this map zone with.
+        :return: True if the given value is another map zone equal to this one; false otherwise.
+        """
+        return self == other
+
+    def __eq__(self, other: object) -> bool:
+        """Compares two ``MapZone`` values for equality.
+
+        See the type documentation for a description of equality semantics.
+
+        :param other: The value to compare this map zone with.
+        :return: True if the given value is another map zone equal to this one; false otherwise.
+        """
+        if not isinstance(other, MapZone):
+            return NotImplemented
+        return (
+            self.windows_id == other.windows_id
+            and self.territory == other.territory
+            and self.tzdb_ids == other.tzdb_ids
+        )
+
+    def __hash__(self) -> int:
+        """Returns a hash code for this map zone.
+
+        See the type documentation for a description of equality semantics.
+
+        :return: A hash code for this map zone.
+        """
+        return _hash_code_helper(
+            self.windows_id,
+            self.territory,
+            *self.tzdb_ids,
+        )
+
+    def __repr__(self) -> str:
+        """Returns a ``str`` that represents this instance.
+
+        :return: The value of the current instance, for diagnostic purposes.
+        """
+        return f"Windows ID: {self.windows_id}; Territory: {self.territory}; TzdbIds: {' '.join(self.tzdb_ids)}"

--- a/pyoda_time/time_zones/cldr/_windows_zones.py
+++ b/pyoda_time/time_zones/cldr/_windows_zones.py
@@ -1,0 +1,146 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+import types
+from typing import Sequence, final
+
+from pyoda_time.utility._csharp_compatibility import _private, _sealed
+from pyoda_time.utility._preconditions import _Preconditions
+
+from ..io._i_date_time_zone_reader import _IDateTimeZoneReader
+from ..io._i_date_time_zone_writer import _IDateTimeZoneWriter
+from ._map_zone import MapZone
+
+
+@final
+@_sealed
+@_private
+class WindowsZones:
+    """Representation of the ``<windowsZones>`` element of CLDR supplemental data.
+
+    See the CLDR design proposal for more details of the structure of the file from which data is taken.
+    http://cldr.unicode.org/development/development-process/design-proposals/extended-windows-olson-zid-mapping
+    """
+
+    __version: str
+    __tzdb_version: str
+    __windows_version: str
+    __map_zones: Sequence[MapZone]
+    __primary_mapping: types.MappingProxyType[str, str]
+
+    @property
+    def version(self) -> str:
+        """Gets the version of the Windows zones mapping data read from the original file.
+
+        As with other IDs, this should largely be treated as an opaque string, but the current method for generating
+        this from the mapping file extracts a number from an element such as <c>&lt;version number="$Revision: 7825
+        $"/&gt;</c>. This is a Subversion revision number, but that association should only be used for diagnostic
+        curiosity, and never assumed in code.
+
+        :return: The version of the Windows zones mapping data read from the original file.
+        """
+        return self.__version
+
+    @property
+    def tzdb_version(self) -> str:
+        """Gets the TZDB version this Windows zone mapping data was created from.
+
+        The CLDR mapping file usually lags behind the TZDB file somewhat - partly because the
+        mappings themselves don't always change when the time zone data does. For example, it's entirely
+        reasonable for a ``TzdbDateTimeZoneSource`` with a ``tzdb_version`` of
+        "2013b" to be supply a ``WindowsZones`` object with a ``tzdb_version`` of "2012f".
+
+        :return: The TZDB version this Windows zone mapping data was created from.
+        """
+        return self.__tzdb_version
+
+    @property
+    def windows_version(self) -> str:
+        r"""Gets the Windows time zone database version this Windows zone mapping data was created from.
+
+        At the time of this writing, this is populated (by CLDR) from the registry key
+        HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Time Zones\TzVersion, so "7dc0101" for example.
+
+        :return: The Windows time zone database version this Windows zone mapping data was created from.
+        """
+        return self.__windows_version
+
+    @property
+    def map_zones(self) -> Sequence[MapZone]:
+        """Gets an immutable collection of mappings from Windows system time zones to TZDB time zones.
+
+        Each mapping consists of a single Windows time zone ID and a single territory to potentially multiple TZDB IDs
+        that are broadly equivalent to that Windows zone/territory pair.
+
+        Mappings for a single Windows system time zone can appear multiple times in this list, in different territories.
+        For example, "Central Standard Time" maps to different TZDB zones in different countries (the US, Canada,
+        Mexico) and even within a single territory there can be multiple zones. Every Windows system time zone covered
+        within this collection has a "primary" entry with a territory code of "001" (which is the value of
+        ``MapZone.PRIMARY_TERRITORY``) and a single corresponding TZDB zone.
+
+        This collection is not guaranteed to cover every Windows time zone. Some zones may be unmappable (such as
+        "Mid-Atlantic Standard Time") and there can be a delay between a new Windows time zone being introduced and it
+        appearing in CLDR, ready to be used by Noda Time. (There's also bound to be a delay between it appearing in
+        CLDR and being used in your production system.) In practice however, you're unlikely to wish to use a time zone
+        which isn't covered here.
+
+        :return: An immutable collection of mappings from Windows system time zones to TZDB time zones.
+        """
+        return self.__map_zones
+
+    @property
+    def primary_mapping(self) -> types.MappingProxyType[str, str]:
+        """Gets an immutable dictionary of primary mappings, from Windows system time zone ID to TZDB zone ID. This
+        corresponds to the "001" territory which is present for every zone within the mapping file.
+
+        Each value in the dictionary is a canonical ID in CLDR, but it may not be canonical
+        in TZDB. For example, the ID corresponding to "India Standard Time" is "Asia/Calcutta", which
+        is canonical in CLDR but is an alias in TZDB for "Asia/Kolkata". To obtain a canonical TZDB
+        ID, use ``TzdbDateTimeZoneSource.canonical_id_map``.
+
+        :return: An immutable dictionary of primary mappings, from Windows system time zone ID to TZDB zone ID.
+        """
+        return self.__primary_mapping
+
+    @classmethod
+    def _ctor(cls, version: str, tzdb_version: str, windows_version: str, map_zones: Sequence[MapZone]) -> WindowsZones:
+        return cls.__ctor(
+            version=_Preconditions._check_not_null(version, "version"),
+            tzdb_version=_Preconditions._check_not_null(tzdb_version, "tzdb_version"),
+            windows_version=_Preconditions._check_not_null(windows_version, "windows_version"),
+            map_zones=tuple(_Preconditions._check_not_null(map_zones, "map_zones")),
+        )
+
+    @classmethod
+    def __ctor(
+        cls, version: str, tzdb_version: str, windows_version: str, map_zones: Sequence[MapZone]
+    ) -> WindowsZones:
+        self = super().__new__(cls)
+        self.__version = version
+        self.__tzdb_version = tzdb_version
+        self.__windows_version = windows_version
+        self.__map_zones = map_zones
+        self.__primary_mapping = types.MappingProxyType(
+            {z.windows_id: z.tzdb_ids[0] for z in map_zones if z.territory == MapZone.PRIMARY_TERRITORY}
+        )
+        return self
+
+    @classmethod
+    def _read(cls, reader: _IDateTimeZoneReader) -> WindowsZones:
+        version: str = reader.read_string()
+        tzdb_version: str = reader.read_string()
+        windows_version: str = reader.read_string()
+        count: int = reader.read_count()
+        map_zones = tuple(MapZone._read(reader) for _ in range(count))
+        return WindowsZones.__ctor(version, tzdb_version, windows_version, map_zones)
+
+    def _write(self, writer: _IDateTimeZoneWriter) -> None:
+        writer.write_string(self.version)
+        writer.write_string(self.tzdb_version)
+        writer.write_string(self.windows_version)
+        writer.write_count(len(self.map_zones))
+        for map_zone in self.map_zones:
+            map_zone._write(writer)

--- a/pyoda_time/time_zones/io/__init__.py
+++ b/pyoda_time/time_zones/io/__init__.py
@@ -2,6 +2,4 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 
-from ._invalid_pyoda_data_exception import InvalidPyodaDataError
-
-__all__: list[str] = ["InvalidPyodaDataError"]
+__all__: list[str] = []

--- a/pyoda_time/time_zones/io/_date_time_zone_reader.py
+++ b/pyoda_time/time_zones/io/_date_time_zone_reader.py
@@ -1,0 +1,243 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import BinaryIO, Sequence, final
+
+from pyoda_time import Duration, Instant, Offset, PyodaConstants
+from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
+from pyoda_time.time_zones.io._i_date_time_zone_reader import _IDateTimeZoneReader
+from pyoda_time.utility import InvalidPyodaDataError
+from pyoda_time.utility._csharp_compatibility import _CsharpConstants, _int64_overflow, _private, _sealed
+
+
+@final
+@_sealed
+@_private
+class _DateTimeZoneReader(_IDateTimeZoneReader):
+    """Implementation of ``_IDateTimeZoneReader`` for the most recent version of the "blob" format of time zone data.
+
+    If the format changes, this class will be renamed (e.g. to _DateTimeZoneReaderV0) and the new implementation will
+    replace it.
+    """
+
+    __input: BinaryIO
+    """Raw stream to read from.
+
+    Be careful before reading from this - you need to take account of bufferedByte as well.
+    """
+    __string_pool: Sequence[str] | None
+    """String pool to use, or null if no string pool is in use."""
+    __buffered_byte: int | None
+    """Sometimes we need to buffer a byte in memory, e.g. to check if there is any more data.
+
+    Anything reading directly from the stream should check here first.
+    """
+
+    @classmethod
+    def _ctor(cls, input_: BinaryIO, string_pool: Sequence[str] | None) -> _DateTimeZoneReader:
+        self = super().__new__(cls)
+        self.__input = input_
+        self.__string_pool = string_pool
+        self.__buffered_byte = None
+        return self
+
+    @property
+    def has_more_data(self) -> bool:
+        if self.__buffered_byte is not None:
+            return True
+        next_byte = self.__input.read(1)
+        if not next_byte:
+            return False
+        # Okay, we got a byte - remember it for the next call to read_byte
+        self.__buffered_byte = next_byte[0]
+        return True
+
+    def read_count(self) -> int:
+        """Reads a non-negative integer value from the stream.
+
+        The value must have been written by ``_DateTimeZoneWriter.write_count``.
+
+        :return: The integer value from the stream.
+        """
+        unsigned = self.__read_varint()
+        if unsigned > _CsharpConstants.INT_MAX_VALUE:
+            raise InvalidPyodaDataError("Count value greater than Int32.MaxValue")
+        return unsigned
+
+    def read_signed_count(self) -> int:
+        """Reads a (possibly-negative) integer value from the stream.
+
+        The value must have been written by ``_DateTimeZoneWriter.write_signed_count``.
+
+        :return: The integer value from the stream.
+        """
+        value = self.__read_varint()
+        return (value >> 1) ^ -(value & 1)  # zigzag encoding
+
+    def __read_varint(self) -> int:
+        """Reads a base-128 varint value from the stream.
+
+        The value must have been written by DateTimeZoneWriter.WriteVarint, which documents the format.
+
+        :return: The integer value from the stream.
+        """
+        # TODO: unchecked
+        ret = 0
+        shift = 0
+        while True:
+            next_byte = self.read_byte()
+            ret += (next_byte & 0x7F) << shift
+            shift += 7
+            if next_byte < 0x80:
+                return ret
+
+    def read_milliseconds(self) -> int:
+        """Reads a number of milliseconds from the stream.
+
+        The value must have been written by ``_DateTimeZoneWriter.write_milliseconds``.
+
+        :return: The milliseconds value from the stream.
+        """
+        # TODO: unchecked
+        first_byte = self.read_byte()
+
+        millis: int
+
+        if (first_byte & 0x80) == 0:
+            millis = first_byte * (30 * PyodaConstants.MILLISECONDS_PER_MINUTE)
+        else:
+            flag = first_byte & 0xE0  # The flag parts of the first byte
+            first_data = first_byte & 0x1F  # The data parts of the first byte
+            match flag:
+                case 0x80:  # Minutes
+                    minutes = (first_data << 8) + self.read_byte()
+                    millis = minutes * PyodaConstants.MILLISECONDS_PER_MINUTE
+                case 0xA0:  # Seconds
+                    seconds = (first_data << 16) + (self.__read_int16() & 0xFFFF)
+                    millis = seconds * PyodaConstants.MILLISECONDS_PER_SECOND
+                case 0xC0:  # Milliseconds
+                    millis = (first_data << 24) + (self.read_byte() << 16) + (self.__read_int16() & 0xFFFF)
+                case _:
+                    raise InvalidPyodaDataError(f"Invalid flag in offset: {flag:02x}")
+        millis -= PyodaConstants.MILLISECONDS_PER_DAY
+        return millis
+
+    def read_offset(self) -> Offset:
+        """Reads an offset value from the stream.
+
+        The value must have been written by ``_DateTimeZoneWriter.write_offset``.
+
+        :return: The offset value from the stream.
+        """
+        millis = self.read_milliseconds()
+        return Offset.from_milliseconds(millis)
+
+    def read_dictionary(self) -> dict[str, str]:
+        """Reads a string to string dictionary value from the stream.
+
+        The value must have been written by ``_DateTimeZoneWriter.write_dictionary``.
+
+        :return: The ``dict[TKey,TValue]`` value from the stream.
+        """
+        results = {self.read_string(): self.read_string() for _ in range(self.read_count())}
+        return results
+
+    def read_zone_interval_transition(self, previous: Instant | None) -> Instant:
+        """Reads an instant representing a zone interval transition from the stream.
+
+        The value must have been written by ``_DateTimeZoneWriter.write_zone_interval_transition``.
+
+        :param previous: The previous transition written (usually for a given timezone), or null if there is no
+            previous transition
+        :return: The instant read from the stream
+        """
+        # TODO: unchecked (redundant)
+        value: int = self.read_count()
+        if value < _DateTimeZoneWriter._ZoneIntervalConstants._MIN_VALUE_FOR_HOURS_SINCE_PREVIOUS:
+            match value:
+                case _DateTimeZoneWriter._ZoneIntervalConstants._MARKER_MIN_VALUE:
+                    return Instant._before_min_value()
+                case _DateTimeZoneWriter._ZoneIntervalConstants._MARKER_MAX_VALUE:
+                    return Instant._after_max_value()
+                case _DateTimeZoneWriter._ZoneIntervalConstants._MARKER_RAW:
+                    return Instant.from_unix_time_ticks(self.__read_int64())
+                case _:
+                    raise InvalidPyodaDataError(f"Unrecognised marker value: {value}")
+        if value < _DateTimeZoneWriter._ZoneIntervalConstants._MIN_VALUE_FOR_MINUTES_SINCE_EPOCH:
+            if previous is None:
+                raise InvalidPyodaDataError(
+                    f"No previous value, so can't interpret value encoded as delta-since-previous: {value}"
+                )
+            return previous + Duration.from_hours(value)
+        return _DateTimeZoneWriter._ZoneIntervalConstants._EPOCH_FOR_MINUTES_SINCE_EPOCH + Duration.from_minutes(value)
+
+    def read_string(self) -> str:
+        """Reads a string value from the stream.
+
+        The value must have been written by ``_DateTimeZoneWriter.write_string``.
+
+        :return: The string value from the stream.
+        """
+        if self.__string_pool is None:
+            length = self.read_count()
+            data = bytearray()
+            while len(data) < length:
+                remaining = length - len(data)
+                chunk = self.__input.read(remaining)
+                if not chunk:
+                    raise InvalidPyodaDataError(
+                        f"Unexpectedly reached end of data with {remaining} bytes still to read"
+                    )
+                data.extend(chunk)
+            return data.decode()
+        else:
+            index = self.read_count()
+            if index >= len(self.__string_pool) or index < 0:
+                raise InvalidPyodaDataError("String pool index out of range")
+            return self.__string_pool[index]
+
+    def __read_int16(self) -> int:
+        """Reads a signed 16 bit integer value from the stream and returns it as an int.
+
+        :return: The 16 bit int value.
+        """
+        # TODO: unchecked (redundant)
+        high = self.read_byte()
+        low = self.read_byte()
+        return (high << 8) | low
+
+    def __read_int32(self) -> int:
+        """Reads a signed 32 bit integer value from the stream and returns it as an int.
+
+        :return: The 32 bit int value.
+        """
+        # TODO: unchecked (redundant)
+        high = self.__read_int16() & 0xFFFF
+        low = self.__read_int16() & 0xFFFF
+        return (high << 16) | low
+
+    def __read_int64(self) -> int:
+        """Reads a signed 64 bit integer value from the stream and returns it as an long.
+
+        :return: The 64 bit long value.
+        """
+        high = self.__read_int32() & 0xFFFFFFFF
+        low = self.__read_int32() & 0xFFFFFFFF
+        return _int64_overflow((high << 32) | low)
+
+    def read_byte(self) -> int:
+        """Reads a signed 8 bit integer value from the stream and returns it as an int.
+
+        :return: The 8 bit int value.
+        :raises InvalidPyodaDataError: The data in the stream has been exhausted.
+        """
+        if self.__buffered_byte is not None:
+            ret, self.__buffered_byte = self.__buffered_byte, None
+            return ret
+        value: bytes = self.__input.read(1)
+        if not value:
+            raise InvalidPyodaDataError("Unexpected end of data stream")
+        return value[0]

--- a/pyoda_time/time_zones/io/_date_time_zone_writer.py
+++ b/pyoda_time/time_zones/io/_date_time_zone_writer.py
@@ -1,0 +1,262 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import BinaryIO, Final, final
+
+from pyoda_time import Instant, Offset, PyodaConstants
+from pyoda_time.time_zones.io._i_date_time_zone_writer import _IDateTimeZoneWriter
+from pyoda_time.utility._csharp_compatibility import (
+    _csharp_modulo,
+    _CsharpConstants,
+    _private,
+    _sealed,
+    _towards_zero_division,
+)
+from pyoda_time.utility._preconditions import _Preconditions
+
+
+@final
+@_sealed
+@_private
+class _DateTimeZoneWriter(_IDateTimeZoneWriter):
+    """Implementation of ``_IDateTimeZoneWriter`` for the most recent version of the "blob" format of time zone data.
+
+    If the format changes, this class will be renamed (e.g. to _DateTimeZoneWriterV0) and the new implementation will
+    replace it.
+    """
+
+    class _DateTimeZoneType(IntEnum):
+        FIXED = 1
+        PRECALCULATED = 2
+
+    class _ZoneIntervalConstants:
+        _EPOCH_FOR_MINUTES_SINCE_EPOCH: Final[Instant] = Instant.from_utc(1800, 1, 1, 0, 0)
+        """The instant to use as an 'epoch' when writing out a number of minutes-since-epoch."""
+
+        _MARKER_MIN_VALUE: Final[int] = 0
+        """The marker value representing the beginning of time."""
+        _MARKER_MAX_VALUE: Final[int] = 1
+        """The marker value representing the end of time."""
+        _MARKER_RAW: Final[int] = 2
+        """The marker value representing an instant as a fixed 64-bit number of ticks."""
+        _MIN_VALUE_FOR_HOURS_SINCE_PREVIOUS: Final[int] = 1 << 7
+        """The minimum varint value that represents an number of hours-since-previous.
+
+        Values below this are reserved for markers.
+        """
+        _MIN_VALUE_FOR_MINUTES_SINCE_EPOCH: Final[int] = 1 << 21
+        """The minimum varint value that represents a number of minutes since an epoch.
+
+        Values below this are interpreted as hours-since-previous (for a range of about 240 years), rather than minutes-
+        since-epoch (for a range of about 4000 years) This choice is somewhat arbitrary, though it results in hour
+        values always taking 2 (or occasionally 3) bytes when encoded as a varint, while minute values take 4 (or
+        conceivably 5).
+        """
+
+    __output: BinaryIO
+    __string_pool: list[str] | None
+
+    @classmethod
+    def _ctor(cls, output: BinaryIO, string_pool: list[str] | None) -> _DateTimeZoneWriter:
+        """Constructs a DateTimeZoneWriter.
+
+        :param output: Where to send the serialized output.
+        :param string_pool: String pool to add strings to, or None for no pool
+        """
+        self = super().__new__(cls)
+        self.__output = output
+        self.__string_pool = string_pool
+        return self
+
+    def write_count(self, count: int) -> None:
+        """Writes the given non-negative integer value to the stream.
+
+        :param count: The value to write.
+        """
+        _Preconditions._check_argument_range("count", count, 0, _CsharpConstants.INT_MAX_VALUE)
+        self.__write_varint(count)
+
+    def write_signed_count(self, count: int) -> None:
+        """Writes the given (possibly-negative) integer value to the stream.
+
+        Unlike ``write_count``, this can encode negative numbers.
+
+        It does, however, use a slightly less efficient encoding for positive numbers.
+
+        :param count: The value to write.
+        """
+        # TODO: unchecked (uint)
+        self.__write_varint((count >> 31) ^ (count << 1))  # zigzag encoding
+
+    def __write_varint(self, value: int) -> None:
+        """Writes the given integer value to the stream as a base-128 varint.
+
+        The format is a simple 7-bit encoding: while the value is greater than 127 (i.e.
+        has more than 7 significant bits) we repeatedly write the least-significant 7 bits
+        with the top bit of the byte set as a continuation bit, then shift the value right
+        7 bits.
+
+        :param value: The value to write.
+        """
+        # TODO: unchecked
+        while value > 0x7F:
+            self.__output.write(bytes([(value & 0x7F) | 0x80]))
+            value >>= 7
+        self.__output.write(bytes([value & 0x7F]))
+
+    def write_milliseconds(self, millis: int) -> None:
+        _Preconditions._check_argument_range(
+            "millis", millis, -PyodaConstants.MILLISECONDS_PER_DAY + 1, PyodaConstants.MILLISECONDS_PER_DAY - 1
+        )
+        millis += PyodaConstants.MILLISECONDS_PER_DAY
+        # First, add 24 hours to the number of milliseconds, to get a value in the range (0, 172800000).
+        # (It's exclusive at both ends, but that's insignificant.)
+        # Check whether it's an exact multiple of half-hours or minutes, and encode
+        # appropriately. In every case, if it's an exact multiple, we know that we'll be able to fit
+        # the value into the number of bits available.
+        #
+        # first byte      units       max data value (+1)   field length
+        # --------------------------------------------------------------
+        # 0xxxxxxx        30 minutes  96                    1 byte  (7 data bits)
+        # 100xxxxx        minutes     2880                  2 bytes (14 data bits)
+        # 101xxxxx        seconds     172800                3 bytes (21 data bits)
+        # 110xxxxx        millis      172800000             4 bytes (29 data bits)
+
+        # TODO: unchecked
+
+        if _csharp_modulo(millis, 30 * PyodaConstants.MILLISECONDS_PER_MINUTE) == 30:
+            units: int = _towards_zero_division(millis, 30 * PyodaConstants.MILLISECONDS_PER_MINUTE)
+            self.write_byte(units)
+        elif _csharp_modulo(millis, PyodaConstants.MILLISECONDS_PER_MINUTE) == 0:
+            minutes: int = _towards_zero_division(millis, PyodaConstants.MILLISECONDS_PER_MINUTE)
+            self.write_byte(0x80 | (minutes >> 8))
+            self.write_byte(minutes & 0xFF)
+        elif _csharp_modulo(millis, PyodaConstants.MILLISECONDS_PER_SECOND) == 0:
+            seconds: int = _towards_zero_division(millis, PyodaConstants.MILLISECONDS_PER_SECOND)
+            self.write_byte(0xA0 | (seconds >> 16))
+            self.__write_int16(seconds & 0xFFFF)
+        else:
+            self.__write_int32(0xC0000000 | millis)
+
+    def write_offset(self, offset: Offset) -> None:
+        """Writes the offset value to the stream.
+
+        :param offset: The value to write.
+        """
+        self.write_milliseconds(offset.milliseconds)
+
+    def write_dictionary(self, dictionary: dict[str, str]) -> None:
+        """Writes the given dictionary of string to string to the stream.
+
+        :param dictionary: The dictionary to write.
+        """
+        _Preconditions._check_not_null(dictionary, "dictionary")
+        self.write_count(len(dictionary))
+        for key, value in dictionary.items():
+            self.write_string(key)
+            self.write_string(value)
+
+    def write_zone_interval_transition(self, previous: Instant | None, value: Instant) -> None:
+        if previous:
+            _Preconditions._check_argument(value >= previous, "value", "Transition must move forward in time")
+
+        # TODO: unchecked
+
+        if value == Instant._before_min_value():
+            self.write_count(self._ZoneIntervalConstants._MARKER_MIN_VALUE)
+            return
+        if value == Instant._after_max_value():
+            self.write_count(self._ZoneIntervalConstants._MARKER_MAX_VALUE)
+            return
+
+        # In practice, most zone interval transitions will occur within 4000-6000 hours of the previous one
+        # (i.e. about 5-8 months), and at an integral number of hours difference. We therefore gain a
+        # significant reduction in output size by encoding transitions as the whole number of hours since the
+        # previous, if possible.
+        # If the previous value was "the start of time" then there's no point in trying to use it.
+        if previous and previous != Instant._before_min_value():
+            # Note that the difference might exceed the range of a long, so we can't use a Duration here.
+            ticks = value.to_unix_time_ticks() - previous.to_unix_time_ticks()
+            if _csharp_modulo(ticks, PyodaConstants.TICKS_PER_HOUR) == 0:
+                hours = _csharp_modulo(ticks, PyodaConstants.TICKS_PER_HOUR)
+                # As noted above, this will generally fall within the 4000-6000 range, although values up to
+                # ~700,000 exist in TZDB.
+                if (
+                    self._ZoneIntervalConstants._MIN_VALUE_FOR_HOURS_SINCE_PREVIOUS
+                    <= hours
+                    < self._ZoneIntervalConstants._MIN_VALUE_FOR_MINUTES_SINCE_EPOCH
+                ):
+                    self.write_count(hours)
+                    return
+
+        # We can't write the transition out relative to the previous transition, so let's next try writing it
+        # out as a whole number of minutes since an (arbitrary, known) epoch.
+        if value >= self._ZoneIntervalConstants._EPOCH_FOR_MINUTES_SINCE_EPOCH:
+            ticks = (
+                value.to_unix_time_ticks()
+                - self._ZoneIntervalConstants._EPOCH_FOR_MINUTES_SINCE_EPOCH.to_unix_time_ticks()
+            )
+            if _csharp_modulo(ticks, PyodaConstants.TICKS_PER_MINUTE) == 0:
+                minutes = _towards_zero_division(ticks, PyodaConstants.TICKS_PER_MINUTE)
+                # We typically have a count on the order of 80M here.
+                if (
+                    self._ZoneIntervalConstants._MIN_VALUE_FOR_MINUTES_SINCE_EPOCH
+                    < minutes
+                    <= _CsharpConstants.INT_MAX_VALUE
+                ):
+                    self.write_count(minutes)
+                    return
+
+        # Otherwise, just write out a marker followed by the instant as a 64-bit number of ticks.  Note that
+        # while most of the values we write here are actually whole numbers of _seconds_, optimising for that
+        # case will save around 2KB (with tzdb 2012j), so doesn't seem worthwhile.
+        self.write_count(self._ZoneIntervalConstants._MARKER_RAW)
+        self.__write_int64(value.to_unix_time_ticks())
+
+    def write_string(self, value: str) -> None:
+        """Writes the string value to the stream.
+
+        :param value: The value to write.
+        """
+        if self.__string_pool is None:
+            data = value.encode()
+            length = len(data)
+            self.write_count(length)
+            self.__output.write(data)
+        else:
+            if value not in self.__string_pool:
+                self.__string_pool.append(value)
+            self.write_count(self.__string_pool.index(value))
+
+    def __write_int16(self, value: int) -> None:
+        """Writes the given 16-bit integer value to the stream.
+
+        :param value: The value to write.
+        """
+        # TODO: unchecked
+        self.write_byte((value >> 8) & 0xFF)
+        self.write_byte(value & 0xFF)
+
+    def __write_int32(self, value: int) -> None:
+        """Writes the given 32-bit integer value to the stream.
+
+        :param value: The value to write.
+        """
+        # TODO unchecked
+        self.__write_int16(value >> 16)
+        self.__write_int16(value)
+
+    def __write_int64(self, value: int) -> None:
+        """Writes the given 64-bit integer value to the stream.
+
+        :param value: The value to write.
+        """
+        self.__write_int32(value >> 32)
+        self.__write_int32(value)
+
+    def write_byte(self, value: int) -> None:
+        # TODO unchecked (unused)
+        self.__output.write(bytes([value]))

--- a/pyoda_time/time_zones/io/_i_date_time_zone_reader.py
+++ b/pyoda_time/time_zones/io/_i_date_time_zone_reader.py
@@ -1,0 +1,87 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Protocol
+
+from pyoda_time._instant import Instant
+from pyoda_time._offset import Offset
+
+
+class _IDateTimeZoneReader(Protocol):
+    """Interface for reading time-related data from a binary stream."""
+
+    @property
+    def has_more_data(self) -> bool:
+        """Returns whether or not there is more data in this stream.
+
+        :return: Whether or not there is more data in the stream.
+        """
+        ...
+
+    def read_count(self) -> int:
+        """Reads a non-negative integer from the stream, which must have been written by a call to
+        ``_IDateTimeZoneWriter.write_count``.
+
+        :return: The integer read from the stream.
+        :raises InvalidPyodaDataError: The data was invalid.
+        """
+        ...
+
+    def read_signed_count(self) -> int:
+        """Reads a non-negative integer from the stream, which must have been written by a call to
+        ``_IDateTimeZoneWriter.write_signed_count``.
+
+        :return: The integer read from the stream
+        :raises InvalidPyodaDataError: The data was invalid.
+        """
+        ...
+
+    def read_string(self) -> str:
+        """Reads a string from the stream.
+
+        :return: The string read from the stream; will not be null
+        :raises InvalidPyodaDataError: The data was invalid.
+        """
+        ...
+
+    def read_byte(self) -> int:
+        """Reads a signed 8 bit integer value from the stream and returns it as an int.
+
+        :return: The 8 bit int value.
+        :raises InvalidPyodaDataError: The data in the stream has been exhausted.
+        """
+        ...
+
+    def read_milliseconds(self) -> int:
+        """Reads a number of milliseconds from the stream.
+
+        :return: The number of milliseconds read from the stream
+        :raises InvalidPyodaDataError: The data was invalid.
+        """
+        ...
+
+    def read_offset(self) -> Offset:
+        """Reads an offset from the stream.
+
+        :return: The offset read from the stream
+        :raises InvalidPyodaDataError: The data was invalid.
+        """
+        ...
+
+    def read_zone_interval_transition(self, previous: Instant | None) -> Instant:
+        """Reads an instant representing a zone interval transition from the stream.
+
+        :param previous: The previous transition written (usually for a given timezone), or None if there is no previous
+            transition.
+        :return: The instant read from the stream
+        :raises InvalidPyodaDataError: The data was invalid.
+        """
+        ...
+
+    def read_dictionary(self) -> dict[str, str]:
+        """Reads a string-to-string dictionary from the stream.
+
+        :return: The dictionary read from the stream
+        :raises InvalidPyodaDataError: The data was invalid.
+        """
+        ...

--- a/pyoda_time/time_zones/io/_i_date_time_zone_writer.py
+++ b/pyoda_time/time_zones/io/_i_date_time_zone_writer.py
@@ -1,0 +1,83 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Protocol
+
+from pyoda_time._instant import Instant
+from pyoda_time._offset import Offset
+
+
+class _IDateTimeZoneWriter(Protocol):
+    """Interface for writing time-related data to a binary stream."""
+
+    def write_count(self, count: int) -> None:
+        """Writes a non-negative integer to the stream.
+
+        This is optimized towards cases where most values will be small.
+
+        :param count: The integer to write to the stream.
+        :raises ValueError: ``count`` is negative.
+        """
+        ...
+
+    def write_signed_count(self, count: int) -> None:
+        """Writes a possibly-negative integer to the stream.
+
+        This is optimized for values of small magnitudes.
+
+        :param count: The integer to write to the stream.
+        """
+        ...
+
+    def write_string(self, value: str) -> None:
+        """Writes a string to the stream.
+
+        Callers can reasonably expect that these values will be pooled in some fashion, so should not apply their own
+        pooling.
+
+        :param value: The string to write to the stream.
+        """
+        ...
+
+    def write_milliseconds(self, millis: int) -> None:
+        """Writes a number of milliseconds to the stream.
+
+        The number of milliseconds must be in the range (-1 day, +1 day).
+
+        :param millis: The number of milliseconds to write to the stream.
+        :raises ValueError: ``millis`` is out of range.
+        """
+        ...
+
+    def write_offset(self, offset: Offset) -> None:
+        """Writes an offset to the stream.
+
+        :param offset: The offset to write to the stream.
+        """
+        ...
+
+    def write_zone_interval_transition(self, previous: Instant | None, value: Instant) -> None:
+        """Writes an instant representing a zone interval transition to the stream.
+
+        This method takes a previously-written transition. Depending on the implementation, this value may be required
+        by the reader in order to reconstruct the next transition, so it should be deterministic for any given value.
+
+        :param previous: The previous transition written (usually for a given timezone), or None if there is no previous
+            transition.
+        :param value: The transition to write to the stream.
+        """
+        ...
+
+    def write_dictionary(self, dictionary: dict[str, str]) -> None:
+        """Writes a string-to-string dictionary to the stream.
+
+        :param dictionary: The dictionary to write to the stream.
+        """
+        ...
+
+    def write_byte(self, value: int) -> None:
+        """Writes the given 8-bit integer value to the stream.
+
+        :param value: The value to write.
+        """
+        ...

--- a/pyoda_time/time_zones/io/_tzdb_stream_data.py
+++ b/pyoda_time/time_zones/io/_tzdb_stream_data.py
@@ -1,0 +1,158 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+import io
+import struct
+import types
+from typing import Any, BinaryIO, Callable, Final, Sequence, TypeVar, final
+
+from pyoda_time.time_zones import TzdbZoneLocation
+from pyoda_time.time_zones._tzdb_zone_1970_location import TzdbZone1970Location
+from pyoda_time.time_zones.cldr import WindowsZones
+from pyoda_time.time_zones.io._date_time_zone_reader import _DateTimeZoneReader
+from pyoda_time.time_zones.io._tzdb_stream_field import _TzdbStreamField
+from pyoda_time.time_zones.io._tzdb_stream_field_id import _TzdbStreamFieldId
+from pyoda_time.utility import InvalidPyodaDataError
+from pyoda_time.utility._csharp_compatibility import _sealed
+from pyoda_time.utility._preconditions import _Preconditions
+
+T = TypeVar("T")
+
+
+@final
+@_sealed
+class _TzdbStreamData:
+    """Provides the raw data exposed by ``TzdbDateTimeZoneSource``."""
+
+    class _Builder:
+        """Mutable builder class used during parsing."""
+
+        def __init__(
+            self,
+            string_pool: Sequence[str] | None = None,
+            tzdb_version: str | None = None,
+            tzdb_id_map: dict[str, str] | None = None,
+            windows_mapping: WindowsZones | None = None,
+        ) -> None:
+            self._string_pool: Sequence[str] | None = string_pool
+            self._tzdb_version: str | None = tzdb_version
+            self._tzdb_id_map: dict[str, str] | None = tzdb_id_map
+            self._zone_locations: Sequence[TzdbZoneLocation] | None = None
+            self._zone_1970_locations: Sequence[TzdbZone1970Location] | None = None
+            self._windows_mapping: WindowsZones | None = windows_mapping
+            self._zone_fields: dict[str, _TzdbStreamField] = {}
+
+        def _handle_string_pool_field(self, field: _TzdbStreamField) -> None:
+            self.__check_single_field(field, self._string_pool)
+            with field._create_stream() as stream:
+                reader = _DateTimeZoneReader._ctor(stream, None)
+                count: int = reader.read_count()
+                string_pool_array = tuple(reader.read_string() for _ in range(count))
+                self._string_pool = string_pool_array
+
+        def _handle_zone_field(self, field: _TzdbStreamField) -> None:
+            self.__check_string_pool_presence(field)
+            # Just read the ID from the zone - we don't parse the data yet.
+            # (We could, but we might as well be lazy.)
+            with field._create_stream() as stream:
+                reader = _DateTimeZoneReader._ctor(stream, self._string_pool)
+                id_: str = reader.read_string()
+                if id_ in self._zone_fields:
+                    raise InvalidPyodaDataError(f"Multiple definitions for zone {id_}")
+                self._zone_fields[id_] = field
+
+        def _handle_tzdb_version_field(self, field: _TzdbStreamField) -> None:
+            self.__check_single_field(field, self._tzdb_version)
+            self._tzdb_version = field._extract_single_value(lambda reader: reader.read_string(), None)
+
+        def _handle_tzdb_id_map_field(self, field: _TzdbStreamField) -> None:
+            self.__check_single_field(field, self._tzdb_id_map)
+            self._tzdb_id_map = field._extract_single_value(lambda reader: reader.read_dictionary(), self._string_pool)
+
+        def _handle_supplemental_windows_zones_field(self, field: _TzdbStreamField) -> None:
+            self.__check_single_field(field, self._windows_mapping)
+            self._windows_mapping = field._extract_single_value(WindowsZones._read, self._string_pool)
+
+        def _handle_zone_locations_field(self, field: _TzdbStreamField) -> None:
+            self.__check_single_field(field, self._zone_locations)
+            self.__check_string_pool_presence(field)
+            with field._create_stream() as stream:
+                reader = _DateTimeZoneReader._ctor(stream, self._string_pool)
+                count = reader.read_count()
+                array = tuple(TzdbZoneLocation._read(reader) for _ in range(count))
+                self._zone_locations = array
+
+        def _handle_zone_1970_locations_field(self, field: _TzdbStreamField) -> None:
+            self.__check_single_field(field, self._zone_1970_locations)
+            self.__check_string_pool_presence(field)
+            with field._create_stream() as stream:
+                reader = _DateTimeZoneReader._ctor(stream, self._string_pool)
+                count = reader.read_count()
+                array = tuple(TzdbZone1970Location._read(reader) for _ in range(count))
+                self._zone_1970_locations = array
+
+        @staticmethod
+        def __check_single_field(field: _TzdbStreamField, expected_null_field: Any) -> None:
+            if expected_null_field is not None:
+                raise InvalidPyodaDataError(f"Multiple fields of ID {field.id}")
+
+        def __check_string_pool_presence(self, field: _TzdbStreamField) -> None:
+            if self._string_pool is None:
+                raise InvalidPyodaDataError(f"String pool must be present before field {field.id}")
+
+    __FIELD_HANDLERS: Final[dict[_TzdbStreamFieldId, Callable[[_Builder, _TzdbStreamField], None]]] = {
+        _TzdbStreamFieldId.STRING_POOL: lambda builder, field: builder._handle_string_pool_field(field),
+        _TzdbStreamFieldId.TIME_ZONE: lambda builder, field: builder._handle_zone_field(field),
+        _TzdbStreamFieldId.TZDB_ID_MAP: lambda builder, field: builder._handle_tzdb_id_map_field(field),
+        _TzdbStreamFieldId.TZDB_VERSION: lambda builder, field: builder._handle_tzdb_version_field(field),
+        _TzdbStreamFieldId.CLDR_SUPPLEMENTAL_WINDOWS_ZONES: lambda builder,
+        field: builder._handle_supplemental_windows_zones_field(field),
+        _TzdbStreamFieldId.ZONE_LOCATIONS: lambda builder, field: builder._handle_zone_locations_field(field),
+        _TzdbStreamFieldId.ZONE_1970_LOCATIONS: lambda builder, field: builder._handle_zone_1970_locations_field(field),
+    }
+
+    __ACCEPTED_VERSION: Final[int] = 0
+
+    @property
+    def tzdb_version(self) -> str:
+        """Returns the TZDB version string."""
+        return self.__tzdb_version
+
+    def __init__(self, builder: _Builder) -> None:
+        self.__string_pool: Sequence[str] = self._check_not_null(builder._string_pool, "string pool")
+        mutable_id_map = self._check_not_null(builder._tzdb_id_map, "TZDB alias map")
+        self.__tzdb_version = self._check_not_null(builder._tzdb_version, "TZDB version")
+        self.__windows_mapping = self._check_not_null(builder._windows_mapping, "CLDR Supplemental Windows Zones")
+        self.__zone_fields = builder._zone_fields
+        self.__zone_locations = builder._zone_locations
+        self.__zone_1970_locations = builder._zone_1970_locations
+
+        # Add in the canonical IDs as mappings to themselves
+        for zone_id in self.__zone_fields:
+            mutable_id_map[zone_id] = zone_id
+        self.__tzdb_id_map = types.MappingProxyType(mutable_id_map)
+
+    @staticmethod
+    def _check_not_null(input_: T | None, name: str) -> T:
+        if input_ is None:
+            raise InvalidPyodaDataError(f"Incomplete TZDB data. Missing field: {name}")
+        return input_
+
+    @classmethod
+    def _from_stream(cls, stream: BinaryIO) -> _TzdbStreamData:
+        _Preconditions._check_not_null(stream, "stream")
+
+        with io.BytesIO(stream.read()) as reader:
+            version = struct.unpack("i", reader.read(4))[0]
+        if version != cls.__ACCEPTED_VERSION:
+            raise InvalidPyodaDataError(f"Unable to read stream with version {version}")
+
+        builder = cls._Builder()
+        for field in _TzdbStreamField._read_fields(stream):
+            handler = cls.__FIELD_HANDLERS.get(field.id)
+            if handler:
+                handler(builder, field)
+
+        return cls(builder)

--- a/pyoda_time/time_zones/io/_tzdb_stream_field.py
+++ b/pyoda_time/time_zones/io/_tzdb_stream_field.py
@@ -1,0 +1,61 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from io import BytesIO
+from typing import BinaryIO, Callable, Generator, Sequence, TypeVar, final
+
+from pyoda_time.utility._csharp_compatibility import _private, _sealed
+
+from ...utility import InvalidPyodaDataError
+from ._date_time_zone_reader import _DateTimeZoneReader
+from ._tzdb_stream_field_id import _TzdbStreamFieldId
+
+T = TypeVar("T")
+
+
+@final
+@_sealed
+@_private
+class _TzdbStreamField:
+    """An unparsed field within a stream."""
+
+    __data: bytes
+    __id: _TzdbStreamFieldId
+
+    @property
+    def id(self) -> _TzdbStreamFieldId:
+        return self.__id
+
+    @classmethod
+    def _ctor(cls, id_: _TzdbStreamFieldId, data: bytes) -> _TzdbStreamField:
+        self = super().__new__(cls)
+        self.__id = id_
+        self.__data = data
+        return self
+
+    def _create_stream(self) -> BinaryIO:
+        """Creates a new read-only stream over the data for this field."""
+        return BytesIO(self.__data)
+
+    def _extract_single_value(
+        self, reader_function: Callable[[_DateTimeZoneReader], T], string_pool: Sequence[str] | None
+    ) -> T:
+        with self._create_stream() as stream:
+            return reader_function(_DateTimeZoneReader._ctor(stream, string_pool))
+
+    @classmethod
+    def _read_fields(cls, stream: BinaryIO) -> Generator[_TzdbStreamField, None, None]:
+        field_id = stream.read(1)
+        if field_id:
+            id_ = _TzdbStreamFieldId(field_id[0])
+            # Read 7-bit encoded length
+            length = _DateTimeZoneReader._ctor(stream, None).read_count()
+            data = bytearray()
+            for offset in range(length):
+                bytes_read: bytes = stream.read(1)
+                if not bytes_read:
+                    raise InvalidPyodaDataError(f"Stream ended after reading {offset} bytes out of {length}")
+                data.extend(bytes_read)
+            yield _TzdbStreamField._ctor(id_, data)

--- a/pyoda_time/time_zones/io/_tzdb_stream_field_id.py
+++ b/pyoda_time/time_zones/io/_tzdb_stream_field_id.py
@@ -1,0 +1,52 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from enum import IntEnum
+
+
+class _TzdbStreamFieldId(IntEnum):
+    """Enumeration of the fields which can occur in a TZDB stream file.
+
+    This enables the file to be self-describing to a reasonable extent.
+    """
+
+    STRING_POOL = 0
+    """String pool.
+
+    Format is: number of strings (WriteCount) followed by that many string values.
+    The indexes into the resultant list are used for other strings in the file, in some fields.
+    """
+
+    TIME_ZONE = 1
+    """Repeated field of time zones.
+
+    Format is: zone ID, then zone as written by ``_DateTimeZoneWriter``.
+    """
+
+    TZDB_VERSION = 2
+    """Single field giving the version of the TZDB source data.
+
+    A string value which does *not* use the string pool.
+    """
+
+    TZDB_ID_MAP = 3
+    """Single field giving the mapping of ID to canonical ID, as written by ``_DateTimeZoneWriter.write_dictionary``."""
+
+    CLDR_SUPPLEMENTAL_WINDOWS_ZONES = 4
+    """Single field containing mapping data as written by ``_WindowsZones.write``."""
+
+    WINDOWS_ADDITIONAL_STANDARD_NAME_TO_ID_MAPPING = 5
+    """Single field giving the mapping of Windows StandardName to TZDB canonical ID, for time zones where
+    TimeZoneInfo.Id != TimeZoneInfo.StandardName, as written by ``_DateTimeZoneWriter.write_dictionary``."""
+
+    ZONE_LOCATIONS = 6
+    """Single field providing all zone locations.
+
+    The format is simply a count, and then that many copies of ``_TzdbZoneLocation`` data.
+    """
+
+    ZONE_1970_LOCATIONS = 7
+    """Single field providing all "zone 1970" locations.
+
+    The format is simply a count, and then that many copies of ``_TzdbZone1970Location`` data.
+    """

--- a/pyoda_time/utility/_invalid_pyoda_data_exception.py
+++ b/pyoda_time/utility/_invalid_pyoda_data_exception.py
@@ -1,0 +1,17 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+
+from typing import final
+
+from ._csharp_compatibility import _sealed
+
+
+@final
+@_sealed
+class InvalidPyodaDataError(Exception):
+    """Exception thrown when data read by Pyoda Time (such as serialized time zone data) is invalid.
+
+    This includes data which is truncated, i.e. we expect more data than we can read.
+    """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -126,6 +126,22 @@ def test_non_generic_compare_to(
     assert str(e.value) == f"{value.__class__.__name__} cannot be compared to object"
 
 
+def test_equals_class(value: T_IEquatable, equal_value: T_IEquatable, *unequal_values: T_IEquatable) -> None:
+    """Tests the IEquatable.Equals method for reference objects. Also tests the object equals method.
+
+    :param value: The base value.
+    :param equal_value: The value equal to but not the same object as the base value.
+    :param unequal_values: Values not equal to the base value.
+    """
+    test_object_equals(value, equal_value, *unequal_values)
+    assert not value.equals(None)
+    assert value.equals(value)
+    assert value.equals(equal_value)
+    assert equal_value.equals(value)
+    for unequal_value in unequal_values:
+        assert not value.equals(unequal_value)
+
+
 def test_equals_struct(value: T_IEquatable, equal_value: T_IEquatable, *unequal_values: T_IEquatable) -> None:
     """Tests the IEquatable.Equals method for value objects. Also tests the object equals method.
 
@@ -283,28 +299,6 @@ def _validate_input(value: T, equal_value: T, unequal_values: T | Sequence[T], u
     for unequal_value in unequal_values:
         assert unequal_value is not None, f"{unequal_name} cannot be null"
         assert unequal_value is not value, f"{unequal_name} and value MUST be different objects"
-
-
-def test_equals(value: T_IEquatable, equal_value: T_IEquatable, *unequal_values: T_IEquatable) -> None:
-    """A combination of ``TestHelpers.TestEqualsClass``, ``TestHelpers.TestEqualsStruct`` and
-    ``TestHelpers.TestObjectEquals`` from Noda Time.
-
-    In Pyoda Time we don't have structs, so we don't need separate helpers for "value types".
-
-    :param value: The base value.
-    :param equal_value: The value equal to but not the same object as the base value.
-    :param unequal_values: The value not equal to the base value.
-    """
-    # TODO: IMplement TestEqualsClass abd TestEqualsStruct & TestObjectEquals instead of this
-    _validate_input(value, equal_value, unequal_values, "unequal_value")
-    assert value is not None
-    assert value.equals(value)
-    assert value.equals(equal_value)
-    assert equal_value.equals(value)
-    for unequal_value in unequal_values:
-        assert not value.equals(unequal_value)
-    assert hash(value) == hash(value)
-    assert hash(value) == hash(equal_value)
 
 
 def create_positive_offset(hours: int, minutes: int, seconds: int) -> Offset:

--- a/tests/test_comparison_operator_consistency.py
+++ b/tests/test_comparison_operator_consistency.py
@@ -28,6 +28,7 @@ from pyoda_time._local_instant import _LocalInstant
 from pyoda_time._year_month_day import _YearMonthDay
 from pyoda_time._year_month_day_calendar import _YearMonthDayCalendar
 from pyoda_time.time_zones import ZoneInterval
+from pyoda_time.time_zones.cldr import MapZone
 
 VALUES = [
     DateInterval(LocalDate.min_iso_value, LocalDate.max_iso_value),
@@ -38,6 +39,7 @@ VALUES = [
     LocalDate.max_iso_value,
     LocalTime.max_value,
     LocalDate.max_iso_value + LocalTime.max_value,
+    MapZone("windowsId", "territory", ["tzdbId1"]),
     Offset.zero,
     OffsetTime(LocalTime.midnight, Offset.zero),
     Period.zero,
@@ -84,11 +86,12 @@ def test_are_all_pyoda_time_classes_covered() -> None:
         "__lt__",
         "__le__",
     ]
-    classes_which_define_comparison_operators = [
+    classes_which_define_comparison_operators = {
         cls.__name__ for cls in classes if any(op in cls.__dict__ for op in comparison_operators)
-    ]
-    classes_covered_by_tests = [value.__class__.__name__ for value in VALUES]
-    assert sorted(classes_covered_by_tests) == sorted(classes_which_define_comparison_operators)
+    }
+    classes_covered_by_tests = {value.__class__.__name__ for value in VALUES}
+    uncovered = sorted(classes_which_define_comparison_operators.difference(classes_covered_by_tests))
+    assert not uncovered
 
 
 def generate_test_param_id(test_param: Any) -> str:

--- a/tests/time_zones/cldr/__init__.py
+++ b/tests/time_zones/cldr/__init__.py
@@ -1,7 +1,3 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-
-from ._invalid_pyoda_data_exception import InvalidPyodaDataError
-
-__all__: list[str] = ["InvalidPyodaDataError"]

--- a/tests/time_zones/cldr/test_map_zone.py
+++ b/tests/time_zones/cldr/test_map_zone.py
@@ -1,0 +1,40 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import io
+
+from pyoda_time.time_zones.cldr import MapZone
+from pyoda_time.time_zones.io._date_time_zone_reader import _DateTimeZoneReader
+from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
+
+from ... import helpers
+
+
+class TestMapZone:
+    def test_equality(self) -> None:
+        zone_1 = MapZone("windowsId", "territory", ("id1", "id2", "id3"))
+        zone_2 = MapZone("windowsId", "territory", ("id1", "id2", "id3"))
+        zone_3 = MapZone("otherWindowsId", "territory", ("id1", "id2", "id3"))
+        zone_4 = MapZone("windowsId", "otherTerritory", ("id1", "id2", "id3"))
+        zone_5 = MapZone("windowsId", "territory", ("id1", "id2"))
+        zone_6 = MapZone("windowsId", "territory", ("id1", "id2", "id4"))
+        helpers.test_equals_class(zone_1, zone_2, zone_3)
+        helpers.test_equals_class(zone_1, zone_2, zone_4)
+        helpers.test_equals_class(zone_1, zone_2, zone_5)
+        helpers.test_equals_class(zone_1, zone_2, zone_6)
+
+    def test_to_string(self) -> None:
+        zone = MapZone("windowsId", "territory", ("id1", "id2", "id3"))
+        expected = "Windows ID: windowsId; Territory: territory; TzdbIds: id1 id2 id3"
+        assert str(zone) == expected
+
+    def test_read_write(self) -> None:
+        zone = MapZone("windowsId", "territory", ("id1", "id2", "id3"))
+        stream = io.BytesIO()
+        writer = _DateTimeZoneWriter._ctor(stream, None)
+        zone._write(writer)
+        stream.seek(0)
+
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        zone_2 = MapZone._read(reader)
+        assert zone == zone_2

--- a/tests/time_zones/cldr/test_windows_zones.py
+++ b/tests/time_zones/cldr/test_windows_zones.py
@@ -1,0 +1,42 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import io
+from typing import Final
+
+from pyoda_time.time_zones.cldr import MapZone, WindowsZones
+from pyoda_time.time_zones.io._date_time_zone_reader import _DateTimeZoneReader
+from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
+
+MAP_ZONE_1: Final[MapZone] = MapZone("windowsId1", "territory1", ("id1.1", "id1.2", "id1.3"))
+MAP_ZONE_2: Final[MapZone] = MapZone("windowsId2", MapZone.PRIMARY_TERRITORY, ("primaryId2",))
+MAP_ZONE_3: Final[MapZone] = MapZone("windowsId3", MapZone.PRIMARY_TERRITORY, ("primaryId3",))
+
+
+class TestWindowsZones:
+    def test_properties(self) -> None:
+        zones = WindowsZones._ctor("version", "tzdb_version", "windowsVersion", (MAP_ZONE_1, MAP_ZONE_2, MAP_ZONE_3))
+        assert zones.version == "version"
+        assert zones.tzdb_version == "tzdb_version"
+        assert zones.windows_version == "windowsVersion"
+        assert zones.primary_mapping["windowsId2"] == "primaryId2"
+        assert zones.primary_mapping["windowsId3"] == "primaryId3"
+        assert zones.map_zones == (MAP_ZONE_1, MAP_ZONE_2, MAP_ZONE_3)
+
+    def test_read_write(self) -> None:
+        zones = WindowsZones._ctor("version", "tzdb_version", "windowsVersion", (MAP_ZONE_1, MAP_ZONE_2, MAP_ZONE_3))
+
+        stream = io.BytesIO()
+        writer = _DateTimeZoneWriter._ctor(stream, None)
+        zones._write(writer)
+        stream.seek(0)
+
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        zones_2 = WindowsZones._read(reader)
+
+        assert zones_2.version == "version"
+        assert zones_2.tzdb_version == "tzdb_version"
+        assert zones_2.windows_version == "windowsVersion"
+        assert zones_2.primary_mapping["windowsId2"] == "primaryId2"
+        assert zones_2.primary_mapping["windowsId3"] == "primaryId3"
+        assert zones_2.map_zones == (MAP_ZONE_1, MAP_ZONE_2, MAP_ZONE_3)

--- a/tests/time_zones/io/__init__.py
+++ b/tests/time_zones/io/__init__.py
@@ -1,7 +1,3 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-
-from ._invalid_pyoda_data_exception import InvalidPyodaDataError
-
-__all__: list[str] = ["InvalidPyodaDataError"]

--- a/tests/time_zones/io/dtz_io_helper.py
+++ b/tests/time_zones/io/dtz_io_helper.py
@@ -1,0 +1,107 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from pyoda_time import Instant, Offset
+from pyoda_time.time_zones.io._date_time_zone_reader import _DateTimeZoneReader
+from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
+from pyoda_time.time_zones.io._i_date_time_zone_reader import _IDateTimeZoneReader
+from pyoda_time.time_zones.io._i_date_time_zone_writer import _IDateTimeZoneWriter
+from pyoda_time.utility._csharp_compatibility import _private
+
+from .io_stream import _IoStream
+
+
+@_private
+class _DtzIoHelper:
+    """Wrapper around a DateTimeZoneWriter/DateTimeZoneReader pair that reads whatever is written to it."""
+
+    __io_stream: _IoStream
+    __string_pool: list[str] | None
+    __reader: _DateTimeZoneReader
+    __writer: _DateTimeZoneWriter
+
+    @classmethod
+    def __ctor(cls, string_pool: list[str] | None) -> _DtzIoHelper:
+        self = super().__new__(cls)
+        self.__io_stream = _IoStream()
+        self.__reader = _DateTimeZoneReader._ctor(self.__io_stream.get_read_stream(), string_pool)
+        self.__writer = _DateTimeZoneWriter._ctor(self.__io_stream.get_write_stream(), string_pool)
+        self.__string_pool = string_pool
+        return self
+
+    @classmethod
+    def _create_no_string_pool(cls) -> _DtzIoHelper:
+        return cls.__ctor(None)
+
+    @classmethod
+    def _create_with_string_pool(cls) -> _DtzIoHelper:
+        return cls.__ctor([])
+
+    @property
+    def _reader(self) -> _IDateTimeZoneReader:
+        return self.__reader
+
+    @property
+    def _writer(self) -> _IDateTimeZoneWriter:
+        return self.__writer
+
+    def reset(self) -> None:
+        self.__io_stream.reset()
+        if self.__string_pool is not None:
+            self.__string_pool.clear()
+
+    def test_count(self, value: int, unread_contents: bytes | None = None) -> None:
+        self.reset()
+        self._writer.write_count(value)
+        if unread_contents is None:
+            actual = self._reader.read_count()
+            assert actual == value
+        else:
+            self.__io_stream.assert_unread_contents(unread_contents)
+        self.__io_stream.assert_end_of_stream()
+
+    def test_signed_count(self, value: int, unread_contents: bytes | None = None) -> None:
+        self.reset()
+        self.__writer.write_signed_count(value)
+        if unread_contents is None:
+            actual = self._reader.read_signed_count()
+            assert actual == value
+        else:
+            self.__io_stream.assert_unread_contents(unread_contents)
+        self.__io_stream.assert_end_of_stream()
+
+    def test_dictionary(self, expected: dict[str, str]) -> None:
+        self.reset()
+        self._writer.write_dictionary(expected)
+        actual = self._reader.read_dictionary()
+        assert actual == expected
+        self.__io_stream.assert_end_of_stream()
+
+    def test_zone_interval_transition(self, previous: Instant | None, expected: Instant) -> None:
+        self.reset()
+        self._writer.write_zone_interval_transition(previous, expected)
+        actual = self._reader.read_zone_interval_transition(previous)
+        assert actual == expected
+        self.__io_stream.assert_end_of_stream()
+
+    def test_offset(self, offset: Offset) -> None:
+        self.reset()
+        self._writer.write_offset(offset)
+        actual = self._reader.read_offset()
+        assert actual == offset
+        self.__io_stream.assert_end_of_stream()
+
+    def test_string(self, expected: str) -> None:
+        self.reset()
+        self._writer.write_string(expected)
+        actual = self._reader.read_string()
+        assert actual == expected
+        self.__io_stream.assert_end_of_stream()
+
+    def test_zone_recurrence(self, expected: object) -> None:
+        raise NotImplementedError
+
+    def test_zone_year_offset(self, expected: object) -> None:
+        raise NotImplementedError

--- a/tests/time_zones/io/io_stream.py
+++ b/tests/time_zones/io/io_stream.py
@@ -1,0 +1,162 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from collections.abc import Buffer
+from io import BytesIO
+from typing import BinaryIO
+
+
+class _IoStream:
+    """Provides a simple, fixed-size, pipe-like stream that has a writer and a reader.
+
+    When the buffer fills up an exception is thrown and currently the buffer is fixed at 4096. The write pointer does
+    not wrap so only a total of 4096 bytes can ever be written to the stream. This is designed for testing purposes and
+    not real-world uses.
+    """
+
+    def __init__(self) -> None:
+        self._buffer: bytearray = bytearray(4096)
+        self._read_index = 0
+        self.__read_stream: BinaryIO | None = None
+        self._write_index = 0
+        self.__write_stream: BinaryIO | None = None
+
+    def __get_byte(self) -> int:
+        """Returns the next byte from the stream if there is one.
+
+        :return: The next byte.
+        """
+        if self._read_index >= self._write_index:
+            raise OSError("IoStream buffer empty in GetByte()")
+        self._read_index += 1
+        return self._buffer[self._read_index]
+
+    def assert_end_of_stream(self) -> None:
+        assert self._read_index == self._write_index
+
+    def assert_unread_contents(self, expected: bytes) -> None:
+        assert self._write_index - self._read_index == len(expected)
+        actual = self._buffer[self._read_index : self._write_index]
+        assert actual == expected
+        self._read_index = self._write_index
+
+    def get_read_stream(self) -> BinaryIO:
+        """Returns a ``BinaryIO`` that can be used to read from the buffer.
+
+        This can only be called once for each instance i.e. only one reader is permitted per buffer.
+
+        :return: The read-only ``BinaryIO``.
+        :raises RuntimeError: A reader was already requested.
+        """
+        if self.__read_stream is not None:
+            raise RuntimeError("Cannot call GetReadStream() twice on the same object.")
+        self.__read_stream = self._ReadStreamImpl(self)
+        return self.__read_stream
+
+    def get_write_stream(self) -> BinaryIO:
+        """Returns a ``BinaryIO`` that can be used to write to the buffer.
+
+        This can only be called once for each instance i.e. only one writer is permitted per buffer.
+
+        :return: The write-only ``BinaryIO``.
+        :raises RuntimeError: A writer was already requested.
+        """
+        if self.__write_stream is not None:
+            raise RuntimeError("Cannot call GetWriteStream() twice on the same object.")
+        self.__write_stream = self._WriteStreamImpl(self)
+        return self.__write_stream
+
+    def put_byte(self, value: int) -> None:
+        """Adds a byte to the buffer.
+
+        :param value: The byte to add.
+        """
+        if self._write_index >= len(self._buffer):
+            raise OSError(f"Exceeded the IoStream buffer size of {len(self._buffer)}")
+        self._write_index += 1
+        self._buffer[self._write_index] = value
+
+    def reset(self) -> None:
+        """Resets the stream to be empty."""
+        self._write_index = self._read_index = 0
+
+    class _ReadStreamImpl(BytesIO):
+        """Provides a read-only ``BinaryIO`` implementation for reading from the buffer."""
+
+        def __init__(self, stream: _IoStream) -> None:
+            super().__init__()
+            self.__io_stream = stream
+            self.__closed = False
+
+        def readable(self) -> bool:
+            return True
+
+        def read(self, size: int | None = -1) -> bytes:
+            """Read up to 'size' bytes from the stream.
+
+            Returns the data read as bytes. If size is negative or None, read until the end of the stream.
+            """
+            if size is None:
+                size = -1
+            if self.__closed:
+                raise ValueError("read from closed file")
+            if size < 0:
+                size = self.__io_stream._write_index - self.__io_stream._read_index
+            else:
+                size = min(size, self.__io_stream._write_index - self.__io_stream._read_index)
+
+            start_index = self.__io_stream._read_index
+            self.__io_stream._read_index += size
+            return bytes(self.__io_stream._buffer[start_index : self.__io_stream._read_index])
+
+        def close(self) -> None:
+            """Flush and close the IO object."""
+            self.__closed = True
+            super().close()
+
+    class _WriteStreamImpl(BytesIO):
+        """Provides a write-only stream implementation for writing to the buffer."""
+
+        def __init__(self, io_stream: _IoStream) -> None:
+            super().__init__()
+            self._io_stream = io_stream
+            self._closed = False
+
+        def writable(self) -> bool:
+            """Return True if the stream supports writing."""
+            return True
+
+        def write(self, __buffer: Buffer, /) -> int:
+            """Write the bytes-like object, b, to the underlying buffer.
+
+            Returns the number of bytes written, which may be less than the length of b.
+            """
+            if self._closed:
+                raise ValueError("write to closed file")
+            if not isinstance(__buffer, bytes):
+                raise TypeError("a bytes-like object is required, not " + type(__buffer).__name__)
+            available_space = len(self._io_stream._buffer) - self._io_stream._write_index
+
+            if available_space <= 0:
+                raise OSError("Buffer is full")
+
+            num_bytes_to_write = min(len(__buffer), available_space)
+
+            self._io_stream._buffer[
+                self._io_stream._write_index : self._io_stream._write_index + num_bytes_to_write
+            ] = __buffer[:num_bytes_to_write]
+            self._io_stream._write_index += num_bytes_to_write
+            return num_bytes_to_write
+
+        def close(self) -> None:
+            """Flush and close the IO object."""
+            self._closed = True
+            super().close()
+
+        def flush(self) -> None:
+            """Flush the stream buffer."""
+            # In this case, flush doesn't need to do anything because
+            # we are directly writing to the buffer and not holding anything in a temporary storage.
+            pass

--- a/tests/time_zones/io/test_date_time_zone_reader.py
+++ b/tests/time_zones/io/test_date_time_zone_reader.py
@@ -1,0 +1,101 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+import io
+
+import pytest
+
+from pyoda_time import PyodaConstants
+from pyoda_time.time_zones.io._date_time_zone_reader import _DateTimeZoneReader
+from pyoda_time.utility import InvalidPyodaDataError
+
+
+class TestDateTimeZoneReader:
+    def test_has_more_data_buffers(self) -> None:
+        stream = io.BytesIO(b"\x01\x02")
+        reader = _DateTimeZoneReader._ctor(stream, None)
+
+        # has_more_data reads a byte and buffers it
+        assert stream.tell() == 0
+        assert reader.has_more_data
+        assert stream.tell() == 1
+        assert reader.has_more_data
+        assert stream.tell() == 1
+
+        # Consume the buffered byte
+        assert reader.read_byte() == 1
+        assert stream.tell() == 1
+
+        # has_more_data reads the next byte
+        assert reader.has_more_data
+        assert stream.tell() == 2
+        assert reader.has_more_data
+        assert stream.tell() == 2
+
+        # Consume the buffered byte
+        assert reader.read_byte() == 2
+        assert stream.tell() == 2
+
+        # No more data
+        assert not reader.has_more_data
+
+    def test_read_count_out_of_range(self) -> None:
+        # Int32.MaxValue + 1 (as a uint) is 10000000_00000000_00000000_00000000
+        # So only bit 31 is set.
+        # Divided into 7 bit chunks (reverse order), with top bit set for continuation, this is:
+        # 10000000 - bits 0-6
+        # 10000000 - bits 7-13
+        # 10000000 - bits 14-20
+        # 10000000 - bits 21-27
+        # 00001000 - bits 28-34
+        data = bytes([0x80, 0x80, 0x80, 0x80, 0b00001000])
+        stream = io.BytesIO(data)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        with pytest.raises(InvalidPyodaDataError):
+            reader.read_count()
+
+    def test_read_milliseconds_invalid_flag(self) -> None:
+        # Top 3 bits are the flag. Valid flag values are 0b100 (minutes), 0b101 (seconds)  and 0b110 (milliseconds)
+        data = bytes([0xE0, 0, 0, 0, 0, 0])  # Invalid flag (followed by 0s to check that it's not just out of data)
+        stream = io.BytesIO(data)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        with pytest.raises(InvalidPyodaDataError):
+            reader.read_milliseconds()
+
+    def test_read_zone_interval_transition_invalid_marker_value(self) -> None:
+        data = bytes((4, 0, 0, 0, 0, 0))  # Marker value of 4 (followed by 0s to check that it's not just out of data)
+        stream = io.BytesIO(data)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        with pytest.raises(InvalidPyodaDataError):
+            reader.read_zone_interval_transition(previous=PyodaConstants.UNIX_EPOCH)
+
+    def test_read_zone_interval_transition_no_previous_value(self) -> None:
+        # Count value between 1 << 7 and 1 << 21 (followed by 0s to check that it's not just out of data)
+        data = bytes((0xFF, 0x7F, 0, 0, 0, 0))
+        stream = io.BytesIO(data)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        with pytest.raises(InvalidPyodaDataError):
+            reader.read_zone_interval_transition(previous=None)
+
+        # Validate that when we *do* provide a previous value, it doesn't throw
+        stream.seek(0)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        reader.read_zone_interval_transition(previous=PyodaConstants.UNIX_EPOCH)
+
+    def test_read_string_not_enough_data(self) -> None:
+        # We say there are 5 bytes, but there are only 4 left...
+        data = bytes([0x05, 0x40, 0x40, 0x40, 0x40])
+        stream = io.BytesIO(data)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        with pytest.raises(InvalidPyodaDataError):
+            reader.read_string()
+
+    def test_read_byte_not_enough_data(self) -> None:
+        data = bytes([0x05])
+        stream = io.BytesIO(data)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        # Just check we can read the first byte, then fail on the second
+        assert reader.read_byte() == 5
+        with pytest.raises(InvalidPyodaDataError):
+            reader.read_byte()

--- a/tests/time_zones/io/test_read_write.py
+++ b/tests/time_zones/io/test_read_write.py
@@ -1,0 +1,170 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from pyoda_time import Duration, Instant, Offset
+from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
+from pyoda_time.utility._csharp_compatibility import _CsharpConstants
+
+from .dtz_io_helper import _DtzIoHelper
+
+
+class TestReadWrite:
+    def test_count(self) -> None:
+        dio = _DtzIoHelper._create_no_string_pool()
+
+        for i in range(16):
+            dio.test_count(i)
+
+        dio.test_count(0x0F)
+        dio.test_count(0x10)
+        dio.test_count(0x7F)
+        dio.test_count(0x80)
+        dio.test_count(0x81)
+        dio.test_count(0x3FFF)
+        dio.test_count(0x4000)
+        dio.test_count(0x4001)
+        dio.test_count(0x1FFFFF)
+        dio.test_count(0x200000)
+        dio.test_count(0x200001)
+        dio.test_count(_CsharpConstants.INT_MAX_VALUE)
+        dio.test_count(0, bytes([0x00]))
+        dio.test_count(1, bytes([0x01]))
+        dio.test_count(127, bytes([0x7F]))
+        dio.test_count(128, bytes([0x80, 0x01]))
+        dio.test_count(300, bytes([0xAC, 0x02]))
+
+    def test_signed_count(self) -> None:
+        dio = _DtzIoHelper._create_no_string_pool()
+
+        for i in range(-16, 16):
+            dio.test_signed_count(i)
+
+        dio.test_signed_count(0x4000000)
+        dio.test_signed_count(-0x4000000)
+        dio.test_signed_count(_CsharpConstants.INT_MIN_VALUE)
+        dio.test_signed_count(_CsharpConstants.INT_MIN_VALUE + 1)
+        dio.test_signed_count(_CsharpConstants.INT_MAX_VALUE - 1)
+        dio.test_signed_count(_CsharpConstants.INT_MAX_VALUE)
+        dio.test_signed_count(0, bytes([0x00]))
+        dio.test_signed_count(-1, bytes([0x01]))
+        dio.test_signed_count(1, bytes([0x02]))
+        dio.test_signed_count(-2, bytes([0x03]))
+        dio.test_signed_count(64, bytes([0x80, 0x01]))
+        dio.test_signed_count(-65, bytes([0x81, 0x01]))
+        dio.test_signed_count(128, bytes([0x80, 0x02]))
+
+    def test_dictionary(self) -> None:
+        dio = _DtzIoHelper._create_no_string_pool()
+        expected: dict[str, str] = {}
+        dio.test_dictionary(expected)
+
+        expected["Able"] = "able"
+        dio.test_dictionary(expected)
+
+        expected["Baker"] = "baker"
+        expected["Charlie"] = "charlie"
+        expected["Delta"] = "delta"
+        dio.test_dictionary(expected)
+
+    def test_zone_interval_transition(self) -> None:
+        dio = _DtzIoHelper._create_no_string_pool()
+        dio.test_zone_interval_transition(None, Instant._before_min_value())
+        dio.test_zone_interval_transition(None, Instant.min_value)
+        # No test for Instant.MaxValue, as it's not on a tick boundary.
+        dio.test_zone_interval_transition(None, Instant._after_max_value())
+
+        dio.test_zone_interval_transition(None, Instant.min_value.plus_ticks(1))
+        # The ZoneIntervalTransition has precision to the tick (with no real need to change that).
+        # Round to the tick just lower than Instant.MaxValue...
+        tick_before_max_instant = Instant.from_unix_time_ticks(Instant.max_value.to_unix_time_ticks())
+        dio.test_zone_interval_transition(None, tick_before_max_instant)
+
+        # Encoding as hours-since-previous.
+        previous = Instant.from_utc(1990, 1, 1, 11, 30)  # arbitrary
+        dio.test_zone_interval_transition(previous, previous)
+        dio.test_zone_interval_transition(
+            previous,
+            previous
+            + Duration.from_hours(_DateTimeZoneWriter._ZoneIntervalConstants._MIN_VALUE_FOR_HOURS_SINCE_PREVIOUS),
+        )
+        dio.test_zone_interval_transition(
+            previous,
+            previous
+            + Duration.from_hours(_DateTimeZoneWriter._ZoneIntervalConstants._MIN_VALUE_FOR_HOURS_SINCE_PREVIOUS - 1),
+        )
+        dio.test_zone_interval_transition(previous, previous + Duration.from_hours(1))
+        dio.test_zone_interval_transition(
+            previous,
+            previous
+            + Duration.from_hours(_DateTimeZoneWriter._ZoneIntervalConstants._MIN_VALUE_FOR_MINUTES_SINCE_EPOCH - 1),
+        )
+        dio.test_zone_interval_transition(
+            previous,
+            previous
+            + Duration.from_hours(_DateTimeZoneWriter._ZoneIntervalConstants._MIN_VALUE_FOR_MINUTES_SINCE_EPOCH),
+        )
+        dio.test_zone_interval_transition(Instant.min_value.plus_ticks(1), tick_before_max_instant)
+
+        # Encoding as minutes-since-epoch
+        epoch = _DateTimeZoneWriter._ZoneIntervalConstants._EPOCH_FOR_MINUTES_SINCE_EPOCH
+        dio.test_zone_interval_transition(None, epoch)
+        dio.test_zone_interval_transition(
+            None,
+            epoch
+            + Duration.from_minutes(_DateTimeZoneWriter._ZoneIntervalConstants._MIN_VALUE_FOR_MINUTES_SINCE_EPOCH),
+        )
+        dio.test_zone_interval_transition(None, epoch + Duration.from_minutes(_CsharpConstants.INT_MAX_VALUE))
+
+        # Out of range cases, or not a multiple of minutes since the epoch.
+        dio.test_zone_interval_transition(None, epoch + Duration.from_hours(1))
+        dio.test_zone_interval_transition(None, epoch + Duration.from_minutes(1))
+        dio.test_zone_interval_transition(None, epoch + Duration.from_seconds(1))
+        dio.test_zone_interval_transition(None, epoch + Duration.from_milliseconds(1))
+        dio.test_zone_interval_transition(None, epoch - Duration.from_hours(1))
+        dio.test_zone_interval_transition(None, epoch + Duration.from_minutes(_CsharpConstants.INT_MAX_VALUE + 1))
+
+        # Example from Pacific/Auckland which failed at one time, and a similar one with seconds.
+        dio.test_zone_interval_transition(None, Instant.from_utc(1927, 11, 5, 14, 30))
+        dio.test_zone_interval_transition(None, Instant.from_utc(1927, 11, 5, 14, 30, 5))
+
+    def test_offset(self) -> None:
+        dio = _DtzIoHelper._create_no_string_pool()
+        dio.test_offset(Offset.min_value)
+        dio.test_offset(Offset.max_value)
+        dio.test_offset(Offset.from_hours(0))
+        dio.test_offset(Offset.from_hours(5))
+        dio.test_offset(Offset.from_hours(-5))
+        dio.test_offset(Offset.from_hours_and_minutes(5, 15))
+        dio.test_offset(Offset.from_hours_and_minutes(5, 30))
+        dio.test_offset(Offset.from_hours_and_minutes(5, 45))
+        dio.test_offset(Offset.from_hours_and_minutes(-5, -15))
+        dio.test_offset(Offset.from_hours_and_minutes(-5, -30))
+        dio.test_offset(Offset.from_hours_and_minutes(-5, -45))
+        dio.test_offset(Offset.from_seconds(1))
+        dio.test_offset(Offset.from_seconds(-1))
+        dio.test_offset(Offset.from_seconds(1000))
+        dio.test_offset(Offset.from_seconds(-1000))
+
+    def test_string_no_pool(self) -> None:
+        dio = _DtzIoHelper._create_no_string_pool()
+        dio.test_string("")
+        dio.test_string("This is a test string")
+
+    def test_string_with_pool(self) -> None:
+        dio = _DtzIoHelper._create_with_string_pool()
+        dio.test_string("")
+        dio.test_string("This is a test string")
+
+    def test_read_byte_after_has_more_data(self) -> None:
+        dio = _DtzIoHelper._create_no_string_pool()
+        dio._writer.write_byte(5)
+
+        assert dio._reader.has_more_data
+        assert dio._reader.read_byte() == 5
+
+    def test_read_string_after_has_more_data(self) -> None:
+        dio = _DtzIoHelper._create_no_string_pool()
+        dio._writer.write_string("foo")
+
+        assert dio._reader.has_more_data
+        assert dio._reader.read_string() == "foo"

--- a/tests/time_zones/io/test_tzdb_stream_data.py
+++ b/tests/time_zones/io/test_tzdb_stream_data.py
@@ -1,0 +1,114 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import io
+from typing import Callable
+
+import pytest
+
+from pyoda_time.time_zones.cldr import WindowsZones
+from pyoda_time.time_zones.io._tzdb_stream_data import _TzdbStreamData
+from pyoda_time.time_zones.io._tzdb_stream_field import _TzdbStreamField
+from pyoda_time.time_zones.io._tzdb_stream_field_id import _TzdbStreamFieldId
+from pyoda_time.utility import InvalidPyodaDataError
+
+
+class TestTzdbStreamData:
+    def test_minimal(self) -> None:
+        data = _TzdbStreamData(self.__create_minimal_builder())
+        assert data.tzdb_version
+
+    def test_missing_string_pool(self) -> None:
+        builder = self.__create_minimal_builder()
+        builder._string_pool = None
+        with pytest.raises(InvalidPyodaDataError):
+            _TzdbStreamData(builder)
+
+    def test_missing_tzdb_alias_map(self) -> None:
+        builder = self.__create_minimal_builder()
+        builder._tzdb_id_map = None
+        with pytest.raises(InvalidPyodaDataError):
+            _TzdbStreamData(builder)
+
+    def test_missing_tzdb_version(self) -> None:
+        builder = self.__create_minimal_builder()
+        builder._tzdb_version = None
+        with pytest.raises(InvalidPyodaDataError):
+            _TzdbStreamData(builder)
+
+    def test_missing_windows_mapping(self) -> None:
+        builder = self.__create_minimal_builder()
+        builder._windows_mapping = None
+        with pytest.raises(InvalidPyodaDataError):
+            _TzdbStreamData(builder)
+
+    def test_invalid_version(self) -> None:
+        # It's hard to create a stream that's valid apart from the version, so we'll just
+        # give one with an invalid version and check that it looks like the right message.
+        stream = io.BytesIO(bytes([0, 0, 0, 1]))
+        with pytest.raises(InvalidPyodaDataError) as e:
+            _TzdbStreamData._from_stream(stream)
+        assert "version" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "field_id,handler_method_name",
+        [
+            (_TzdbStreamFieldId.TIME_ZONE, "_handle_zone_field"),
+            (_TzdbStreamFieldId.ZONE_1970_LOCATIONS, "_handle_zone_1970_locations_field"),
+            (_TzdbStreamFieldId.ZONE_LOCATIONS, "_handle_zone_locations_field"),
+        ],
+    )
+    def test_missing_string_pool_2(self, field_id: _TzdbStreamFieldId, handler_method_name: str) -> None:
+        field = _TzdbStreamField._ctor(field_id, bytes([0]))
+        builder = _TzdbStreamData._Builder()
+        method: Callable[[_TzdbStreamField], None] = getattr(builder, handler_method_name)
+
+        with pytest.raises(InvalidPyodaDataError):
+            method(field)
+
+    @pytest.mark.parametrize(
+        "field_id,handler_method_name",
+        [
+            (_TzdbStreamFieldId.STRING_POOL, "_handle_string_pool_field"),
+            (_TzdbStreamFieldId.TZDB_ID_MAP, "_handle_tzdb_id_map_field"),
+            (_TzdbStreamFieldId.TZDB_VERSION, "_handle_tzdb_version_field"),
+            (_TzdbStreamFieldId.ZONE_1970_LOCATIONS, "_handle_zone_1970_locations_field"),
+            (_TzdbStreamFieldId.ZONE_LOCATIONS, "_handle_zone_locations_field"),
+        ],
+    )
+    def test_duplicate_field(self, field_id: _TzdbStreamFieldId, handler_method_name: str) -> None:
+        field = _TzdbStreamField._ctor(field_id, bytes([0]))
+        builder = _TzdbStreamData._Builder()
+        # Provide an empty string pool if we're not checking for a duplicate string pool
+        if field_id != _TzdbStreamFieldId.STRING_POOL:
+            builder._string_pool = []
+        method: Callable[[_TzdbStreamField], None] = getattr(builder, handler_method_name)
+
+        # First call should be okay
+        method(field)
+
+        # Second call should throw
+        with pytest.raises(InvalidPyodaDataError):
+            method(field)
+
+    def test_duplicate_time_zone_field(self) -> None:
+        # This isn't really a valid field, but we don't parse the data yet anyway - it's
+        # enough to give the ID.
+        zone_field = _TzdbStreamField._ctor(_TzdbStreamFieldId.STRING_POOL, bytearray(1))
+
+        builder = _TzdbStreamData._Builder()
+        builder._string_pool = ["zone1"]
+        builder._handle_zone_field(zone_field)
+        with pytest.raises(InvalidPyodaDataError):
+            builder._handle_zone_field(zone_field)
+
+    @staticmethod
+    def __create_minimal_builder() -> _TzdbStreamData._Builder:
+        return _TzdbStreamData._Builder(
+            string_pool=[],
+            tzdb_id_map=dict(),
+            tzdb_version="tzdb-version",
+            windows_mapping=WindowsZones._ctor(
+                version="cldr-version", tzdb_version="tzdb-version", windows_version="windows-version", map_zones=[]
+            ),
+        )

--- a/tests/time_zones/io/test_tzdb_stream_field.py
+++ b/tests/time_zones/io/test_tzdb_stream_field.py
@@ -1,0 +1,26 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import io
+
+import pytest
+
+from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
+from pyoda_time.time_zones.io._tzdb_stream_field import _TzdbStreamField
+from pyoda_time.utility import InvalidPyodaDataError
+
+
+class TestTzdbStreamField:
+    # Only tests for situations which aren't covered elsewhere
+
+    def test_insufficient_data(self) -> None:
+        stream = io.BytesIO()
+        writer = _DateTimeZoneWriter._ctor(stream, None)
+        writer.write_byte(1)
+        writer.write_count(10)
+
+        stream.seek(0)
+        iterator = _TzdbStreamField._read_fields(stream)
+
+        with pytest.raises(InvalidPyodaDataError):
+            next(iterator)

--- a/tests/time_zones/test_tzdb_zone_1970_location_test.py
+++ b/tests/time_zones/test_tzdb_zone_1970_location_test.py
@@ -1,0 +1,110 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import io
+
+import pytest
+
+from pyoda_time.time_zones import TzdbZone1970Location
+from pyoda_time.time_zones.io._date_time_zone_reader import _DateTimeZoneReader
+from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
+from pyoda_time.utility import InvalidPyodaDataError
+
+from .. import helpers
+
+SAMPLE_COUNTRY = TzdbZone1970Location.Country("Country name", "CO")
+
+
+class TestTzdbZone1970Location:
+    def test_valid(self) -> None:
+        location = TzdbZone1970Location(
+            60 * 3600 + 15 * 60 + 5, 100 * 3600 + 30 * 60 + 10, [SAMPLE_COUNTRY], "Etc/MadeUpZone", "Comment"
+        )
+        assert location.latitude == pytest.approx(60.25 + 5.0 / 3600, abs=0.000001)
+        assert location.longitude == pytest.approx(100.5 + 10.0 / 3600, abs=0.000001)
+        assert location.countries[0].name == "Country name"
+        assert location.countries[0].code == "CO"
+        assert location.zone_id == "Etc/MadeUpZone"
+        assert location.comment == "Comment"
+
+    def test_country_to_string(self) -> None:
+        assert str(SAMPLE_COUNTRY) == "CO (Country name)"
+
+    def test_serialization(self) -> None:
+        location = TzdbZone1970Location(
+            60 * 3600 + 15 * 60 + 5, 100 * 3600 + 30 * 60 + 10, (SAMPLE_COUNTRY,), "Etc/MadeUpZone", "Comment"
+        )
+        stream = io.BytesIO()
+        writer = _DateTimeZoneWriter._ctor(stream, None)
+        location._write(writer)
+        stream.seek(0)
+        reloaded = TzdbZone1970Location._read(_DateTimeZoneReader._ctor(stream, None))
+        assert reloaded.latitude == location.latitude
+        assert reloaded.longitude == location.longitude
+        assert reloaded.countries == location.countries
+        assert reloaded.zone_id == location.zone_id
+        assert reloaded.comment == location.comment
+
+    def test_read_invalid(self) -> None:
+        stream = io.BytesIO()
+        writer = _DateTimeZoneWriter._ctor(stream, None)
+        # Valid latitude/longitude
+        writer.write_signed_count(0)
+        writer.write_signed_count(0)
+        # But no countries
+        writer.write_count(0)
+        writer.write_string("Europe/Somewhere")
+        writer.write_string("")
+        stream.seek(0)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        with pytest.raises(InvalidPyodaDataError):
+            TzdbZone1970Location._read(reader)
+
+    def test_latitude_range(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            TzdbZone1970Location(90 * 3600 + 1, 0, [SAMPLE_COUNTRY], "Zone", "")
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            TzdbZone1970Location(-90 * 3600 - 1, 0, [SAMPLE_COUNTRY], "Zone", "")
+        # We'll assume these are built correctly: we're just checking the constructor doesn't throw.
+        TzdbZone1970Location(90 * 3600, 0, [SAMPLE_COUNTRY], "Zone", "")
+        TzdbZone1970Location(-90 * 3600, 0, [SAMPLE_COUNTRY], "Zone", "")
+
+    def test_longitude_range(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            TzdbZone1970Location(0, 180 * 3600 + 1, [SAMPLE_COUNTRY], "Zone", "")
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            TzdbZone1970Location(0, -180 * 3600 - 1, [SAMPLE_COUNTRY], "Zone", "")
+        # We'll assume these are built correctly: we're just checking the constructor doesn't throw.
+        TzdbZone1970Location(0, 180 * 3600, [SAMPLE_COUNTRY], "Zone", "")
+        TzdbZone1970Location(0, -180 * 3600, [SAMPLE_COUNTRY], "Zone", "")
+
+    def test_constructor_invalid_arguments(self) -> None:
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZone1970Location(0, 0, None, "Zone", "")  # type: ignore
+        with pytest.raises(ValueError):  # TODO: ArgumentException
+            TzdbZone1970Location(0, 0, [SAMPLE_COUNTRY, None], "Zone", "")  # type: ignore
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZone1970Location(0, 0, [SAMPLE_COUNTRY], "Zone", None)  # type: ignore
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZone1970Location(0, 0, [SAMPLE_COUNTRY], None, "")  # type: ignore
+        with pytest.raises(ValueError):  # TODO: ArgumentException
+            TzdbZone1970Location(0, 0, [], None, "")  # type: ignore
+
+    def test_country_constructor_invalid_arguments(self) -> None:
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZone1970Location.Country(code=None, name="Name")  # type: ignore
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZone1970Location.Country(code="CO", name=None)  # type: ignore
+        with pytest.raises(ValueError):  # TODO: ArgumentException
+            TzdbZone1970Location.Country(code="CO", name="")
+        with pytest.raises(ValueError):  # TODO: ArgumentException
+            TzdbZone1970Location.Country(code="Long code", name="Name")
+        with pytest.raises(ValueError):  # TODO: ArgumentException
+            TzdbZone1970Location.Country(code="S", name="Name")
+
+    def test_country_equality(self) -> None:
+        helpers.test_equals_class(
+            TzdbZone1970Location.Country("France", "FR"),
+            TzdbZone1970Location.Country("France", "FR"),
+            TzdbZone1970Location.Country("Germany", "DE"),
+        )

--- a/tests/time_zones/test_tzdb_zone_location.py
+++ b/tests/time_zones/test_tzdb_zone_location.py
@@ -1,0 +1,103 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+import io
+
+import pytest
+
+from pyoda_time.time_zones import TzdbZoneLocation
+from pyoda_time.time_zones.io._date_time_zone_reader import _DateTimeZoneReader
+from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
+from pyoda_time.utility import InvalidPyodaDataError
+
+
+class TestTzdbZoneLocation:
+    def test_valid(self) -> None:
+        location = TzdbZoneLocation(
+            latitude_seconds=60 * 3600 + 15 * 60 + 5,
+            longitude_seconds=100 * 3600 + 30 * 60 + 10,
+            country_name="Country name",
+            country_code="CO",
+            zone_id="Etc/MadeUpZone",
+            comment="Comment",
+        )
+        assert location.latitude == pytest.approx(60.25 + 5.0 / 3600, abs=0.000001)
+        assert location.longitude == pytest.approx(100.5 + 10.0 / 3600, abs=0.000001)
+        assert location.country_name == "Country name"
+        assert location.country_code == "CO"
+        assert location.zone_id == "Etc/MadeUpZone"
+        assert location.comment == "Comment"
+
+    def test_latitude_range(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            TzdbZoneLocation(90 * 3600 + 1, 0, "Name", "CO", "Zone", "")
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            TzdbZoneLocation(-90 * 3600 - 1, 0, "Name", "CO", "Zone", "")
+        # We'll assume these are built correctly: we're just checking the constructor doesn't throw.
+        TzdbZoneLocation(90 * 3600, 0, "Name", "CO", "Zone", "")
+        TzdbZoneLocation(-90 * 3600, 0, "Name", "CO", "Zone", "")
+
+    def test_longitude_range(self) -> None:
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            TzdbZoneLocation(0, 180 * 3600 + 1, "Name", "CO", "Zone", "")
+        with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
+            TzdbZoneLocation(0, -180 * 3600 - 1, "Name", "CO", "Zone", "")
+        # We'll assume these are built correctly: we're just checking the constructor doesn't throw.
+        TzdbZoneLocation(0, 180 * 3600, "Name", "CO", "Zone", "")
+        TzdbZoneLocation(0, -180 * 3600, "Name", "CO", "Zone", "")
+
+    def test_constructor_invalid_arguments(self) -> None:
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZoneLocation(0, 0, None, "CO", "Zone", "")  # type: ignore
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZoneLocation(0, 0, "Name", None, "Zone", "")  # type: ignore
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZoneLocation(0, 0, "Name", "CO", None, "")  # type: ignore
+        with pytest.raises(TypeError):  # TODO: ArgumentNullException
+            TzdbZoneLocation(0, 0, "Name", "CO", "Zone", None)  # type: ignore
+        with pytest.raises(ValueError):  # TODO: ArgumentException
+            TzdbZoneLocation(0, 0, "", "CO", "Zone", "")
+        with pytest.raises(ValueError):  # TODO: ArgumentException
+            TzdbZoneLocation(0, 0, "Name", "Long code", "Zone", "")
+        with pytest.raises(ValueError):  # TODO: ArgumentException
+            TzdbZoneLocation(0, 0, "Name", "S", "Zone", "")
+
+    def test_serialization(self) -> None:
+        location = TzdbZoneLocation(
+            60 * 3600 + 15 * 60 + 5,
+            100 * 3600 + 30 * 60 + 10,
+            "Country name",
+            "CO",
+            "Etc/MadeUpZone",
+            "Comment",
+        )
+
+        stream = io.BytesIO()
+        writer = _DateTimeZoneWriter._ctor(stream, None)
+        location._write(writer)
+        stream.seek(0)
+
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        location_2 = TzdbZoneLocation._read(reader)
+
+        assert location_2.latitude == pytest.approx(60.25 + 5.0 / 3600, abs=0.000001)
+        assert location_2.longitude == pytest.approx(100.5 + 10.0 / 3600, abs=0.000001)
+        assert location_2.country_name == "Country name"
+        assert location_2.country_code == "CO"
+        assert location_2.zone_id == "Etc/MadeUpZone"
+        assert location_2.comment == "Comment"
+
+    def test_read_invalid(self) -> None:
+        stream = io.BytesIO()
+        writer = _DateTimeZoneWriter._ctor(stream, None)
+        # This is invalid
+        writer.write_signed_count(90 * 3600 + 1)
+        writer.write_signed_count(0)
+        writer.write_string("name")
+        writer.write_string("co")
+        writer.write_string("Europe/Somewhere")
+        writer.write_string("")
+        stream.seek(0)
+        reader = _DateTimeZoneReader._ctor(stream, None)
+        with pytest.raises(InvalidPyodaDataError):
+            TzdbZoneLocation._read(reader)

--- a/tests/time_zones/test_zone_interval.py
+++ b/tests/time_zones/test_zone_interval.py
@@ -134,7 +134,7 @@ class TestZoneInterval:
             str(interval.iso_local_end)
 
     def test_equality(self) -> None:
-        helpers.test_equals(
+        helpers.test_equals_class(
             # Equal values
             ZoneInterval(
                 name="name",


### PR DESCRIPTION
Port of the various classes used to interact with and serialise TZDB data.

This lays a good chunk of the groundwork for timezone-related functionality.