### PR TITLE
build: don't update the project in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Set up Python
         run: uv python install
 
-      - name: Install the project
-        run: uv sync --all-extras --dev
-
       - name: Run tests
         run: uv run pytest --cov . --cov-report xml -n auto
 
@@ -49,9 +46,6 @@ jobs:
       - name: Set up Python
         run: uv python install
 
-      - name: Install the project
-        run: uv sync --all-extras --dev
-
       - name: Run pre-commit hooks
         run: uv run pre-commit run -a
 
@@ -69,9 +63,6 @@ jobs:
 
       - name: Set up Python
         run: uv python install
-
-      - name: Install the project
-        run: uv sync --all-extras --dev
 
       - name: Generate html docs
         run: make docs.sphinx.html


### PR DESCRIPTION
Amongst other things, this modifies the uv.lock which interferes with checks for modified files.