### PR TITLE
fix: stdblib conversions for `Duration`

### DIFF
--- a/pyoda_time/_duration.py
+++ b/pyoda_time/_duration.py
@@ -864,18 +864,15 @@ class Duration(metaclass=_DurationMeta):
     def to_timedelta(self) -> datetime.timedelta:
         """Returns a ``datetime.timedelta`` that represents the same number of microseconds as this ``Duration``.
 
-        If the number of nanoseconds in a duration is not a whole number of microseconds, it will be
-        passed to ``datetime.timedelta()`` as a fractional argument, and will be subject to the internal
-        summing/rounding behaviour documented at https://docs.python.org/3/library/datetime.html#datetime.timedelta.
-
-        If the duration can be resolved to a whole number of microseconds, then the conversion should not lose
-        information.
+        If the number of nanoseconds in a duration is not a whole number of microseconds, it will be truncated towards
+        zero. For instance, durations in the range [-999, 999] would all count as 0 microseconds.
 
         :return: A new TimeSpan with the same number of ticks as this Duration.
         """
 
         return datetime.timedelta(
-            days=self.__days, microseconds=self.__nano_of_day / PyodaConstants.NANOSECONDS_PER_MICROSECOND
+            days=self.days,
+            microseconds=_towards_zero_division(self.nanosecond_of_day, PyodaConstants.NANOSECONDS_PER_MICROSECOND),
         )
 
     def to_nanoseconds(self) -> int:

--- a/tests/test_duration.py
+++ b/tests/test_duration.py
@@ -16,6 +16,32 @@ from tests import helpers
 T = TypeVar("T")
 
 
+@pytest.mark.parametrize(
+    "duration_nanoseconds,timedelta_microseconds",
+    [
+        (1, 0),
+        (999, 0),
+        (1000, 1),
+        (1001, 1),
+        (1999, 1),
+        (2000, 2),
+        (2001, 2),
+        (-1, 0),
+        (-999, 0),
+        (-1000, -1),
+        (-1001, -1),
+        (-1999, -1),
+        (-2000, -2),
+        (-2001, -2),
+    ],
+)
+def test_to_timedelta_truncates_towards_zero(duration_nanoseconds: int, timedelta_microseconds: int) -> None:
+    expected = timedelta(microseconds=timedelta_microseconds)
+    actual = Duration.from_nanoseconds(duration_nanoseconds).to_timedelta()
+
+    assert actual == expected
+
+
 class TestDuration:
     def test_default_constructor(self) -> None:
         """Using the default constructor is equivalent to Duration.Zero."""


### PR DESCRIPTION
See #160 

Fixes the behaviour of `Duration.to_timedelta()` so that it now truncates towards zero if not on a microsecond boundary, rather than the conversion delegating to the internal rounding behaviour of the standard library.