### PR TITLE
feat: port `DurationPattern`

### DIFF
--- a/pyoda_time/globalization/_pyoda_format_info.py
+++ b/pyoda_time/globalization/_pyoda_format_info.py
@@ -180,6 +180,17 @@ class _PyodaFormatInfo(metaclass=_PyodaFormatInfoMeta):
     #  internal FixedFormatInfoPatternParser<Duration> DurationPatternParser
 
     @property
+    def _duration_pattern_parser(self) -> _FixedFormatInfoPatternParser[Duration]:
+        if self.__duration_pattern_parser is None:
+            with self.__FIELD_LOCK:
+                if self.__duration_pattern_parser is None:
+                    from ..text._duration_pattern_parser import _DurationPatternParser
+                    from ..text._fixed_format_info_pattern_parser import _FixedFormatInfoPatternParser
+
+                    self.__duration_pattern_parser = _FixedFormatInfoPatternParser(_DurationPatternParser(), self)
+        return self.__duration_pattern_parser
+
+    @property
     def _offset_pattern_parser(self) -> _FixedFormatInfoPatternParser[Offset]:
         if self.__offset_pattern_parser is None:
             with self.__FIELD_LOCK:

--- a/pyoda_time/text/__init__.py
+++ b/pyoda_time/text/__init__.py
@@ -5,6 +5,7 @@
 __all__: list[str] = [
     "patterns",
     "AnnualDatePattern",
+    "DurationPattern",
     "InstantPattern",
     "InvalidPatternError",
     "LocalDatePattern",
@@ -16,6 +17,7 @@ __all__: list[str] = [
 ]
 
 from ._annual_date_pattern import AnnualDatePattern
+from ._duration_pattern import DurationPattern
 from ._instant_pattern import InstantPattern
 from ._invalid_pattern_exception import InvalidPatternError
 from ._local_date_pattern import LocalDatePattern

--- a/pyoda_time/text/_duration_pattern.py
+++ b/pyoda_time/text/_duration_pattern.py
@@ -1,0 +1,183 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from typing import _ProtocolMeta, final
+
+from pyoda_time._compatibility._culture_info import CultureInfo
+from pyoda_time._compatibility._string_builder import StringBuilder
+from pyoda_time._duration import Duration
+from pyoda_time.globalization._pyoda_format_info import _PyodaFormatInfo
+from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.text._parse_result import ParseResult
+from pyoda_time.text.patterns._pattern_bcl_support import _PatternBclSupport
+from pyoda_time.utility._csharp_compatibility import _private, _sealed
+from pyoda_time.utility._preconditions import _Preconditions
+
+
+class __DurationPatternMeta(_ProtocolMeta):
+    __pattern_bcl_support: _PatternBclSupport[Duration] | None = None
+
+    @property
+    def roundtrip(self) -> DurationPattern:
+        """Gets the general pattern for durations using the invariant culture, with a format string of
+        "-D:hh:mm:ss.FFFFFFFFF".
+
+        This pattern round-trips. This corresponds to the "o" standard pattern.
+
+        :return: The general pattern for durations using the invariant culture.
+        """
+        return DurationPattern._Patterns._roundtrip_pattern_impl
+
+    @property
+    def json_roundtrip(self) -> DurationPattern:
+        """Gets a pattern for durations using the invariant culture, with a format string of "-H:mm:ss.FFFFFFFFF".
+
+        This pattern round-trips. This corresponds to the "j" standard pattern.
+
+        :return: The pattern for durations using the invariant culture.
+        """
+        return DurationPattern._Patterns._json_roundtrip_pattern_impl
+
+    @property
+    def _bcl_support(self) -> _PatternBclSupport[Duration]:
+        if self.__pattern_bcl_support is None:
+            self.__pattern_bcl_support = _PatternBclSupport("o", lambda fi: fi._duration_pattern_parser)
+        return self.__pattern_bcl_support
+
+
+@final
+@_sealed
+@_private
+class DurationPattern(IPattern[Duration], metaclass=__DurationPatternMeta):
+    """Represents a pattern for parsing and formatting ``Duration`` values."""
+
+    class __PatternsMeta(type):
+        __roundtrip_pattern_impl: DurationPattern | None = None
+        __json_roundtrip_pattern_impl: DurationPattern | None = None
+
+        @property
+        def _roundtrip_pattern_impl(self) -> DurationPattern:
+            if self.__roundtrip_pattern_impl is None:
+                self.__roundtrip_pattern_impl = DurationPattern.create_with_invariant_culture("-D:hh:mm:ss.FFFFFFFFF")
+            return self.__roundtrip_pattern_impl
+
+        @property
+        def _json_roundtrip_pattern_impl(self) -> DurationPattern:
+            if self.__json_roundtrip_pattern_impl is None:
+                self.__json_roundtrip_pattern_impl = DurationPattern.create_with_invariant_culture("-H:mm:ss.FFFFFFFFF")
+            return self.__json_roundtrip_pattern_impl
+
+    class _Patterns(metaclass=__PatternsMeta):
+        pass
+
+    __pattern: IPattern[Duration]
+    __pattern_text: str
+
+    @property
+    def pattern_text(self) -> str:
+        """Gets the pattern text for this pattern, as supplied on creation.
+
+        :return: The pattern text for this pattern, as supplied on creation.
+        """
+        return self.__pattern_text
+
+    @classmethod
+    def __ctor(cls, pattern_text: str, pattern: IPattern[Duration]) -> DurationPattern:
+        self = super().__new__(cls)
+        self.__pattern_text = pattern_text
+        self.__pattern = pattern
+        return self
+
+    def parse(self, text: str) -> ParseResult[Duration]:
+        """Parses the given text value according to the rules of this pattern.
+
+        This method never throws an exception (barring a bug in Pyoda Time itself). Even errors such as the argument
+        being null are wrapped in a parse result.
+
+        :param text: The text value to parse.
+        :return: The result of parsing, which may be successful or unsuccessful.
+        """
+        return self.__pattern.parse(text)
+
+    def format(self, value: Duration) -> str:
+        """Formats the given duration as text according to the rules of this pattern.
+
+        :param value: The duration to format.
+        :return: The duration formatted according to this pattern.
+        """
+        return self.__pattern.format(value)
+
+    def append_format(self, value: Duration, builder: StringBuilder) -> StringBuilder:
+        """Formats the given value as text according to the rules of this pattern, appending to the given
+        ``StringBuilder``.
+
+        :param value: The value to format.
+        :param builder: The ``StringBuilder`` to append to.
+        :return: The builder passed in as ``builder``.
+        """
+        return self.__pattern.append_format(value, builder)
+
+    @classmethod
+    def __create(cls, pattern_text: str, format_info: _PyodaFormatInfo) -> DurationPattern:
+        """Creates a pattern for the given pattern text and format info.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :param format_info: Localization information
+        :return: A pattern for parsing and formatting offsets.
+        :raises InvalidPatternError: The pattern text was invalid.
+        """
+        _Preconditions._check_not_null(pattern_text, "pattern_text")
+        _Preconditions._check_not_null(format_info, "format_info")
+        pattern = format_info._duration_pattern_parser._parse_pattern(pattern_text)
+        return DurationPattern.__ctor(pattern_text, pattern)
+
+    @classmethod
+    def create(cls, pattern_text: str, culture_info: CultureInfo) -> DurationPattern:
+        """Creates a pattern for the given pattern text and culture.
+
+        See the user guide for the available pattern text options.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :param culture_info: The culture to use in the pattern
+        :return: A pattern for parsing and formatting offsets.
+        :raises InvalidPatternError: The pattern text was invalid.
+        """
+        return cls.__create(pattern_text, _PyodaFormatInfo._get_format_info(culture_info))
+
+    @classmethod
+    def create_with_current_culture(cls, pattern_text: str) -> DurationPattern:
+        """Creates a pattern for the given pattern text in the current thread's current culture.
+
+        See the user guide for the available pattern text options. Note that the current culture
+        is captured at the time this method is called - it is not captured at the point of parsing
+        or formatting values.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :return: A pattern for parsing and formatting offsets.
+        :raises InvalidPatternError: The pattern text was invalid.
+        """
+        return cls.__create(pattern_text, _PyodaFormatInfo.current_info)
+
+    @classmethod
+    def create_with_invariant_culture(cls, pattern_text: str) -> DurationPattern:
+        """Creates a pattern for the given pattern text in the invariant culture.
+
+        See the user guide for the available pattern text options. Note that the current culture
+        is captured at the time this method is called - it is not captured at the point of parsing
+        or formatting values.
+
+        :param pattern_text: Pattern text to create the pattern for
+        :return: A pattern for parsing and formatting offsets.
+        :raises InvalidPatternError: The pattern text was invalid.
+        """
+        return cls.__create(pattern_text, _PyodaFormatInfo.invariant_info)
+
+    def with_culture(self, culture_info: CultureInfo) -> DurationPattern:
+        """Creates a pattern for the same original pattern text as this pattern, but with the specified culture.
+
+        :param culture_info: The culture to use in the new pattern.
+        :return: A new pattern with the given culture.
+        """
+        return self.__create(self.pattern_text, _PyodaFormatInfo._get_format_info(culture_info))

--- a/pyoda_time/text/_duration_pattern_parser.py
+++ b/pyoda_time/text/_duration_pattern_parser.py
@@ -1,0 +1,280 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from typing import Callable, Final, Mapping, cast, final
+
+from pyoda_time import Duration, PyodaConstants
+from pyoda_time.globalization._pyoda_format_info import _PyodaFormatInfo
+from pyoda_time.text import InvalidPatternError, ParseResult
+from pyoda_time.text._format_helper import _FormatHelper
+from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.text._parse_bucket import _ParseBucket
+from pyoda_time.text._text_error_messages import _TextErrorMessages
+from pyoda_time.text.patterns._i_pattern_parser import _IPatternParser
+from pyoda_time.text.patterns._pattern_cursor import _PatternCursor
+from pyoda_time.text.patterns._pattern_fields import _PatternFields
+from pyoda_time.text.patterns._stepped_pattern_builder import _SteppedPatternBuilder
+from pyoda_time.text.patterns._time_pattern_helper import _TimePatternHelper
+from pyoda_time.utility._csharp_compatibility import _csharp_modulo, _sealed, _towards_zero_division
+from pyoda_time.utility._preconditions import _Preconditions
+
+
+@final
+@_sealed
+class _DurationPatternParser(_IPatternParser[Duration]):
+    @staticmethod
+    def _get_positive_nanosecond_of_second(duration: Duration) -> int:
+        return _csharp_modulo(abs(duration.nanosecond_of_day), PyodaConstants.NANOSECONDS_PER_SECOND)
+
+    @staticmethod
+    def _create_total_handler(
+        field: _PatternFields, nanoseconds_per_unit: int, units_per_day: int, max_value: int
+    ) -> Callable[[_PatternCursor, _SteppedPatternBuilder[Duration]], None]:
+        def handler(pattern: _PatternCursor, builder: _SteppedPatternBuilder[Duration]) -> None:
+            # Needs to be big enough for 92771293593600 seconds
+            count = pattern.get_repeat_count(maximum_count=14)  # 13 in Pyoda Time
+            # AddField would throw an inappropriate exception here, so handle it specially.
+            if (builder._used_fields & _PatternFields.TOTAL_DURATION) != _PatternFields.NONE:
+                raise InvalidPatternError(_TextErrorMessages.MULTIPLE_CAPITAL_DURATION_FIELDS)
+            builder._add_field(field=field, character_in_pattern=pattern.current)
+            builder._add_field(field=_PatternFields.TOTAL_DURATION, character_in_pattern=pattern.current)
+            # Noda Time uses int64 variants of certain methods here, but in Python we just deal with int.
+            builder._add_parse_value_action(
+                minimum_digits=count,
+                maximum_digits=14,  # 13 in Pyoda Time
+                pattern_char=pattern.current,
+                minimum_value=0,
+                maximum_value=max_value,
+                value_setter=lambda bucket, value: cast(_DurationPatternParser._DurationParseBucket, bucket)._add_units(
+                    units=value, nanoseconds_per_unit=nanoseconds_per_unit
+                ),
+                type_=Duration,
+            )
+            builder._add_format_action(
+                lambda value, sb: _FormatHelper._left_pad_non_negative(
+                    _DurationPatternParser.__get_positive_nanosecond_units(value, nanoseconds_per_unit, units_per_day),
+                    count,
+                    sb,
+                )
+            )
+
+        return handler
+
+    @staticmethod
+    def _create_day_handler() -> Callable[[_PatternCursor, _SteppedPatternBuilder[Duration]], None]:
+        def handler(pattern: _PatternCursor, builder: _SteppedPatternBuilder[Duration]) -> None:
+            count = pattern.get_repeat_count(10)  # Enough for 1073741824
+            # AddField would throw an inappropriate exception here, so handle it specially.
+            if (builder._used_fields & _PatternFields.TOTAL_DURATION) != _PatternFields.NONE:
+                raise InvalidPatternError(_TextErrorMessages.MULTIPLE_CAPITAL_DURATION_FIELDS)
+            builder._add_field(field=_PatternFields.DAY_OF_MONTH, character_in_pattern=pattern.current)
+            builder._add_field(field=_PatternFields.TOTAL_DURATION, character_in_pattern=pattern.current)
+            builder._add_parse_value_action(
+                minimum_digits=count,
+                maximum_digits=10,
+                pattern_char=pattern.current,
+                minimum_value=0,
+                maximum_value=1073741824,
+                value_setter=lambda bucket, value: cast(_DurationPatternParser._DurationParseBucket, bucket)._add_days(
+                    value
+                ),
+                type_=Duration,
+            )
+            builder.add_format_left_pad(
+                count=count,
+                selector=lambda duration: duration._floor_days
+                if duration._floor_days >= 0
+                # Round towards 0.
+                else -duration._floor_days
+                if duration._nanosecond_of_floor_day == 0
+                else -(duration._floor_days + 1),
+                assume_non_negative=True,
+                assume_fits_in_count=False,
+            )
+
+        return handler
+
+    @staticmethod
+    def _create_partial_handler(
+        field: _PatternFields, nanoseconds_per_unit: int, units_per_container: int
+    ) -> Callable[[_PatternCursor, _SteppedPatternBuilder[Duration]], None]:
+        def handler(pattern: _PatternCursor, builder: _SteppedPatternBuilder[Duration]) -> None:
+            count = pattern.get_repeat_count(2)
+            builder._add_field(field, pattern.current)
+            builder._add_parse_value_action(
+                minimum_digits=count,
+                maximum_digits=2,
+                pattern_char=pattern.current,
+                minimum_value=0,
+                maximum_value=units_per_container - 1,
+                value_setter=lambda bucket, value: cast(_DurationPatternParser._DurationParseBucket, bucket)._add_units(
+                    value, nanoseconds_per_unit
+                ),
+                type_=Duration,
+            )
+            # This is never used for anything larger than a day, so the day part is irrelevant.
+            builder.add_format_left_pad(
+                count=count,
+                selector=lambda duration: _csharp_modulo(
+                    _towards_zero_division(abs(duration.nanosecond_of_day), nanoseconds_per_unit), units_per_container
+                ),
+                assume_non_negative=True,
+                assume_fits_in_count=(count == 2),
+            )
+
+        return handler
+
+    @staticmethod
+    def _handle_plus(pattern: _PatternCursor, builder: _SteppedPatternBuilder[Duration]) -> None:
+        builder._add_field(_PatternFields.SIGN, pattern.current)
+        builder.add_required_sign(
+            sign_setter=lambda bucket, positive: setattr(bucket, "_is_negative", not positive),
+            non_negative_predicate=lambda duration: duration._floor_days >= 0,
+        )
+
+    @staticmethod
+    def _handle_minus(pattern: _PatternCursor, builder: _SteppedPatternBuilder[Duration]) -> None:
+        builder._add_field(_PatternFields.SIGN, pattern.current)
+        builder.add_negative_only_sign(
+            sign_setter=lambda bucket, positive: setattr(bucket, "_is_negative", not positive),
+            non_negative_predicate=lambda duration: duration._floor_days >= 0,
+        )
+
+    @staticmethod
+    def __get_positive_nanosecond_units(duration: Duration, nanoseconds_per_unit: int, units_per_day: int) -> int:
+        floor_days = duration._floor_days
+        if floor_days >= 0:
+            return floor_days * units_per_day + _towards_zero_division(
+                duration._nanosecond_of_floor_day, nanoseconds_per_unit
+            )
+
+        nanosecond_of_day = duration.nanosecond_of_day
+        # If it's not an exact number of days, FloorDays will overshoot (negatively) by 1.
+        if nanosecond_of_day == 0:
+            negative_value = floor_days * units_per_day
+        else:
+            negative_value = (floor_days + 1) * units_per_day + _towards_zero_division(
+                nanosecond_of_day, nanoseconds_per_unit
+            )
+        return -negative_value
+
+    class _DurationParseBucket(_ParseBucket[Duration]):
+        def __init__(self) -> None:
+            self._is_negative = False
+            self.__current_nanos = 0
+
+        def _add_nanoseconds(self, nanoseconds: int) -> None:
+            self.__current_nanos += nanoseconds
+
+        def _add_days(self, days: int) -> None:
+            self.__current_nanos += days * PyodaConstants.NANOSECONDS_PER_DAY
+
+        def _add_units(self, units: int, nanoseconds_per_unit: int) -> None:
+            self.__current_nanos += units * nanoseconds_per_unit
+
+        def calculate_value(self, used_fields: _PatternFields, value: str) -> ParseResult[Duration]:
+            if self._is_negative:
+                self.__current_nanos = -self.__current_nanos
+            if self.__current_nanos < Duration._MIN_NANOSECONDS or self.__current_nanos > Duration._MAX_NANOSECONDS:
+                return ParseResult._for_invalid_value_post_parse(
+                    value, _TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE, Duration.__name__
+                )
+            return ParseResult.for_value(Duration.from_nanoseconds(self.__current_nanos))
+
+    __PATTERN_CHARACTER_HANDLERS: Final[
+        Mapping[str, Callable[[_PatternCursor, _SteppedPatternBuilder[Duration]], None]]
+    ] = {
+        "%": _SteppedPatternBuilder._handle_percent,
+        "'": _SteppedPatternBuilder._handle_quote,
+        '"': _SteppedPatternBuilder._handle_quote,
+        "\\": _SteppedPatternBuilder._handle_backslash,
+        ".": _TimePatternHelper._create_period_handler(
+            max_count=9,
+            getter=_get_positive_nanosecond_of_second,
+            setter=lambda bucket, value: cast(_DurationPatternParser._DurationParseBucket, bucket)._add_nanoseconds(
+                value
+            ),
+        ),
+        ":": lambda pattern, builder: builder._add_literal(
+            expected_text=builder._format_info.time_separator,
+            failure=ParseResult._time_separator_mismatch,
+        ),
+        "D": _create_day_handler(),
+        "H": _create_total_handler(
+            field=_PatternFields.HOURS_24,
+            nanoseconds_per_unit=PyodaConstants.NANOSECONDS_PER_HOUR,
+            units_per_day=PyodaConstants.HOURS_PER_DAY,
+            max_value=25769803776,  # 402653184L in Noda Time
+        ),
+        "h": _create_partial_handler(
+            field=_PatternFields.HOURS_24,
+            nanoseconds_per_unit=PyodaConstants.NANOSECONDS_PER_HOUR,
+            units_per_container=PyodaConstants.HOURS_PER_DAY,
+        ),
+        "M": _create_total_handler(
+            field=_PatternFields.MINUTES,
+            nanoseconds_per_unit=PyodaConstants.NANOSECONDS_PER_MINUTE,
+            units_per_day=PyodaConstants.MINUTES_PER_DAY,
+            max_value=1546188226560,  # 24159191040L in Noda Time
+        ),
+        "m": _create_partial_handler(
+            field=_PatternFields.MINUTES,
+            nanoseconds_per_unit=PyodaConstants.NANOSECONDS_PER_MINUTE,
+            units_per_container=PyodaConstants.MINUTES_PER_HOUR,
+        ),
+        "S": _create_total_handler(
+            field=_PatternFields.SECONDS,
+            nanoseconds_per_unit=PyodaConstants.NANOSECONDS_PER_SECOND,
+            units_per_day=PyodaConstants.SECONDS_PER_DAY,
+            max_value=92771293593600,  # 1449551462400L in Noda Time
+        ),
+        "s": _create_partial_handler(
+            field=_PatternFields.SECONDS,
+            nanoseconds_per_unit=PyodaConstants.NANOSECONDS_PER_SECOND,
+            units_per_container=PyodaConstants.SECONDS_PER_MINUTE,
+        ),
+        "f": _TimePatternHelper._create_fraction_handler(
+            max_count=9,
+            getter=_get_positive_nanosecond_of_second,
+            setter=lambda bucket, value: cast(_DurationPatternParser._DurationParseBucket, bucket)._add_nanoseconds(
+                value
+            ),
+        ),
+        "F": _TimePatternHelper._create_fraction_handler(
+            max_count=9,
+            getter=_get_positive_nanosecond_of_second,
+            setter=lambda bucket, value: cast(_DurationPatternParser._DurationParseBucket, bucket)._add_nanoseconds(
+                value
+            ),
+        ),
+        "+": _handle_plus,
+        "-": _handle_minus,
+    }
+
+    def parse_pattern(self, pattern: str, format_info: _PyodaFormatInfo) -> IPattern[Duration]:
+        _Preconditions._check_not_null(pattern, "pattern")
+        if not pattern:
+            raise InvalidPatternError(_TextErrorMessages.FORMAT_STRING_EMPTY)
+
+        if len(pattern) == 1:
+            from ._duration_pattern import DurationPattern
+
+            match pattern:
+                case "o":
+                    return DurationPattern._Patterns._roundtrip_pattern_impl
+                case "j":
+                    return DurationPattern._Patterns._json_roundtrip_pattern_impl
+                case _:
+                    raise InvalidPatternError(_TextErrorMessages.UNKNOWN_STANDARD_FORMAT, pattern, Duration.__name__)
+
+        pattern_builder = _SteppedPatternBuilder(format_info, self._DurationParseBucket)
+        pattern_builder._parse_custom_pattern(pattern, self.__PATTERN_CHARACTER_HANDLERS)
+        # Somewhat random sample, admittedly...
+        return pattern_builder._build(
+            Duration.from_hours(1)
+            + Duration.from_minutes(30)
+            + Duration.from_seconds(5)
+            + Duration.from_milliseconds(500)
+        )

--- a/pyoda_time/text/patterns/_stepped_pattern_builder.py
+++ b/pyoda_time/text/patterns/_stepped_pattern_builder.py
@@ -206,6 +206,8 @@ class _SteppedPatternBuilder(Generic[TResult]):
     def _add_format_action(self, format_action: Callable[[TResult, StringBuilder], None]) -> None:
         self.__format_actions.append(format_action)
 
+    # Noda Time has an AddParseInt64ValueAction here, but we don't need that in Python.
+
     def _add_parse_value_action(
         self,
         minimum_digits: int,

--- a/tests/text/pattern_test_data.py
+++ b/tests/text/pattern_test_data.py
@@ -64,7 +64,7 @@ class PatternTestData(Generic[T]):
         assert self.message is None
         pattern: IPattern[T] = self.create_pattern()
         actual = pattern.format(self.value)
-        assert actual == self.text
+        assert actual == self.text, f"{actual} == {self.text}"
 
         if self.standard_pattern is not None:
             assert self.text == self.standard_pattern.format(self.value)

--- a/tests/text/test_duration_pattern.py
+++ b/tests/text/test_duration_pattern.py
@@ -1,0 +1,371 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Any
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from pyoda_time._compatibility._culture_info import CultureInfo
+from pyoda_time._duration import Duration
+from pyoda_time.text import DurationPattern
+from pyoda_time.text._i_pattern import IPattern
+from pyoda_time.text._text_error_messages import _TextErrorMessages
+
+from ..text.pattern_test_base import PatternTestBase
+from ..text.pattern_test_data import PatternTestData
+from .cultures import Cultures
+
+
+class Data(PatternTestData[Duration]):
+    @property
+    def default_template(self) -> Duration:
+        # Ignored anyway...
+        return Duration.zero
+
+    def __init__(
+        self,
+        *,
+        value: Duration = Duration.zero,
+        culture: CultureInfo = CultureInfo.invariant_culture,
+        standard_pattern: IPattern[Duration] | None = None,
+        pattern: str | None = None,
+        text: str | None = None,
+        template: Duration | None = None,
+        description: str | None = None,
+        message: str | None = None,
+        parameters: list[Any] | None = None,
+    ) -> None:
+        super().__init__(
+            value=value,
+            culture=culture,
+            standard_pattern=standard_pattern,
+            pattern=pattern,
+            text=text,
+            template=template,
+            description=description,
+            message=message,
+            parameters=parameters,
+        )
+
+    def create_pattern(self) -> IPattern[Duration]:
+        assert self.pattern is not None
+        return DurationPattern.create(self.pattern, self.culture)
+
+
+FORMAT_ONLY_DATA: list[Data] = [
+    # No sign, so we can't parse it.
+    Data(value=Duration.from_hours(-1).plus(Duration.from_minutes(0)), pattern="HH:mm", text="01:00"),
+    # Loss of nano precision
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456789),
+        pattern="D:hh:mm:ss.ffff",
+        text="1:02:03:04.1234",
+    ),
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456789),
+        pattern="D:hh:mm:ss.FFFF",
+        text="1:02:03:04.1234",
+    ),
+]
+
+PARSE_ONLY_DATA: list[Data] = []
+
+INVALID_PATTERN_DATA: list[Data] = [
+    Data(pattern="", message=_TextErrorMessages.FORMAT_STRING_EMPTY),
+    Data(pattern="HH:MM", message=_TextErrorMessages.MULTIPLE_CAPITAL_DURATION_FIELDS),
+    Data(pattern="HH D", message=_TextErrorMessages.MULTIPLE_CAPITAL_DURATION_FIELDS),
+    Data(pattern="MM mm", message=_TextErrorMessages.REPEATED_FIELD_IN_PATTERN, parameters=["m"]),
+    Data(pattern="G", message=_TextErrorMessages.UNKNOWN_STANDARD_FORMAT, parameters=["G", "Duration"]),
+]
+
+PARSE_FAILURE_DATA: list[Data] = [
+    Data(
+        value=Duration.zero,
+        pattern="H:mm",
+        text="1:60",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=[60, "m", "Duration"],
+    ),
+    # Total field values out of range
+    # The "text" contains a value which is {max for field} + 1
+    Data(
+        value=Duration.min_value,
+        pattern="-D:hh:mm:ss.fffffffff",
+        text="1073741825:00:00:00.000000000",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=["1073741825", "D", "Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-H:mm:ss.fffffffff",
+        text="25769803777:00:00.000000000",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=["25769803777", "H", "Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-M:ss.fffffffff",
+        text="1546188226561:00.000000000",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=["1546188226561", "M", "Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-S.fffffffff",
+        text="92771293593601.000000000",
+        message=_TextErrorMessages.FIELD_VALUE_OUT_OF_RANGE,
+        parameters=["92771293593601", "S", "Duration"],
+    ),
+    # Each field in range, but overall result out of range
+    # TODO: Each of the following eight tests fails because our Duration can have larger values than Noda Time
+    Data(
+        value=Duration.min_value,
+        pattern="-D:hh:mm:ss.fffffffff",
+        text="-1073741824:00:00:00.000000001",
+        message=_TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE,
+        parameters=["Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-D:hh:mm:ss.fffffffff",
+        text="1073741824:00:00:00.000000000",
+        message=_TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE,
+        parameters=["Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-H:mm:ss.fffffffff",
+        text="-25769803776:00:00.000000001",
+        message=_TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE,
+        parameters=["Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-H:mm:ss.fffffffff",
+        text="25769803776:00:00.000000000",
+        message=_TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE,
+        parameters=["Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-M:ss.fffffffff",
+        text="-1546188226560:00.000000001",
+        message=_TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE,
+        parameters=["Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-M:ss.fffffffff",
+        text="1546188226560:00.000000000",
+        message=_TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE,
+        parameters=["Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-S.fffffffff",
+        text="-92771293593600.000000001",
+        message=_TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE,
+        parameters=["Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="-S.fffffffff",
+        text="92771293593600.000000000",
+        message=_TextErrorMessages.OVERALL_VALUE_OUT_OF_RANGE,
+        parameters=["Duration"],
+    ),
+    Data(
+        value=Duration.min_value,
+        pattern="'x'S",
+        text="x",
+        message=_TextErrorMessages.MISMATCHED_NUMBER,
+        parameters=["S"],
+    ),
+]
+
+FORMAT_AND_PARSE_DATA: list[Data] = [
+    Data(value=Duration.from_hours(1) + Duration.from_minutes(2), pattern="+HH:mm", text="+01:02"),
+    Data(value=Duration.from_hours(-1) + Duration.from_minutes(-2), pattern="+HH:mm", text="-01:02"),
+    Data(value=Duration.from_hours(1) + Duration.from_minutes(2), pattern="-HH:mm", text="01:02"),
+    Data(value=Duration.from_hours(-1) + Duration.from_minutes(-2), pattern="-HH:mm", text="-01:02"),
+    Data(value=Duration.from_hours(26) + Duration.from_minutes(3), pattern="D:h:m", text="1:2:3"),
+    Data(value=Duration.from_hours(26) + Duration.from_minutes(3), pattern="DD:hh:mm", text="01:02:03"),
+    Data(value=Duration.from_hours(242) + Duration.from_minutes(3), pattern="D:hh:mm", text="10:02:03"),
+    Data(value=Duration.from_hours(2) + Duration.from_minutes(3), pattern="H:mm", text="2:03"),
+    Data(value=Duration.from_hours(2) + Duration.from_minutes(3), pattern="HH:mm", text="02:03"),
+    Data(value=Duration.from_hours(26) + Duration.from_minutes(3), pattern="HH:mm", text="26:03"),
+    Data(value=Duration.from_hours(260) + Duration.from_minutes(3), pattern="HH:mm", text="260:03"),
+    Data(
+        value=Duration.from_hours(2) + Duration.from_minutes(3) + Duration.from_seconds(4),
+        pattern="H:mm:ss",
+        text="2:03:04",
+    ),
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456789),
+        pattern="D:hh:mm:ss.fffffffff",
+        text="1:02:03:04.123456789",
+    ),
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456000),
+        pattern="D:hh:mm:ss.fffffffff",
+        text="1:02:03:04.123456000",
+    ),
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456789),
+        pattern="D:hh:mm:ss.FFFFFFFFF",
+        text="1:02:03:04.123456789",
+    ),
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456000),
+        pattern="D:hh:mm:ss.FFFFFFFFF",
+        text="1:02:03:04.123456",
+    ),
+    Data(
+        value=Duration.from_hours(1) + Duration.from_minutes(2) + Duration.from_seconds(3), pattern="M:ss", text="62:03"
+    ),
+    Data(
+        value=Duration.from_hours(1) + Duration.from_minutes(2) + Duration.from_seconds(3),
+        pattern="MMM:ss",
+        text="062:03",
+    ),
+    Data(
+        value=Duration.from_days(0)
+        + Duration.from_hours(0)
+        + Duration.from_minutes(1)
+        + Duration.from_seconds(2)
+        + Duration.from_nanoseconds(123400000),
+        pattern="SS.FFFF",
+        text="62.1234",
+    ),
+    # Check handling of F after non-period.
+    Data(
+        value=Duration.from_days(0)
+        + Duration.from_hours(0)
+        + Duration.from_minutes(1)
+        + Duration.from_seconds(2)
+        + Duration.from_nanoseconds(123400000),
+        pattern="SS'x'FFFF",
+        text="62x1234",
+    ),
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456789),
+        pattern="D:hh:mm:ss.FFFFFFFFF",
+        text="1.02.03.04.123456789",
+        culture=Cultures.dot_time_separator,
+    ),
+    # Roundtrip pattern is invariant; redundantly specify the culture to validate that it doesn't make a difference.
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456789),
+        standard_pattern=DurationPattern.roundtrip,
+        pattern="o",
+        text="1:02:03:04.123456789",
+        culture=Cultures.dot_time_separator,
+    ),
+    Data(
+        value=Duration.from_days(-1)
+        + Duration.from_hours(-2)
+        + Duration.from_minutes(-3)
+        + Duration.from_seconds(-4)
+        + Duration.from_nanoseconds(-123456789),
+        standard_pattern=DurationPattern.roundtrip,
+        pattern="o",
+        text="-1:02:03:04.123456789",
+        culture=Cultures.dot_time_separator,
+    ),
+    # Same tests for the "JSON roundtrip" pattern.
+    Data(
+        value=Duration.from_days(1)
+        + Duration.from_hours(2)
+        + Duration.from_minutes(3)
+        + Duration.from_seconds(4)
+        + Duration.from_nanoseconds(123456789),
+        standard_pattern=DurationPattern.json_roundtrip,
+        pattern="j",
+        text="26:03:04.123456789",
+        culture=Cultures.dot_time_separator,
+    ),
+    Data(
+        value=Duration.from_days(-1)
+        + Duration.from_hours(-2)
+        + Duration.from_minutes(-3)
+        + Duration.from_seconds(-4)
+        + Duration.from_nanoseconds(-123456789),
+        standard_pattern=DurationPattern.json_roundtrip,
+        pattern="j",
+        text="-26:03:04.123456789",
+        culture=Cultures.dot_time_separator,
+    ),
+    # Extremes...
+    Data(value=Duration.min_value, pattern="-D:hh:mm:ss.fffffffff", text="-1073741824:00:00:00.000000000"),
+    Data(value=Duration.max_value, pattern="-D:hh:mm:ss.fffffffff", text="1073741823:23:59:59.999999999"),
+    Data(value=Duration.min_value, pattern="-H:mm:ss.fffffffff", text="-25769803776:00:00.000000000"),
+    Data(value=Duration.max_value, pattern="-H:mm:ss.fffffffff", text="25769803775:59:59.999999999"),
+    Data(value=Duration.min_value, pattern="-M:ss.fffffffff", text="-1546188226560:00.000000000"),
+    Data(value=Duration.max_value, pattern="-M:ss.fffffffff", text="1546188226559:59.999999999"),
+    Data(value=Duration.min_value, pattern="-S.fffffffff", text="-92771293593600.000000000"),
+    Data(value=Duration.max_value, pattern="-S.fffffffff", text="92771293593599.999999999"),
+]
+
+PARSE_DATA = PARSE_ONLY_DATA + FORMAT_AND_PARSE_DATA
+FORMAT_DATA = FORMAT_ONLY_DATA + FORMAT_AND_PARSE_DATA
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=}") for data in INVALID_PATTERN_DATA])
+def invalid_pattern_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=}") for data in PARSE_FAILURE_DATA])
+def parse_failure_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=}") for data in PARSE_DATA])
+def parse_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(data, id=f"{data.pattern=} {data.text=} {data.culture=}") for data in FORMAT_DATA])
+def format_data(request: FixtureRequest) -> Data:
+    assert isinstance(request.param, Data)
+    return request.param
+
+
+class TestDurationPattern(PatternTestBase[Duration]):
+    pass


