### PR TITLE
feat: implement `LocalTime` conversions

### DIFF
--- a/pyoda_time/_local_time.py
+++ b/pyoda_time/_local_time.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import datetime
 import functools
 from typing import TYPE_CHECKING, Generator, final, overload
 
@@ -478,6 +479,16 @@ class LocalTime(metaclass=_LocalTimeMeta):
 
         return _TimePeriodField._milliseconds._add_local_time(self, milliseconds)
 
+    def plus_microseconds(self, microseconds: int) -> LocalTime:
+        """Returns a new LocalTime representing the current value with the given number of microseconds added.
+
+        :param microseconds: The number of microseconds to add
+        :return: The current value plus the given number of microseconds.
+        """
+        from pyoda_time.fields._time_period_field import _TimePeriodField
+
+        return _TimePeriodField._microseconds._add_local_time(self, microseconds)
+
     def plus_ticks(self, ticks: int) -> LocalTime:
         """Returns a new LocalTime representing the current value with the given number of ticks added.
 
@@ -548,3 +559,32 @@ class LocalTime(metaclass=_LocalTimeMeta):
         :return: The earlier time of ``x`` or ``y``.
         """
         return x if x < y else y
+
+    def to_time(self) -> datetime.time:
+        """Converts this value to an equivalent ``datetime.time``.
+
+        If the value does not fall on a microsecond boundary, it will be truncated to the earlier microsecond boundary.
+
+        :return: The equivalent ``datetime.time``.
+        """
+
+        return datetime.time(
+            hour=self.hour,
+            minute=self.minute,
+            second=self.second,
+            microsecond=_towards_zero_division(self.nanosecond_of_second, PyodaConstants.NANOSECONDS_PER_MICROSECOND),
+        )
+
+    @classmethod
+    def from_time(cls, time: datetime.time) -> LocalTime:
+        """Constructs a ``LocalTime`` from a ``datetime.time``.
+
+        :param time: The time of day to convert.
+        :return: The ``LocalTime`` equivalent.
+        """
+        return cls.from_ticks_since_midnight(
+            time.hour * PyodaConstants.TICKS_PER_HOUR
+            + time.minute * PyodaConstants.TICKS_PER_MINUTE
+            + time.second * PyodaConstants.TICKS_PER_SECOND
+            + time.microsecond * PyodaConstants.TICKS_PER_MICROSECOND
+        )

--- a/pyoda_time/fields/_time_period_field.py
+++ b/pyoda_time/fields/_time_period_field.py
@@ -26,6 +26,12 @@ class _TimePeriodFieldMeta(type):
         return _TimePeriodField(PyodaConstants.NANOSECONDS_PER_TICK)
 
     @property
+    def _microseconds(self) -> _TimePeriodField:
+        # TODO: Investigate where other _TimePeriodFields are used...
+        #  This one is not ported from Noda Time.
+        return _TimePeriodField(PyodaConstants.NANOSECONDS_PER_MICROSECOND)
+
+    @property
     def _milliseconds(self) -> _TimePeriodField:
         return _TimePeriodField(PyodaConstants.NANOSECONDS_PER_MILLISECOND)
 

--- a/tests/test_local_time.py
+++ b/tests/test_local_time.py
@@ -1,6 +1,8 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
+from datetime import datetime, timedelta
+
 import pytest
 
 from pyoda_time import LocalTime, Offset, OffsetTime, Period, PyodaConstants
@@ -248,3 +250,23 @@ class TestLocalTimeConstruction:
             LocalTime.from_hours_since_midnight(-1)
         with pytest.raises(ValueError):  # TODO: ArgumentOutOfRangeException
             LocalTime.from_hours_since_midnight(PyodaConstants.HOURS_PER_DAY)
+
+
+class TestLocalTimeConversion:
+    def test_to_time_on_microsecond_boundary(self) -> None:
+        local_time = LocalTime(12, 34, 56).plus_microseconds(4567)
+        expected = (datetime(1, 1, 1, 12, 34, 56) + timedelta(microseconds=4567)).time()
+        actual = local_time.to_time()
+        assert actual == expected
+
+    def test_to_time_rounds_down(self) -> None:
+        local_time = LocalTime(12, 34, 56).plus_microseconds(4567).plus_nanoseconds(89)
+        expected = (datetime(1, 1, 1, 12, 34, 56) + timedelta(microseconds=4567)).time()
+        actual = local_time.to_time()
+        assert actual == expected
+
+    def test_from_time(self) -> None:
+        time_ = (datetime(1, 1, 1, 12, 34, 56) + timedelta(microseconds=4567)).time()
+        expected = LocalTime(12, 34, 56).plus_microseconds(4567)
+        actual = LocalTime.from_time(time_)
+        assert actual == expected


### PR DESCRIPTION
In Noda Time, users can call `.ToTimeOnly()` and `.FromTimeOnly()` to convert between `LocalTime` and `TimeOnly` (provided they are targeting a sufficiently recent version of dotnet).

This is an attempt to implement something roughly equivalent in Python, which permits conversion to/from `datetime.time`.

Incidentally, I added a new Pyoda-Time-specific `.plus_microseconds()` method, with an appropriate `_TimePeriodField._microseconds` to support it.