### PR TITLE
feat: `IClock`, `SystemClock` & `ZonedClock`

### DIFF
--- a/docs/source/pyoda_time.rst
+++ b/docs/source/pyoda_time.rst
@@ -10,6 +10,7 @@ Subpackages
    pyoda_time.calendars
    pyoda_time.fields
    pyoda_time.globalization
+   pyoda_time.testing
    pyoda_time.text
    pyoda_time.time_zones
    pyoda_time.utility

--- a/docs/source/pyoda_time.testing.rst
+++ b/docs/source/pyoda_time.testing.rst
@@ -1,0 +1,17 @@
+pyoda\_time.testing package
+===========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 1
+
+   pyoda_time.testing.time_zones
+
+Module contents
+---------------
+
+.. automodule:: pyoda_time.testing
+   :members:
+   :undoc-members:

--- a/docs/source/pyoda_time.testing.time_zones.rst
+++ b/docs/source/pyoda_time.testing.time_zones.rst
@@ -1,0 +1,9 @@
+pyoda\_time.testing.time\_zones package
+=======================================
+
+Module contents
+---------------
+
+.. automodule:: pyoda_time.testing.time_zones
+   :members:
+   :undoc-members:

--- a/pyoda_time/__init__.py
+++ b/pyoda_time/__init__.py
@@ -8,6 +8,7 @@ __all__: list[str] = [
     "calendars",
     "fields",
     "globalization",
+    "testing",
     "text",
     "time_zones",
     "utility",
@@ -19,6 +20,7 @@ __all__: list[str] = [
     "DateTimeZone",
     "DateTimeZoneProviders",
     "Duration",
+    "IClock",
     "IDateTimeZoneProvider",
     "Instant",
     "Interval",
@@ -34,8 +36,10 @@ __all__: list[str] = [
     "PeriodUnits",
     "PyodaConstants",
     "SkippedTimeError",
+    "SystemClock",
     "TimeAdjusters",
     "YearMonth",
+    "ZonedClock",
     "ZonedDateTime",
 ]
 
@@ -44,6 +48,7 @@ from . import (
     calendars,
     fields,
     globalization,
+    testing,
     text,
     time_zones,
     utility,
@@ -60,6 +65,7 @@ from ._date_interval import DateInterval
 from ._date_time_zone import DateTimeZone
 from ._date_time_zone_providers import DateTimeZoneProviders
 from ._duration import Duration
+from ._i_clock import IClock
 from ._i_date_time_zone_provider import IDateTimeZoneProvider
 from ._instant import Instant
 from ._interval import Interval
@@ -74,6 +80,8 @@ from ._period import Period
 from ._period_builder import PeriodBuilder
 from ._period_units import PeriodUnits
 from ._skipped_time_error import SkippedTimeError
+from ._system_clock import SystemClock
 from ._time_adjusters import TimeAdjusters
 from ._year_month import YearMonth
+from ._zoned_clock import ZonedClock
 from ._zoned_date_time import ZonedDateTime

--- a/pyoda_time/_i_clock.py
+++ b/pyoda_time/_i_clock.py
@@ -1,0 +1,69 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Protocol
+
+from ._calendar_system import CalendarSystem
+from ._date_time_zone import DateTimeZone
+from ._date_time_zone_providers import DateTimeZoneProviders
+from ._instant import Instant
+
+if TYPE_CHECKING:
+    from ._zoned_clock import ZonedClock
+
+
+class IClock(Protocol):
+    """Represents a clock which can return the current time as an ``Instant``.
+
+    ``IClock`` is intended for use anywhere you need to have access to the current time.
+
+    Although it's not strictly incorrect to call ``SystemClock.instance.get_current_instant()`` directly,
+    in the same way as you might call ``datetime.now(tz=UTC)``, it's strongly discouraged
+    as a matter of style for production code. We recommend providing an instance of ``IClock``
+    to anything that needs it, which allows you to write tests using the fake clock in the pyoda_time.testing
+    package (or your own implementation).
+    """
+
+    @abstractmethod
+    def get_current_instant(self) -> Instant:
+        """Gets the current ``Instant`` on the timeline according to this clock.
+
+        :return: The current instant on the timeline according to this clock.
+        """
+        ...
+
+    # region ClockExtensions methods
+
+    def in_zone(self, zone: DateTimeZone, calendar: CalendarSystem = CalendarSystem.iso) -> ZonedClock:
+        """Constructs a ``ZonedClock`` from this clock, a time zone, and a calendar system.
+
+        :param zone: Time zone to use in the returned object.
+        :param calendar: Calendar to use in the returned object.
+        :return: A ``ZonedClock`` with the given clock, time zone and calendar system.
+        """
+        from ._zoned_clock import ZonedClock
+
+        return ZonedClock(self, zone, calendar)
+
+    def in_utc(self) -> ZonedClock:
+        """Constructs a ``ZonedClock`` from this clock, using the UTC time zone and ISO calendar system.
+
+        :return: A ``ZonedClock`` with the given clock, in the UTC time zone and ISO calendar system.
+        """
+        return self.in_zone(DateTimeZone.utc)
+
+    def in_tzdb_system_default_zone(self) -> ZonedClock:
+        """Constructs a ``ZonedClock`` from this clock, in the TZDB mapping for the system default time zone and the ISO
+        calendar system.
+
+        :return:
+        """
+        zone = DateTimeZoneProviders.tzdb.get_system_default()
+        return self.in_zone(zone)
+
+    # TODO: def in_bcl_system_default_zone(self) -> ZonedClock:
+
+    # endregion

--- a/pyoda_time/_i_date_time_zone_provider.py
+++ b/pyoda_time/_i_date_time_zone_provider.py
@@ -1,10 +1,13 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-from abc import abstractmethod
-from typing import Iterable, Protocol
+from __future__ import annotations
 
-from pyoda_time._date_time_zone import DateTimeZone
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Iterable, Protocol
+
+if TYPE_CHECKING:
+    from pyoda_time._date_time_zone import DateTimeZone
 
 
 class IDateTimeZoneProvider(Protocol):

--- a/pyoda_time/_instant.py
+++ b/pyoda_time/_instant.py
@@ -425,11 +425,12 @@ class Instant(metaclass=_InstantMeta):
             return _LocalInstant.after_max_value()
         return _LocalInstant._ctor(nanoseconds=as_duration)
 
-    def in_zone(self, zone: DateTimeZone, calendar: CalendarSystem) -> ZonedDateTime:
+    def in_zone(self, zone: DateTimeZone, calendar: CalendarSystem | None = None) -> ZonedDateTime:
         from . import ZonedDateTime
 
         _Preconditions._check_not_null(zone, "zone")
-        _Preconditions._check_not_null(calendar, "calendar")
+        if calendar is None:
+            return ZonedDateTime(instant=self, zone=zone)
         return ZonedDateTime(instant=self, zone=zone, calendar=calendar)
 
     @property

--- a/pyoda_time/_system_clock.py
+++ b/pyoda_time/_system_clock.py
@@ -1,0 +1,52 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+import threading
+import time
+from typing import Final, _ProtocolMeta, final
+
+from pyoda_time._i_clock import IClock
+from pyoda_time._instant import Instant
+from pyoda_time.utility._csharp_compatibility import _private, _sealed
+
+
+class __SystemClockMeta(_ProtocolMeta):
+    __lock: Final[threading.Lock] = threading.Lock()
+    __instance: SystemClock | None = None
+
+    @property
+    def instance(self) -> SystemClock:
+        """The singleton instance of ``SystemClock``.
+
+        :return: The singleton instance of ``SystemClock``.
+        """
+        if not self.__instance:
+            with self.__lock:
+                if not self.__instance:
+                    self.__instance = object.__new__(SystemClock)
+        return self.__instance
+
+
+@final
+@_sealed
+@_private
+class SystemClock(IClock, metaclass=__SystemClockMeta):
+    """Singleton implementation of ``IClock`` which reads the current system time.
+
+    It is recommended that for anything other than throwaway code, this is only referenced
+    in a single place in your code: where you provide a value to inject into the rest of
+    your application, which should only depend on the interface.
+    """
+
+    instance: SystemClock
+
+    def get_current_instant(self) -> Instant:
+        """Gets the current time as an ``Instant``.
+
+        :return: The current time in nanoseconds as an ``Instant``.
+        """
+        from pyoda_time._pyoda_constants import PyodaConstants
+
+        return PyodaConstants.UNIX_EPOCH.plus_nanoseconds(time.time_ns())

--- a/pyoda_time/_zoned_clock.py
+++ b/pyoda_time/_zoned_clock.py
@@ -1,0 +1,112 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+from typing import final
+
+from pyoda_time import Instant
+from pyoda_time._calendar_system import CalendarSystem
+from pyoda_time._date_time_zone import DateTimeZone
+from pyoda_time._i_clock import IClock
+from pyoda_time._local_date import LocalDate
+from pyoda_time._local_date_time import LocalDateTime
+from pyoda_time._local_time import LocalTime
+from pyoda_time._offset_date_time import OffsetDateTime
+from pyoda_time._zoned_date_time import ZonedDateTime
+from pyoda_time.utility._csharp_compatibility import _sealed
+from pyoda_time.utility._preconditions import _Preconditions
+
+
+@final
+@_sealed
+class ZonedClock(IClock):
+    """A clock with an associated time zone and calendar.
+
+    This is effectively a convenience class decorating an ``IClock``.
+    """
+
+    @property
+    def clock(self) -> IClock:
+        """Gets the clock used to provide the current instant.
+
+        :return: The clock associated with this zoned clock.
+        """
+        return self.__clock
+
+    @property
+    def zone(self) -> DateTimeZone:
+        """Gets the time zone used when converting the current instant into a zone-sensitive value.
+
+        :return: The time zone associated with this zoned clock.
+        """
+        return self.__zone
+
+    @property
+    def calendar(self) -> CalendarSystem:
+        """Gets the calendar system used when converting the current instant into a calendar-sensitive value.
+
+        :return: The calendar system associated with this zoned clock.
+        """
+        return self.__calendar
+
+    def __init__(self, clock: IClock, zone: DateTimeZone, calendar: CalendarSystem) -> None:
+        """Creates a new ``ZonedClock`` with the given clock, time zone and calendar system.
+
+        :param clock: Clock to use to obtain instants.
+        :param zone: Time zone to adjust instants into.
+        :param calendar: Calendar system to use.
+        """
+        self.__clock = _Preconditions._check_not_null(clock, "clock")
+        self.__zone = _Preconditions._check_not_null(zone, "zone")
+        self.__calendar = _Preconditions._check_not_null(calendar, "calendar")
+
+    def get_current_instant(self) -> Instant:
+        """Returns the current instant provided by the underlying clock.
+
+        :return: The current instant provided by the underlying clock.
+        """
+        return self.__clock.get_current_instant()
+
+    def get_current_zoned_date_time(self) -> ZonedDateTime:
+        """Returns the current instant provided by the underlying clock, adjusted to the time zone of this object.
+
+        :return: The current instant provided by the underlying clock, adjusted to the time zone of this object.
+        """
+        return self.get_current_instant().in_zone(self.zone, self.calendar)
+
+    def get_current_local_date_time(self) -> LocalDateTime:
+        """Returns the local date/time of the current instant provided by the underlying clock, adjusted to the time
+        zone of this object.
+
+        :return: The local date/time of the current instant provided by the underlying clock, adjusted to the time zone
+            of this object.
+        """
+        return self.get_current_zoned_date_time().local_date_time
+
+    def get_current_offset_date_time(self) -> OffsetDateTime:
+        """Returns the offset date/time of the current instant provided by the underlying clock, adjusted to the time
+        zone of this object.
+
+        :return: The offset date/time of the current instant provided by the underlying clock, adjusted to the time zone
+            of this object.
+        """
+        return self.get_current_zoned_date_time().to_offset_date_time()
+
+    def get_current_date(self) -> LocalDate:
+        """Returns the local date of the current instant provided by the underlying clock, adjusted to the time zone of
+        this object.
+
+        :return: The local date of the current instant provided by the underlying clock, adjusted to the time zone of
+            this object.
+        """
+        return self.get_current_zoned_date_time().date
+
+    def get_curent_time_of_day(self) -> LocalTime:
+        """Returns the local time of the current instant provided by the underlying clock, adjusted to the time zone of
+        this object.
+
+        :return: The local time of the current instant provided by the underlying clock, adjusted to the time zone of
+            this object.
+        """
+        return self.get_current_zoned_date_time().time_of_day

--- a/pyoda_time/_zoned_date_time.py
+++ b/pyoda_time/_zoned_date_time.py
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
         CalendarSystem,
         DateTimeZone,
         Instant,
+        LocalDate,
         LocalDateTime,
+        LocalTime,
         Offset,
         OffsetDateTime,
     )
@@ -83,7 +85,37 @@ class ZonedDateTime:
 
     @property
     def local_date_time(self) -> LocalDateTime:
+        """Gets the local date and time represented by this zoned date and time.
+
+        The returned ``LocalDateTime`` will have the same calendar system and return the same values for each of the
+        calendar properties (Year, MonthOfYear and so on), but will not be associated with any particular time zone.
+
+        :return:
+        """
         return self.__offset_date_time.local_date_time
+
+    @property
+    def date(self) -> LocalDate:
+        """Gets the local date represented by this zoned date and time.
+
+        The returned ``LocalDate`` will have the same calendar system and return the same values for each of the
+        date-based calendar properties (Year, MonthOfYear and so on), but will not be associated with any particular
+        time zone.
+
+        :return: The local date represented by this zoned date and time.
+        """
+        return self.__offset_date_time.date
+
+    @property
+    def time_of_day(self) -> LocalTime:
+        """Gets the time portion of this zoned date and time.
+
+        The returned ``LocalTime`` will return the same values for each of the time-based properties (Hour, Minute and
+        so on), but will not be associated with any particular time zone.
+
+        :return: The time portion of this zoned date and time.
+        """
+        return self.__offset_date_time.time_of_day
 
     @property
     def year(self) -> int:
@@ -106,3 +138,28 @@ class ZonedDateTime:
         :return: The instant corresponding to this value.
         """
         return self.__offset_date_time.to_instant()
+
+    # region Operators
+
+    def __eq__(self, other: object) -> bool:
+        """Implements the operator ==.
+
+        See the type documentation for a description of equality semantics.
+
+        :param other: The object to compare to this one.
+        :return: True if the specified value is a ``ZonedDateTime`` representing the same instant in the same time zone;
+            false otherwise.
+        """
+        if not isinstance(other, ZonedDateTime):
+            return NotImplemented
+        return self.__offset_date_time == other.__offset_date_time and self.__zone == other.__zone
+
+    # endregion
+
+    def to_offset_date_time(self) -> OffsetDateTime:
+        """Constructs an ``OffsetDateTime`` with the same local date and time, and the same offset as this zoned date
+        and time, effectively just "removing" the time zone itself.
+
+        :return: An OffsetDateTime with the same local date/time and offset as this value.
+        """
+        return self.__offset_date_time

--- a/pyoda_time/testing/__init__.py
+++ b/pyoda_time/testing/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+__all__ = [
+    "time_zones",
+    "FakeClock",
+]
+
+from . import time_zones
+from ._fake_clock import FakeClock

--- a/pyoda_time/testing/_fake_clock.py
+++ b/pyoda_time/testing/_fake_clock.py
@@ -1,0 +1,179 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from __future__ import annotations
+
+import threading
+from typing import Final, final
+
+from .._duration import Duration
+from .._i_clock import IClock
+from .._instant import Instant
+from ..utility._csharp_compatibility import _sealed
+
+
+@final
+@_sealed
+class FakeClock(IClock):
+    """Clock which can be constructed with an initial instant, and then advanced programmatically (and optionally,
+    automatically advanced on each read).
+
+    This class is designed to be used when testing classes which take an ``IClock`` as a dependency.
+
+    This class is somewhere between a fake and a stub, depending on how it's used - if it's set to
+    ``auto_advance`` then time will pass, but in a pretty odd way (i.e. dependent on how often it's
+    consulted).
+    """
+
+    __slots__ = (
+        "__lock",
+        "__now",
+        "__auto_advance",
+    )
+
+    def __init__(self, initial: Instant, auto_advance: Duration = Duration.zero) -> None:
+        """Creates a fake clock initially set to the given instant.
+
+        The clock will advance by the given duration on each read, defaulting to ``Duration.zero``.
+
+        :param initial: The initial instant.
+        :param auto_advance: The duration to advance the clock on each read.
+        """
+        self.__lock: Final[threading.Lock] = threading.Lock()
+        self.__now: Instant = initial
+        self.__auto_advance: Duration = auto_advance
+
+    @classmethod
+    def from_utc(
+        cls,
+        year: int,
+        month_of_year: int,
+        day_of_month: int,
+        hour_of_day: int = 0,
+        minute_of_hour: int = 0,
+        second_of_minute: int = 0,
+    ) -> FakeClock:
+        """Returns a fake clock initially set to the given year/month/day/time in UTC in the ISO calendar.
+
+        The value of the ``auto_advance`` property will be initialised to zero.
+
+        :param year: The year. This is the "absolute year", so a value of 0 means 1 BC, for example.
+        :param month_of_year: The month of year.
+        :param day_of_month: The day of month.
+        :param hour_of_day: The hour.
+        :param minute_of_hour: The minute.
+        :param second_of_minute: The second.
+        :return: A ``FakeClock`` initialised to the given instant, with no auto-advance.
+        """
+        return cls(Instant.from_utc(year, month_of_year, day_of_month, hour_of_day, minute_of_hour, second_of_minute))
+
+    def advance(self, duration: Duration) -> None:
+        """Advances the clock by the given duration.
+
+        :param duration: The duration to advance the clock by (or if negative, the duration to move it back by).
+        """
+        with self.__lock:
+            self.__now += duration
+
+    def advance_nanoseconds(self, nanoseconds: int) -> None:
+        """Advances the clock by the given number of nanoseconds.
+
+        :param nanoseconds: The number of nanoseconds to advance the clock by (or if negative, the number to move it
+            back by).
+        """
+        with self.__lock:
+            self.advance(Duration.from_nanoseconds(nanoseconds))
+
+    def advance_ticks(self, ticks: int) -> None:
+        """Advances the clock by the given number of ticks.
+
+        :param ticks: The number of ticks to advance the clock by (or if negative, the number to move it back by).
+        """
+        with self.__lock:
+            self.advance(Duration.from_ticks(ticks))
+
+    def advance_milliseconds(self, milliseconds: int) -> None:
+        """Advances the clock by the given number of milliseconds.
+
+        :param milliseconds: The number of milliseconds to advance the clock by (or if negative, the number to move it
+            back by).
+        """
+        with self.__lock:
+            self.advance(Duration.from_milliseconds(milliseconds))
+
+    def advance_seconds(self, seconds: int) -> None:
+        """Advances the clock by the given number of seconds.
+
+        :param seconds: The number of seconds to advance the clock by (or if negative, the number to move it back by).
+        """
+        with self.__lock:
+            self.advance(Duration.from_seconds(seconds))
+
+    def advance_minutes(self, minutes: int) -> None:
+        """Advances the clock by the given number of minutes.
+
+        :param minutes: The number of minutes to advance the clock by (or if negative, the number to move it back by).
+        """
+        with self.__lock:
+            self.advance(Duration.from_minutes(minutes))
+
+    def advance_hours(self, hours: int) -> None:
+        """Advances the clock by the given number of hours.
+
+        :param hours: The number of hours to advance the clock by (or if negative, the number to move it back by).
+        """
+        with self.__lock:
+            self.advance(Duration.from_hours(hours))
+
+    def advance_days(self, days: int) -> None:
+        """Advances the clock by the given number of days.
+
+        :param days: The number of days to advance the clock by (or if negative, the number to move it back by).
+        """
+        with self.__lock:
+            self.advance(Duration.from_days(days))
+
+    def reset(self, instant: Instant) -> None:
+        """Resets the clock to the given instant.
+
+        The value of the ``auto_advance`` property will be unchanged.
+
+        :param instant: The instant to set the clock to.
+        """
+        with self.__lock:
+            self.__now = instant
+
+    def get_current_instant(self) -> Instant:
+        """Returns the "current time" for this clock.
+
+        Unlike a normal clock, this property may return the same value from repeated calls until one of the methods to
+        change the time is called.
+
+        If the value of the ``auto_advance`` property is non-zero, then every call to this method will advance the
+        current time by that value.
+
+        :return: The "current time" from this (fake) clock.
+        """
+        with self.__lock:
+            then = self.__now
+            self.__now += self.__auto_advance
+            return then
+
+    @property
+    def auto_advance(self) -> Duration:
+        """Gets/Sets the amount of time to advance the clock by on each call to read the current time.
+
+        If this is ``Duration.zero``, the current time as reported by this clock will not change other than by calls to
+        ``reset`` or to one of the ``advance`` methods.
+
+        The value could even be negative, to simulate particularly odd system clock effects.
+
+        :return: The amount of time to advance the clock by on each call to read the current time.
+        """
+        with self.__lock:
+            return self.__auto_advance
+
+    @auto_advance.setter
+    def auto_advance(self, value: Duration) -> None:
+        with self.__lock:
+            self.__auto_advance = value

--- a/pyoda_time/testing/time_zones/__init__.py
+++ b/pyoda_time/testing/time_zones/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+__all__ = ["SingleTransitionDateTimeZone"]
+
+from ._single_transition_date_time_zone import SingleTransitionDateTimeZone

--- a/pyoda_time/testing/time_zones/_single_transition_date_time_zone.py
+++ b/pyoda_time/testing/time_zones/_single_transition_date_time_zone.py
@@ -1,10 +1,19 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-from pyoda_time import DateTimeZone, Instant, Offset
+from __future__ import annotations
+
+from typing import final
+
+from pyoda_time._date_time_zone import DateTimeZone
+from pyoda_time._instant import Instant
+from pyoda_time._offset import Offset
 from pyoda_time.time_zones import ZoneInterval
+from pyoda_time.utility._csharp_compatibility import _sealed
 
 
+@final
+@_sealed
 class SingleTransitionDateTimeZone(DateTimeZone):
     """Time zone with a single transition between two offsets.
 

--- a/pyoda_time/time_zones/_date_time_zone_cache.py
+++ b/pyoda_time/time_zones/_date_time_zone_cache.py
@@ -1,16 +1,19 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-from typing import Final, Iterable, final
+from __future__ import annotations
 
-from .._date_time_zone import DateTimeZone
+from typing import TYPE_CHECKING, Final, Iterable, final
+
 from .._i_date_time_zone_provider import IDateTimeZoneProvider
 from ..utility._csharp_compatibility import _sealed
 from ..utility._preconditions import _Preconditions
 from ._date_time_zone_not_found_error import DateTimeZoneNotFoundError
-from ._fixed_date_time_zone import _FixedDateTimeZone
-from ._i_date_time_zone_source import IDateTimeZoneSource
 from ._invalid_date_time_zone_source_error import InvalidDateTimeZoneSourceError
+
+if TYPE_CHECKING:
+    from .._date_time_zone import DateTimeZone
+    from ._i_date_time_zone_source import IDateTimeZoneSource
 
 
 @final
@@ -92,6 +95,8 @@ class DateTimeZoneCache(IDateTimeZoneProvider):
 
     def __getitem__(self, zone_id: str) -> DateTimeZone:
         if (zone := self.get_zone_or_none(zone_id)) is None:
+            from pyoda_time.time_zones._fixed_date_time_zone import _FixedDateTimeZone
+
             if (zone := _FixedDateTimeZone._get_fixed_zone_or_null(zone_id)) is None:
                 raise DateTimeZoneNotFoundError(f"Time zone {zone_id} is unknown to source {self.version_id}")
         return zone

--- a/pyoda_time/time_zones/_i_date_time_zone_source.py
+++ b/pyoda_time/time_zones/_i_date_time_zone_source.py
@@ -1,9 +1,12 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
-from typing import Iterable, Protocol
+from __future__ import annotations
 
-from pyoda_time._date_time_zone import DateTimeZone
+from typing import TYPE_CHECKING, Iterable, Protocol
+
+if TYPE_CHECKING:
+    from pyoda_time._date_time_zone import DateTimeZone
 
 
 class IDateTimeZoneSource(Protocol):

--- a/tests/extensions/__init__.py
+++ b/tests/extensions/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
+

--- a/tests/extensions/test_clock_extensions.py
+++ b/tests/extensions/test_clock_extensions.py
@@ -1,0 +1,33 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Final
+
+from pyoda_time import CalendarSystem, DateTimeZone, DateTimeZoneProviders, PyodaConstants
+from pyoda_time.testing import FakeClock
+
+NEW_YORK: Final[DateTimeZone] = DateTimeZoneProviders.tzdb["America/New_York"]
+
+
+class TestClockExtensions:
+    def test_in_zone_no_calendar(self) -> None:
+        clock = FakeClock(PyodaConstants.UNIX_EPOCH)
+        zoned = clock.in_zone(NEW_YORK)
+        zone_epoch = PyodaConstants.UNIX_EPOCH.in_zone(NEW_YORK)
+        assert zoned.get_current_zoned_date_time() == zone_epoch
+
+    def test_in_zone_with_calendar(self) -> None:
+        clock = FakeClock(PyodaConstants.UNIX_EPOCH)
+        zoned = clock.in_zone(NEW_YORK, CalendarSystem.julian)
+        zone_epoch = PyodaConstants.UNIX_EPOCH.in_zone(NEW_YORK, CalendarSystem.julian)
+        assert zoned.get_current_zoned_date_time() == zone_epoch
+
+    def test_in_utc(self) -> None:
+        clock = FakeClock(PyodaConstants.UNIX_EPOCH)
+        zoned = clock.in_utc()
+        zone_epoch = PyodaConstants.UNIX_EPOCH.in_utc()
+        assert zoned.get_current_zoned_date_time() == zone_epoch
+
+    # TODO:
+    #  def test_in_tzdb_system_default_zone(self) -> None:
+    #  def test_in_bcl_system_default_zone(self) -> None:

--- a/tests/test_comparison_operator_consistency.py
+++ b/tests/test_comparison_operator_consistency.py
@@ -25,6 +25,7 @@ from pyoda_time import (
     OffsetDateTime,
     OffsetTime,
     Period,
+    SystemClock,
     YearMonth,
 )
 from pyoda_time._calendar_ordinal import _CalendarOrdinal
@@ -64,6 +65,7 @@ VALUES = [
     YearMonth(year=1, month=1),
     _YearMonthDay._ctor(raw_value=1),
     _YearMonthDayCalendar._ctor(year_month_day=1, calendar_ordinal=_CalendarOrdinal.BADI),
+    SystemClock.instance.in_utc().get_current_zoned_date_time(),  # ZonedDateTime
     ZoneInterval(name="", start=Instant.min_value, end=Instant.max_value, wall_offset=Offset.zero, savings=Offset.zero),
     _ZoneRecurrence(
         "name",

--- a/tests/test_system_clock.py
+++ b/tests/test_system_clock.py
@@ -1,0 +1,43 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from datetime import datetime, timezone
+from random import Random
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from pyoda_time import Duration, Instant, PyodaConstants, SystemClock
+from pyoda_time.utility._csharp_compatibility import _to_ticks
+
+
+@patch("pyoda_time._system_clock.time")
+def test_get_current_instant(mock_time: MagicMock) -> None:
+    random: Random = Random(str(uuid4()))
+    nanoseconds = random.randint(0, (Instant.max_value - PyodaConstants.UNIX_EPOCH).to_nanoseconds())
+    mock_time.time_ns.return_value = nanoseconds
+
+    current_instant = SystemClock.instance.get_current_instant()
+
+    assert (current_instant - PyodaConstants.UNIX_EPOCH).to_nanoseconds() == nanoseconds
+    mock_time.time_ns.assert_called_once_with()
+
+
+def test_construction_raises() -> None:
+    with pytest.raises(TypeError) as e:
+        SystemClock()
+    assert str(e.value) == "SystemClock is not intended to be initialised directly."
+
+
+class TestSystemClock:
+    def test_instance_now(self) -> None:
+        stdlib_now_ticks = _to_ticks(datetime.now(tz=timezone.utc))
+        pyoda_ticks = SystemClock.instance.get_current_instant().to_unix_time_ticks()
+        assert (pyoda_ticks - stdlib_now_ticks) < Duration.from_seconds(1).bcl_compatible_ticks
+
+    def test_sanity(self) -> None:
+        minimum_expected = Instant.from_utc(2019, 8, 1, 0, 0)
+        maximum_expected = Instant.from_utc(2025, 1, 1, 0, 0)
+        now = SystemClock.instance.get_current_instant()
+        assert minimum_expected.to_unix_time_ticks() < now.to_unix_time_ticks() < maximum_expected.to_unix_time_ticks()

--- a/tests/test_zoned_clock.py
+++ b/tests/test_zoned_clock.py
@@ -1,0 +1,44 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Final
+
+from pyoda_time import (
+    CalendarSystem,
+    DateTimeZone,
+    LocalDate,
+    LocalDateTime,
+    LocalTime,
+    Offset,
+    PyodaConstants,
+    ZonedDateTime,
+)
+from pyoda_time.testing import FakeClock
+from pyoda_time.testing.time_zones import SingleTransitionDateTimeZone
+
+SAMPLE_ZONE: Final[DateTimeZone] = SingleTransitionDateTimeZone(PyodaConstants.UNIX_EPOCH, 1, 2)
+
+
+class TestZonedClock:
+    def test_get_current(self) -> None:
+        julian = CalendarSystem.julian
+        underlying_clock = FakeClock(PyodaConstants.UNIX_EPOCH)
+        zoned_clock = underlying_clock.in_zone(SAMPLE_ZONE, julian)
+        assert zoned_clock.get_current_instant() == PyodaConstants.UNIX_EPOCH
+        assert zoned_clock.get_current_zoned_date_time() == ZonedDateTime(
+            instant=underlying_clock.get_current_instant(), zone=SAMPLE_ZONE, calendar=julian
+        )
+        assert zoned_clock.get_current_local_date_time() == LocalDateTime(1969, 12, 19, 2, 0, calendar=julian)
+        assert zoned_clock.get_current_offset_date_time() == LocalDateTime(
+            1969, 12, 19, 2, 0, calendar=julian
+        ).with_offset(Offset.from_hours(2))
+        assert zoned_clock.get_current_date() == LocalDate(1969, 12, 19, julian)
+        assert zoned_clock.get_curent_time_of_day() == LocalTime(2, 0, 0)
+
+    def test_properties(self) -> None:
+        calendar = CalendarSystem.julian
+        clock = FakeClock(PyodaConstants.UNIX_EPOCH)
+        zoned_clock = clock.in_zone(SAMPLE_ZONE, calendar)
+        assert zoned_clock.clock is clock
+        assert zoned_clock.calendar is calendar
+        assert zoned_clock.zone is SAMPLE_ZONE

--- a/tests/time_zones/test_date_time_zone_cache.py
+++ b/tests/time_zones/test_date_time_zone_cache.py
@@ -7,6 +7,7 @@ import pytest
 
 from pyoda_time import DateTimeZone, Offset, PyodaConstants
 from pyoda_time._date_time_zone_providers import DateTimeZoneProviders
+from pyoda_time.testing.time_zones import SingleTransitionDateTimeZone
 from pyoda_time.time_zones import (
     DateTimeZoneCache,
     DateTimeZoneNotFoundError,
@@ -14,8 +15,6 @@ from pyoda_time.time_zones import (
     InvalidDateTimeZoneSourceError,
 )
 from pyoda_time.utility._csharp_compatibility import _csharp_modulo
-
-from ..testing.single_transition_date_time_zone import SingleTransitionDateTimeZone
 
 
 class DummyDateTimeZoneSource(IDateTimeZoneSource):

--- a/tests/time_zones/test_precalculated_date_time_zone.py
+++ b/tests/time_zones/test_precalculated_date_time_zone.py
@@ -6,6 +6,7 @@ import io
 import pytest
 
 from pyoda_time import DateTimeZone, Duration, Instant, LocalDateTime, LocalTime, Offset
+from pyoda_time.testing.time_zones import SingleTransitionDateTimeZone
 from pyoda_time.time_zones import ZoneInterval
 from pyoda_time.time_zones._fixed_date_time_zone import _FixedDateTimeZone
 from pyoda_time.time_zones._precalculated_date_time_zone import _PrecalculatedDateTimeZone
@@ -16,8 +17,6 @@ from pyoda_time.time_zones._zone_year_offset import _ZoneYearOffset
 from pyoda_time.time_zones.io._date_time_zone_reader import _DateTimeZoneReader
 from pyoda_time.time_zones.io._date_time_zone_writer import _DateTimeZoneWriter
 from pyoda_time.utility._csharp_compatibility import _CsharpConstants
-
-from ..testing.single_transition_date_time_zone import SingleTransitionDateTimeZone
 
 FIRST_INTERVAL = ZoneInterval(
     name="First",


### PR DESCRIPTION
The `SystemClock` implementation here uses `time.time_ns()`, so is operating at a finer resolution (nanoseconds) than Noda Time's implementation which uses `DateTime.UtcNow.Ticks`. Not that it probably makes any difference; I could well see the relatively slow execution of pure python code eating up the duration of 1 tick in the real world.

This also moves /tests/testing into /pyoda_time/testing. Because the `NodaTime.Testing` library is public, and we (like Noda Time) advertise `FakeClock` as a thing that people might use. Rather than releasing a separate package, we'll just include it as a sub-package in the main project.