### PR DESCRIPTION
Brief bit of exposition needed here first.

In .NET, spans of time tend to be represented by `TimeSpan`. The Noda Time equivalent to that is a `Duration`. Noda Time's `Duration` is capable of conversion to and from all the values in the range of `TimeSpan`, which covers 292 years or so. In fact, Noda Time's Duration has a much larger range than that, something like 20,000+ years.

When `Duration` was implemented back in #47, I decided that for Pyoda Time, `Duration` should have a similar relationship with `datetime.timedelta`, i.e.  it should be possible to convert all possible `timedelta` values to and from the Pyoda type. The thing is that `timedelta`'s range is so vast that it makes the .NET range look measly by comparison.

At the time, I decided to drastically increase the range of `Duration` from the range offered by Noda Time, so that the Pyoda `Duration` would have a range which is slightly larger than `timedelta`. That decision has had knock-on effects for the `DurationPattern` port, particularly with regard to parsing validation and so forth.

The end result is that this `DurationPattern` implementation is very reminiscent of the one you'll find in the mother project, but it allows for much, much greater values to be parsed and formatted.

One other small note. I'm currently having a discussion with myself over in #154 about string formatting stuff. Included in this PR is the use of the new pattern in `Duration.__str__` and `Duration.__format__`. There is no test coverage for that currently, but I had a bit of a play in a REPL and...

```python-repl
>>> from pyoda_time import Duration
>>> 
>>> 
>>> Duration.max_value
1073741823:23:59:59.999999999
>>> Duration.min_value
-1073741824:00:00:00
>>> Duration.epsilon
0:00:00:00.000000001
>>> f"{Duration.max_value:o}"
'1073741823:23:59:59.999999999'
>>> f"{Duration.max_value:j}"
'25769803775:59:59.999999999'
>>> f"{Duration.max_value:D hh mm ss 'hello world'}"
'1073741823 23 59 59 hello world'

```