### PR TITLE
ci: check sphinx docs are generated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,34 @@ jobs:
 
       - name: Run pre-commit hooks
         run: poetry run pre-commit run -a
+
+  sphinx:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.8.3
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Generate html docs
+        run: make docs.sphinx.html
+
+      - name: Check for unstaged files
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            echo "Unstaged files detected. Please run `make docs.sphinx.html` and commit the generated files."
+            git status --porcelain
+            exit 1
+          fi

--- a/docs/source/pyoda_time.time_zones.cldr.rst
+++ b/docs/source/pyoda_time.time_zones.cldr.rst
@@ -1,0 +1,9 @@
+pyoda\_time.time\_zones.cldr package
+====================================
+
+Module contents
+---------------
+
+.. automodule:: pyoda_time.time_zones.cldr
+   :members:
+   :undoc-members:

--- a/docs/source/pyoda_time.time_zones.io.rst
+++ b/docs/source/pyoda_time.time_zones.io.rst
@@ -1,0 +1,9 @@
+pyoda\_time.time\_zones.io package
+==================================
+
+Module contents
+---------------
+
+.. automodule:: pyoda_time.time_zones.io
+   :members:
+   :undoc-members:

--- a/docs/source/pyoda_time.time_zones.rst
+++ b/docs/source/pyoda_time.time_zones.rst
@@ -1,6 +1,15 @@
 pyoda\_time.time\_zones package
 ===============================
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 1
+
+   pyoda_time.time_zones.cldr
+   pyoda_time.time_zones.io
+
 Module contents
 ---------------
 


### PR DESCRIPTION
Adding an action that verifies we have run `make docs.sphinx.html` and committed the files generated by sphinx-apidoc.

If we haven't, the unstaged files in `/docs/source` will be detected and fail the job.

This is now a required status for PRs.

Noticed this while working on something unrelated...

Check the commits on this PR for more context.