### PR TITLE
feat: stdlib conversions for `LocalDateTime`

### DIFF
--- a/pyoda_time/_local_date.py
+++ b/pyoda_time/_local_date.py
@@ -189,6 +189,16 @@ class LocalDate(metaclass=_LocalDateMeta):
     def _year_month_day(self) -> _YearMonthDay:
         return self.__year_month_day_calendar._to_year_month_day()
 
+    def at_midnight(self) -> LocalDateTime:
+        """Gets a ``LocalDateTime`` at midnight on the date represented by this local date.
+
+        :return: The ``LocalDateTime`` representing midnight on this local date, in the same calendar system.
+        """
+        from ._local_date_time import LocalDateTime
+        from ._local_time import LocalTime
+
+        return LocalDateTime._ctor(local_date=self, local_time=LocalTime.midnight)
+
     @classmethod
     def from_week_year_week_and_day(
         cls, week_year: int, week_of_week_year: int, day_of_week: IsoDayOfWeek

--- a/pyoda_time/_local_date_time.py
+++ b/pyoda_time/_local_date_time.py
@@ -212,6 +212,11 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
 
         gregorian = self.with_calendar(CalendarSystem.gregorian)
 
+        # In Noda Time, they measure the ticks since the BCL epoch here and throw if < 0.
+        # This is a bit simpler...
+        if gregorian.year <= datetime.datetime.min.year:
+            raise RuntimeError("LocalDateTime out of range of datetime")
+
         return datetime.datetime(
             year=gregorian.year,
             month=gregorian.month,

--- a/pyoda_time/_local_date_time.py
+++ b/pyoda_time/_local_date_time.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING, final, overload
 
 from ._calendar_system import CalendarSystem
-from .utility._csharp_compatibility import _sealed
+from .utility._csharp_compatibility import _sealed, _to_ticks
 from .utility._preconditions import _Preconditions
+from .utility._tick_arithmetic import _TickArithmetic
 
 if TYPE_CHECKING:
     from . import Offset, OffsetDateTime, Period, ZonedDateTime
@@ -157,6 +159,11 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
         return self.__time.millisecond
 
     @property
+    def microsecond(self) -> int:
+        """The microsecond of this local date and time within the second, in the range 0 to 999,999 inclusive."""
+        return self.__time.microsecond
+
+    @property
     def tick_of_second(self) -> int:
         """The tick of this local time within the second, in the range 0 to 9,999,999 inclusive."""
         return self.__time.tick_of_second
@@ -186,7 +193,34 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
         """The date portion of this local date and time as a ``LocalDate``."""
         return self.__date
 
-    # TODO def to_datetime_unspecified(self):
+    def to_naive_datetime(self) -> datetime.datetime:
+        """Constructs a naive ``datetime.datetime`` from this value.
+
+        If the date and time is not on a microsecond boundary (the unit of granularity of ``datetime.datetime``) the
+        value will be truncated towards the start of time.
+
+        ``datetime.datetime`` uses the Gregorian calendar by definition, so the value is implicitly converted
+        to the Gregorian calendar first. The result will be on the same physical day,
+        but the values returned by the Year/Month/Day properties of the ``datetime.datetime`` may not
+        match the Year/Month/Day properties of this value.
+
+        :return: A ``datetime.datetime`` for the same date and time as this value.
+        """
+        # Implementation note:
+        # This function is intended to be roughly equivalent to ``LocalDateTime.ToDateTimeUnspecified()`` in Noda Time.
+        # But the way in which they are implemented is quite different.
+
+        gregorian = self.with_calendar(CalendarSystem.gregorian)
+
+        return datetime.datetime(
+            year=gregorian.year,
+            month=gregorian.month,
+            day=gregorian.day,
+            hour=gregorian.hour,
+            minute=gregorian.minute,
+            second=gregorian.second,
+            microsecond=gregorian.microsecond,
+        )
 
     def _to_local_instant(self) -> _LocalInstant:
         from ._local_instant import _LocalInstant
@@ -267,11 +301,35 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
 
         return _TimePeriodField._nanoseconds._add_local_date_time(self, nanoseconds)
 
-    # @classmethod
-    # TODO: def from_datetime(cls, datetime: _datetime.datetime) -> LocalDateTime:
+    @classmethod
+    def from_naive_datetime(cls, dt: datetime.datetime, calendar: CalendarSystem = CalendarSystem.iso) -> LocalDateTime:
+        """Converts a timezone-naive ``datetime.datetime`` to a ``LocalDateTime``, optionally in a specified calendar.
 
-    # @classmethod
-    # TODO: def from_datetime(cls, datetime: _datetime.datetime, calendar: CalendarSystem) -> LocalDateTime:
+        :param dt: Timezone-naive datetime to convert into a Pyoda Time local date and time.
+        :param calendar: The calendar system to convert into.
+        :return: A new ``LocalDateTime`` with the same values as the specified ``datetime.datetime``.
+        :raises ValueError: If ``dt`` is a timezone-aware ``datetime.datetime``.
+        """
+        # Unlike Noda Time, we need to verify the tzinfo of the datetime.
+        # In C#, DateTime doesn't have this...
+        # They have DateTimeKind, but that is irrelevant.
+        # What is important is that it is a DateTime, not a DateTimeOffset.
+
+        _Preconditions._check_argument(
+            expession=dt.tzinfo is None,
+            parameter="datetime",
+            message="Invalid datetime.tzinfo for LocalDateTime.from_datetime_utc",
+        )
+        from pyoda_time._local_date import LocalDate
+        from pyoda_time._local_time import LocalTime
+        from pyoda_time._pyoda_constants import PyodaConstants
+
+        days, tick_of_day = _TickArithmetic.ticks_to_days_and_tick_of_day(_to_ticks(dt))
+        days -= PyodaConstants._BCL_DAYS_AT_UNIX_EPOCH
+        return cls._ctor(
+            local_date=LocalDate._ctor(days_since_epoch=days, calendar=calendar),
+            local_time=LocalTime._ctor(nanoseconds=tick_of_day * PyodaConstants.NANOSECONDS_PER_TICK),
+        )
 
     # region Implementation of IEquatable<LocalDateTime>
 

--- a/pyoda_time/_local_time.py
+++ b/pyoda_time/_local_time.py
@@ -345,6 +345,13 @@ class LocalTime(metaclass=_LocalTimeMeta):
         return _csharp_modulo(millisecond_of_day, PyodaConstants.MILLISECONDS_PER_SECOND)
 
     @property
+    def microsecond(self) -> int:
+        """The microsecond of this local time within the second, in the range 0 to 999,999 inclusive."""
+        # TODO: unchecked
+        microsecond_of_day = _towards_zero_division(self.__nanoseconds, PyodaConstants.NANOSECONDS_PER_MICROSECOND)
+        return _csharp_modulo(microsecond_of_day, PyodaConstants.MICROSECONDS_PER_SECOND)
+
+    @property
     def tick_of_second(self) -> int:
         """The tick of this local time within the second, in the range 0 to 9,999,999 inclusive."""
         # TODO: unchecked

--- a/pyoda_time/_pyoda_constants.py
+++ b/pyoda_time/_pyoda_constants.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
+from zoneinfo import ZoneInfo
+
 if TYPE_CHECKING:
     from . import Instant
 
@@ -68,6 +70,10 @@ class PyodaConstants(metaclass=_PyodaConstantsMeta):
     TICKS_PER_HOUR: Final[int] = TICKS_PER_MINUTE * MINUTES_PER_HOUR
     TICKS_PER_DAY: Final[int] = TICKS_PER_HOUR * HOURS_PER_DAY
     TICKS_PER_WEEK: Final[int] = TICKS_PER_DAY * DAYS_PER_WEEK
+    _BCL_TICKS_AT_UNIX_EPOCH: Final[int] = 621355968000000000
+    """The number of ticks in a BCL DateTime at the Unix epoch."""
+    _BCL_DAYS_AT_UNIX_EPOCH: Final[int] = 719162
+    """The number of days in a BCL DateTime at the Unix epoch."""
 
     # Constants which are specific to Pyoda Time
     NANOSECONDS_PER_MICROSECOND: Final[int] = 1000
@@ -78,3 +84,4 @@ class PyodaConstants(metaclass=_PyodaConstantsMeta):
     MICROSECONDS_PER_HOUR: Final[int] = MICROSECONDS_PER_MINUTE * MINUTES_PER_HOUR
     MICROSECONDS_PER_DAY: Final[int] = MICROSECONDS_PER_HOUR * HOURS_PER_DAY
     MICROSECONDS_PER_WEEK: Final[int] = MICROSECONDS_PER_DAY * DAYS_PER_WEEK
+    _UTC_ZONE_INFO: Final[ZoneInfo] = ZoneInfo("UTC")

--- a/tests/test_local_date_time.py
+++ b/tests/test_local_date_time.py
@@ -37,9 +37,9 @@ class TestLocalDateTime:
 
     def test_to_naive_datetime_out_of_range(self) -> None:
         ldt = LocalDate(datetime.min.year, datetime.min.month, datetime.min.day).plus_days(-1).at_midnight()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(RuntimeError) as e:
             ldt.to_naive_datetime()
-        assert str(e.value) == "year 0 is out of range"
+        assert str(e.value) == "LocalDateTime out of range of datetime"
 
     def test_from_naive_datetime(self) -> None:
         expected = LocalDateTime(2011, 8, 18, 20, 53)

--- a/tests/test_local_date_time.py
+++ b/tests/test_local_date_time.py
@@ -1,11 +1,66 @@
 # Copyright 2024 The Pyoda Time Authors. All rights reserved.
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
+from datetime import UTC, datetime, timedelta, timezone
 
-from pyoda_time import LocalDateTime
+import pytest
+from zoneinfo import ZoneInfo
+
+from pyoda_time import CalendarSystem, DateTimeZone, DateTimeZoneProviders, LocalDate, LocalDateTime, PyodaConstants
+
+PACIFIC: DateTimeZone = DateTimeZoneProviders.tzdb["America/Los_Angeles"]
 
 
 class TestLocalDateTime:
+    def test_to_naive_datetime(self) -> None:
+        """Equivalent to ``LocalDateTime.ToDateTimeUnspecified()`` in Noda Time."""
+        ldt = LocalDateTime(2011, 3, 5, 1, 0, 0)
+        expected = datetime(2011, 3, 5, 1, 0, 0)
+        actual = ldt.to_naive_datetime()
+        assert actual == expected
+        assert actual.tzinfo is None
+
+    def test_to_naive_datetime_julian_calendar(self) -> None:
+        ldt = LocalDateTime(2011, 3, 5, 1, 0, 0, calendar=CalendarSystem.julian)
+        expected = datetime(2011, 3, 18, 1, 0, 0)
+        actual = ldt.to_naive_datetime()
+        assert actual == expected
+        assert actual.tzinfo is None
+
+    @pytest.mark.parametrize("year", (100, 1900, 2900))
+    def test_to_naive_datetime_truncates_towards_start_of_time(self, year: int) -> None:
+        ldt = LocalDateTime(year, 1, 1, 13, 15, 55).plus_nanoseconds(PyodaConstants.NANOSECONDS_PER_SECOND - 1)
+        expected = datetime(year, 1, 1, 13, 15, 55) + timedelta(microseconds=PyodaConstants.MICROSECONDS_PER_SECOND - 1)
+        actual = ldt.to_naive_datetime()
+        assert actual == expected
+        assert actual.tzinfo is None
+
+    def test_to_naive_datetime_out_of_range(self) -> None:
+        ldt = LocalDate(datetime.min.year, datetime.min.month, datetime.min.day).plus_days(-1).at_midnight()
+        with pytest.raises(ValueError) as e:
+            ldt.to_naive_datetime()
+        assert str(e.value) == "year 0 is out of range"
+
+    def test_from_naive_datetime(self) -> None:
+        expected = LocalDateTime(2011, 8, 18, 20, 53)
+        actual = LocalDateTime.from_naive_datetime(datetime(2011, 8, 18, 20, 53))
+        assert actual == expected
+
+    def test_from_naive_datetime_with_calendar(self) -> None:
+        # Julian calendar is 13 days behind Gregorian calendar in the 21st century
+        expected = LocalDateTime(2011, 8, 5, 20, 53, calendar=CalendarSystem.julian)
+        actual = LocalDateTime.from_naive_datetime(datetime(2011, 8, 18, 20, 53), CalendarSystem.julian)
+        assert actual == expected
+
+    @pytest.mark.parametrize("tzinfo", (UTC, ZoneInfo("UTC"), ZoneInfo("Europe/London")))
+    def test_from_naive_datetime_raises_for_aware_datetime(self, tzinfo: timezone | ZoneInfo) -> None:
+        """This test doesn't exist in Noda Time, becase in C# DateTime does not have a tzinfo equivalent."""
+        dt = datetime(2024, 6, 4, 23, 5, tzinfo=tzinfo)
+        with pytest.raises(ValueError) as e:
+            LocalDateTime.from_naive_datetime(dt)
+        assert str(e.value) == "Invalid datetime.tzinfo for LocalDateTime.from_datetime_utc"
+        assert e.value.__notes__ == ["Parameter name: datetime"]
+
     def test_default_constructor(self) -> None:
         """Using the default constructor is equivalent to January 1st 1970, midnight, UTC, ISO calendar."""
         actual = LocalDateTime()


### PR DESCRIPTION
See #160 

Noda Time has `FromDateTime` and `ToDateTimeUnspecified`.

Owing to the differences between Python's `datetime` and dotnet's `DateTime`, the equivalent methods in Python are `from_naive_datetime` and `to_naive_datetime`.