### PR TITLE
fix(CultureInfo): default locale name should contain hyphen rather than underscore

### DIFF
--- a/pyoda_time/_compatibility/_culture_info.py
+++ b/pyoda_time/_compatibility/_culture_info.py
@@ -112,11 +112,14 @@ class __CultureInfoMeta(type):
     @staticmethod
     def _get_default_locale_name() -> str | None:
         """Return the name of the default ICU Locale."""
-        # Much like .NET defers to their ICU interop layer.
+        # TODO: In .NET this calls into native code (GlobalizationNative_GetDefaultLocaleName)
+        #  https://source.dot.net/#System.Private.CoreLib/src/libraries/Common/src/Interop/Interop.Locale.cs,20
+        #  https://github.com/dotnet/runtime/blob/d1747a74705a49700d7c568fdb568704c2bbad58/src/native/libs/System.Globalization.Native/pal_locale.c#L215C9-L258
+        #  We shouldn't need to str.replace() below...
         locale: icu.Locale = icu.Locale.getDefault()
         if locale is None:
             return None
-        return str(locale.getName())
+        return str(locale.getName()).replace("_", "-")
 
     @staticmethod
     def __get_culture_by_name(name: str) -> CultureInfo:

--- a/tests/_compatibility/__init__.py
+++ b/tests/_compatibility/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.

--- a/tests/_compatibility/test_culture_info.py
+++ b/tests/_compatibility/test_culture_info.py
@@ -1,0 +1,56 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+import pytest
+
+from pyoda_time._compatibility._culture_info import CultureInfo
+
+
+@pytest.fixture
+def default_locale_name() -> str:
+    """The default locale name according to PyICU via CultureInfo."""
+    default_locale_name: str | None = CultureInfo._get_default_locale_name()
+    assert default_locale_name is not None
+    return default_locale_name
+
+
+def test_get_default_locale_name_does_not_contain_hyphen(default_locale_name: str) -> None:
+    """Assert that the default locale name is set correctly."""
+    assert "_" not in default_locale_name
+
+
+@pytest.mark.parametrize(
+    "icu_locale_name,expected",
+    [
+        # As observed in dotnet 8
+        ("fr-FR", "dd/MM/yyyy"),
+        ("fr_FR", "dd/MM/yyyy"),
+        ("fr-CA", "yyyy-MM-dd"),
+        ("fr_CA", "dd/MM/yyyy"),
+        ("en-GB", "dd/MM/yyyy"),
+        ("en_GB", "M/d/yyyy"),
+        ("en-US", "M/d/yyyy"),
+        ("en_US", "M/d/yyyy"),
+        ("", "MM/dd/yyyy"),  # Invariant Culture
+    ],
+)
+def test_short_date_pattern(icu_locale_name: str, expected: str) -> None:
+    """Assert that the short date pattern matches the value observed in dotnet."""
+    assert CultureInfo(icu_locale_name).date_time_format.short_date_pattern == expected
+
+
+def test_user_default_culture_short_date_pattern(default_locale_name: str) -> None:
+    """Assert that the user default culture's short date pattern matches that of a manually-constructed Culture."""
+    user_default: CultureInfo = CultureInfo._get_user_default_culture()
+    via_constructor: CultureInfo = CultureInfo(name=default_locale_name)
+
+    assert user_default.date_time_format.short_date_pattern == via_constructor.date_time_format.short_date_pattern
+
+
+def test_current_culture_short_date_pattern(default_locale_name: str) -> None:
+    """Assert that the current culture's short date pattern matches that of a manually-constructed Culture."""
+    current: CultureInfo = CultureInfo.current_culture
+    expected: CultureInfo = CultureInfo.get_culture_info(name=default_locale_name)
+
+    assert current.date_time_format.short_date_pattern == expected.date_time_format.short_date_pattern


### PR DESCRIPTION
While implementing #156, I noticed something was amiss with `LocaleDateTime`. For my locale (en-GB), I should see the date in the format `dd/MM/yyyy`, but what I actually saw in the REPL was:

```
>>> from pyoda_time import LocalDateTime
>>> LocalDateTime(year=1, month=2, day=3)
2/3/0001 12:00:00 AM
```

Looking into it, I discovered that `CultureInfo.current_culture.date_time_format.short_date_pattern` was giving me `M/d/yyyy` instead of `dd/MM/yyyy`.

This was made more confusing by the fact that if I constructed a `CultureInfo` manually, it gave me the right short date format:

```
>>> from pyoda_time._compatibility._culture_info import CultureInfo
>>> CultureInfo("en-GB").date_time_format.short_date_pattern
'dd/MM/yyyy'
```

After a bit more investigation, I discovered that the root cause lay in `CultureInfo._get_default_locale_name()`, which was returning `en_GB` (underscore) rather than `en-GB` (hyphen). Verified via:

```
>>> CultureInfo("en_GB").date_time_format.short_date_pattern
'M/d/yyyy'
```

This in itself was perplexing as I would have expected both `"en-GB"` and `"en_GB"` to result in Cultures with the same short date format. I went hunting in dotnet to get some answers... This test passes:

```csharp
    [Test]
    public void EnGbShortDateFormat()
    {
        Assert.That(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, Is.EqualTo("dd/MM/yyyy"));
        Assert.That(new CultureInfo("en-GB").DateTimeFormat.ShortDatePattern, Is.EqualTo("dd/MM/yyyy"));
        Assert.That(new CultureInfo("en_GB").DateTimeFormat.ShortDatePattern, Is.EqualTo("M/d/yyyy"));
    }
```

So the take-aways here are:

- Yes, there was a bug in `CultureInfo._get_default_locale_name()` which for me was returning `"en_GB"` (ICU locale name) rather than `"en-GB"` (dotnet style culture name).
- There isn't a bug on our side with the short date formats for `"en_GB"` and `"en-GB"` cultures having different short date formats; Or at least, we are bug-for-bug compatible with dotnet in this regard.

Oh, and after patching this up, here is what I get in my REPL:

```
>>> from pyoda_time import LocalDateTime
>>> LocalDateTime(year=1, month=2, day=3)
03/02/0001 00:00:00
```