### PR TITLE
ci: use new release-please-action repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: release
         id: release
-        uses: google-github-actions/release-please-action@v4.1.0
+        uses: googleapis/release-please-action@v4.1.1
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           release-type: python


### PR DESCRIPTION
https://github.com/google-github-actions/release-please-action/pull/1

`google-github-actions/release-please-action` has moved to `googleapis/release-please-action`