### PR TITLE
feat: implement resolvers

### DIFF
--- a/pyoda_time/_offset_date_time.py
+++ b/pyoda_time/_offset_date_time.py
@@ -75,6 +75,14 @@ class OffsetDateTime:
         raise TypeError
 
     @property
+    def calendar(self) -> CalendarSystem:
+        """Gets the calendar system associated with this offset date and time.
+
+        :return: The calendar system associated with this offset date and time.
+        """
+        return self.__local_date.calendar
+
+    @property
     def year(self) -> int:
         """Gets the year of this offset date and time.
 
@@ -86,23 +94,55 @@ class OffsetDateTime:
 
     @property
     def nanosecond_of_day(self) -> int:
+        """Gets the nanosecond of this offset date and time within the day, in the range 0 to 86,399,999,999,999
+        inclusive.
+
+        :return: The nanosecond of this offset date and time within the day, in the range 0 to 86,399,999,999,999
+            inclusive.
+        """
         return self.__offset_time.nanosecond_of_day
 
     @property
     def local_date_time(self) -> LocalDateTime:
+        """Returns the local date and time represented within this offset date and time.
+
+        :return: The local date and time represented within this offset date and time.
+        """
         from . import LocalDateTime
 
         return LocalDateTime._ctor(local_date=self.date, local_time=self.time_of_day)
 
     @property
     def date(self) -> LocalDate:
+        """Gets the local date represented by this offset date and time.
+
+        The returned `LocalDate` will have the same calendar system and return the same values for each of the
+        date-based calendar properties (Year, MonthOfYear and so on), but will not have any offset information.
+
+        :return: The local date represented by this offset date and time.
+        """
         return self.__local_date
 
     @property
     def time_of_day(self) -> LocalTime:
+        """Gets the time portion of this offset date and time.
+
+        The returned `LocalTime` will return the same values for each of the time-based properties (Hour, Minute and
+        so on), but will not have any offset information.
+
+        :return: The time portion of this offset date and time.
+        """
         from . import LocalTime
 
         return LocalTime._ctor(nanoseconds=self.nanosecond_of_day)
+
+    @property
+    def offset(self) -> Offset:
+        """Gets the offset from UTC.
+
+        :return: The offset from UTC.
+        """
+        return self.__offset_time.offset
 
     def to_instant(self) -> Instant:
         """Converts this offset date and time to an instant in time by subtracting the offset from the local date and

--- a/pyoda_time/_skipped_time_error.py
+++ b/pyoda_time/_skipped_time_error.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, final
 
-from pyoda_time.utility._csharp_compatibility import _private, _sealed
+from pyoda_time.utility._csharp_compatibility import _sealed
 from pyoda_time.utility._preconditions import _Preconditions
 
 if TYPE_CHECKING:
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 @final
 @_sealed
-@_private
 class SkippedTimeError(ValueError):
     """Exception thrown to indicate that the specified local time doesn't exist in a particular time zone due to
     daylight saving time changes.

--- a/pyoda_time/_system_clock.py
+++ b/pyoda_time/_system_clock.py
@@ -42,6 +42,8 @@ class SystemClock(IClock, metaclass=__SystemClockMeta):
     your application, which should only depend on the interface.
     """
 
+    instance: SystemClock
+
     def get_current_instant(self) -> Instant:
         """Gets the current time as an ``Instant``.
 

--- a/pyoda_time/_zoned_date_time.py
+++ b/pyoda_time/_zoned_date_time.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, overload
 
-from .utility._preconditions import _Preconditions
+from pyoda_time._duration import Duration
+from pyoda_time.utility._preconditions import _Preconditions
 
 if TYPE_CHECKING:
     from . import (
@@ -76,6 +77,11 @@ class ZonedDateTime:
         self.__zone: DateTimeZone = _Preconditions._check_not_null(zone, "zone")
 
     @property
+    def offset(self) -> Offset:
+        """The offset of the local representation of this value from UTC."""
+        return self.__offset_date_time.offset
+
+    @property
     def zone(self) -> DateTimeZone:
         """Gets the time zone associated with this value.
 
@@ -92,9 +98,17 @@ class ZonedDateTime:
         The returned ``LocalDateTime`` will have the same calendar system and return the same values for each of the
         calendar properties (Year, MonthOfYear and so on), but will not be associated with any particular time zone.
 
-        :return:
+        :return: The local date and time represented by this zoned date and time.
         """
         return self.__offset_date_time.local_date_time
+
+    @property
+    def calendar(self) -> CalendarSystem:
+        """Gets the calendar system associated with this zoned date and time.
+
+        :return: The calendar system associated with this zoned date and time.
+        """
+        return self.__offset_date_time.calendar
 
     @property
     def date(self) -> LocalDate:
@@ -155,6 +169,20 @@ class ZonedDateTime:
         if not isinstance(other, ZonedDateTime):
             return NotImplemented
         return self.__offset_date_time == other.__offset_date_time and self.__zone == other.__zone
+
+    def __add__(self, other: Duration) -> ZonedDateTime:
+        """Returns a new ``ZonedDateTime`` with the time advanced by the given duration.
+
+        Note that due to daylight saving time changes this may not advance the local time by the same amount.
+
+        The returned value retains the calendar system and time zone of ``self``.
+
+        :param other: The duration to add.
+        :return: A new value with the time advanced by the given duration, in the same calendar system and time zone.
+        """
+        if not isinstance(other, Duration):
+            return NotImplemented  # type: ignore[unreachable]
+        return ZonedDateTime(instant=self.to_instant() + other, zone=self.zone, calendar=self.calendar)
 
     # endregion
 

--- a/pyoda_time/time_zones/__init__.py
+++ b/pyoda_time/time_zones/__init__.py
@@ -3,14 +3,18 @@
 # as found in the LICENSE.txt file.
 
 __all__ = [
+    "AmbiguousTimeResolver",
     "DateTimeZoneCache",
     "DateTimeZoneNotFoundError",
     "IDateTimeZoneSource",
     "InvalidDateTimeZoneSourceError",
+    "Resolvers",
+    "SkippedTimeResolver",
     "TzdbZone1970Location",
     "TzdbZoneLocation",
     "ZoneInterval",
     "ZoneLocalMapping",
+    "ZoneLocalMappingResolver",
     "cldr",
     "io",
 ]
@@ -18,8 +22,10 @@ __all__ = [
 from . import cldr, io
 from ._date_time_zone_cache import DateTimeZoneCache
 from ._date_time_zone_not_found_error import DateTimeZoneNotFoundError
+from ._delegates import AmbiguousTimeResolver, SkippedTimeResolver, ZoneLocalMappingResolver
 from ._i_date_time_zone_source import IDateTimeZoneSource
 from ._invalid_date_time_zone_source_error import InvalidDateTimeZoneSourceError
+from ._resolvers import Resolvers
 from ._tzdb_zone_1970_location import TzdbZone1970Location
 from ._tzdb_zone_location import TzdbZoneLocation
 from ._zone_interval import ZoneInterval

--- a/pyoda_time/time_zones/_delegates.py
+++ b/pyoda_time/time_zones/_delegates.py
@@ -1,0 +1,106 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from pyoda_time import DateTimeZone, LocalDateTime, ZonedDateTime
+    from pyoda_time.time_zones import ZoneInterval, ZoneLocalMapping
+
+
+class AmbiguousTimeResolver(Protocol):
+    """Chooses between two ``ZonedDateTime`` values that resolve to the same ``LocalDateTime``.
+
+    This delegate is used by ``Resolvers.create_mapping_resolver`` when handling an ambiguous local time,
+    due to clocks moving backward in a time zone transition (usually due to an autumnal daylight saving transition).
+
+    The returned value should be one of the two parameter values, based on the policy of the specific
+    implementation. Alternatively, it can raise an ``AmbiguousTimeError`` to implement a policy of
+    "reject ambiguous times."
+
+    See the ``Resolvers`` class for predefined implementations.
+
+    Implementations of this delegate can reasonably assume that the target local date and time really is ambiguous;
+    the behaviour when the local date and time can be unambiguously mapped into the target time zone (or when it's
+    skipped) is undefined.
+    """
+
+    def __call__(self, earlier: ZonedDateTime, later: ZonedDateTime) -> ZonedDateTime:
+        """Chooses between two ``ZonedDateTime`` values that resolve to the same ``LocalDateTime``.
+
+        :param earlier: The earlier of the ambiguous matches for the original local date and time.
+        :param later: The later of the ambiguous matches for the original local date and time.
+        :raises AmbiguousTimeError: The implementation rejects requests to map ambiguous times.
+        :return: A ``ZonedDateTime`` in the target time zone; typically, one of the two input parameters.
+        """
+
+
+class SkippedTimeResolver(Protocol):
+    """Resolves a ``LocalDateTime`` to a ``ZonedDateTime`` in the situation where the requested local time does not
+    exist in the target time zone.
+
+    This delegate is used by ``Resolvers.create_mapping_resolver`` when handling the situation where the
+    requested local time does not exist, due to clocks moving forward in a time zone transition (usually due to a
+    spring daylight saving transition).
+
+    The returned value will necessarily represent a different local date and time to the target one, but
+    the exact form of mapping is up to the delegate implementation. For example, it could return a value
+    as close to the target local date and time as possible, or the time immediately after the transition.
+    Alternatively, it can throw a ``SkippedTimeError`` to implement a policy of "reject
+    skipped times."
+
+    See the ``Resolvers`` class for predefined implementations.
+
+    Implementations of this delegate can reasonably
+    assume that the target local date and time really is skipped; the behaviour when the local date and time
+    can be directly mapped into the target time zone is undefined.
+    """
+
+    def __call__(
+        self,
+        local_date_time: LocalDateTime,
+        zone: DateTimeZone,
+        interval_before: ZoneInterval,
+        interval_after: ZoneInterval,
+    ) -> ZonedDateTime:
+        """
+
+        :param local_date_time: The local date and time to map to the given time zone.
+        :param zone: The target time zone.
+        :param interval_before: The zone interval directly before the target local date and time would have occurred.
+        :param interval_after: The zone interval directly after the target local date and time would have occurred.
+        :raises SkippedTimeError: The implementation rejects requests to map skipped times.
+        :return: A ``ZonedDateTime`` in the target time zone.
+        """
+
+
+class ZoneLocalMappingResolver(Protocol):
+    """Resolves the result of attempting to map a local date and time to a target time zone.
+
+    This delegate is consumed by ``LocalDateTime.in_zone`` and
+    ``DateTimeZone.resolve_local(LocalDateTime, ZoneLocalMappingResolver)``,
+    among others. It provides the strategy for converting a ``ZoneLocalMapping`` (the result of attempting
+    to map a local date and time to a target time zone) to a ``ZonedDateTime``.
+
+    See the ``Resolvers`` class for predefined implementations and a way of combining
+    separate ``SkippedTimeResolver`` and ``AmbiguousTimeResolver`` values.
+    """
+
+    def __call__(self, mapping: ZoneLocalMapping) -> ZonedDateTime:
+        """Resolves the result of attempting to map a local date and time to a target time zone.
+
+        :param mapping: The intermediate result of mapping a local time to a target time zone.
+        :raises AmbiguousTimeError: The implementation rejects requests to map ambiguous times.
+        :raises SkippedTimeError: The implementation rejects requests to map skipped times.
+        :return: A ``ZonedDateTime`` in the target time zone.
+        """
+
+
+__all__ = [
+    "AmbiguousTimeResolver",
+    "SkippedTimeResolver",
+    "ZoneLocalMappingResolver",
+]

--- a/pyoda_time/time_zones/_resolvers.py
+++ b/pyoda_time/time_zones/_resolvers.py
@@ -1,0 +1,142 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .._ambiguous_time_error import AmbiguousTimeError
+from .._duration import Duration
+from .._offset_date_time import OffsetDateTime
+from .._skipped_time_error import SkippedTimeError
+from .._zoned_date_time import ZonedDateTime
+from ..utility._preconditions import _Preconditions
+
+if TYPE_CHECKING:
+    from .._date_time_zone import DateTimeZone
+    from .._local_date_time import LocalDateTime
+    from . import ZoneInterval, ZoneLocalMapping
+    from ._delegates import AmbiguousTimeResolver, SkippedTimeResolver, ZoneLocalMappingResolver
+
+
+class Resolvers:
+    """Commonly-used implementations of the delegates used in resolving a ``LocalDateTime`` to a ``ZonedDateTime``, and
+    a method to combine two "partial" resolvers into a full one.
+
+    This class contains predefined implementations of ``ZoneLocalMappingResolver``, ``AmbiguousTimeResolver``, and
+    ``SkippedTimeResolver``, along with ``CreateMappingResolver``, which produces a ``ZoneLocalMappingResolver``
+    from instances of the other two.
+    """
+
+    @staticmethod
+    def return_earlier(earlier: ZonedDateTime, later: ZonedDateTime) -> ZonedDateTime:
+        """An ``AmbiguousTimeResolver`` which returns the earlier of the two matching times."""
+        return earlier
+
+    @staticmethod
+    def return_later(earlier: ZonedDateTime, later: ZonedDateTime) -> ZonedDateTime:
+        """An ``AmbiguousTimeResolver`` which returns the later of the two matching times."""
+        return later
+
+    @staticmethod
+    def throw_when_ambiguous(earlier: ZonedDateTime, later: ZonedDateTime) -> ZonedDateTime:
+        """An ``AmbiguousTimeResolver`` which simply raises an ``AmbiguousTimeError``."""
+        raise AmbiguousTimeError(earlier, later)
+
+    @staticmethod
+    def return_end_of_interval_before(
+        local_date_time: LocalDateTime,
+        zone: DateTimeZone,
+        interval_before: ZoneInterval,
+        interval_after: ZoneInterval,
+    ) -> ZonedDateTime:
+        """A ``SkippedTimeResolver`` which returns the final tick of the time zone interval before the "gap"."""
+        _Preconditions._check_not_null(zone, "zone")
+        _Preconditions._check_not_null(interval_before, "interval_before")
+        _Preconditions._check_not_null(interval_after, "interval_after")
+        # Given that there's a zone after before, it can't extend to the end of time.
+        return ZonedDateTime(
+            instant=interval_before.end - Duration.epsilon, zone=zone, calendar=local_date_time.calendar
+        )
+
+    @staticmethod
+    def return_start_of_interval_after(
+        local_date_time: LocalDateTime,
+        zone: DateTimeZone,
+        interval_before: ZoneInterval,
+        interval_after: ZoneInterval,
+    ) -> ZonedDateTime:
+        """A ``SkippedTimeResolver`` which returns the first tick of the time zone interval after the "gap"."""
+        _Preconditions._check_not_null(zone, "zone")
+        _Preconditions._check_not_null(interval_before, "interval_before")
+        _Preconditions._check_not_null(interval_after, "interval_after")
+        return ZonedDateTime(instant=interval_after.start, zone=zone, calendar=local_date_time.calendar)
+
+    @staticmethod
+    def return_forward_shifted(
+        local_date_time: LocalDateTime,
+        zone: DateTimeZone,
+        interval_before: ZoneInterval,
+        interval_after: ZoneInterval,
+    ) -> ZonedDateTime:
+        """A ``SkippedTimeResolver`` which shifts values in the "gap" forward by the duration of the gap (which is
+        usually 1 hour).
+
+        This corresponds to the instant that would have occured, had there not been a transition.
+        """
+        _Preconditions._check_not_null(zone, "zone")
+        _Preconditions._check_not_null(interval_before, "interval_before")
+        _Preconditions._check_not_null(interval_after, "interval_after")
+        return ZonedDateTime._ctor(
+            offset_date_time=OffsetDateTime(
+                local_date_time=local_date_time,
+                offset=interval_before.wall_offset,
+            ).with_offset(interval_after.wall_offset),
+            zone=zone,
+        )
+
+    @staticmethod
+    def throw_when_skipped(
+        local_date_time: LocalDateTime,
+        zone: DateTimeZone,
+        interval_before: ZoneInterval,
+        interval_after: ZoneInterval,
+    ) -> ZonedDateTime:
+        """A ``SkippedTimeResolver`` which simply throws a ``SkippedTimeError``."""
+        _Preconditions._check_not_null(zone, "zone")
+        _Preconditions._check_not_null(interval_before, "interval_before")
+        _Preconditions._check_not_null(interval_after, "interval_after")
+        raise SkippedTimeError(local_date_time, zone)
+
+    @staticmethod
+    def create_mapping_resolver(
+        ambiguous_time_resolver: AmbiguousTimeResolver, skipped_time_resolver: SkippedTimeResolver
+    ) -> ZoneLocalMappingResolver:
+        """Combines an ``AmbiguousTimeResolver`` and a ``SkippedTimeResolver`` to create a ``ZoneLocalMappingResolver``.
+
+        The ``ZoneLocalMappingResolver`` created by this method operates in the obvious way: unambiguous mappings
+        are returned directly, ambiguous mappings are delegated to the given ``AmbiguousTimeResolver``, and
+        "skipped" mappings are delegated to the given ``SkippedTimeResolver``.
+
+        :param ambiguous_time_resolver: Resolver to use for ambiguous mappings.
+        :param skipped_time_resolver: Resolver to use for "skipped" mappings.
+        :return: The logical combination of the two resolvers.
+        """
+        _Preconditions._check_not_null(ambiguous_time_resolver, "ambiguous_time_resolver")
+        _Preconditions._check_not_null(skipped_time_resolver, "skipped_time_resolver")
+
+        def func(mapping: ZoneLocalMapping) -> ZonedDateTime:
+            match _Preconditions._check_not_null(mapping, "mapping").count:
+                case 0:
+                    return skipped_time_resolver(
+                        mapping.local_date_time, mapping.zone, mapping.early_interval, mapping.late_interval
+                    )
+                case 1:
+                    return mapping.first()
+                case 2:
+                    return ambiguous_time_resolver(mapping.first(), mapping.last())
+                case _:
+                    raise ValueError("Mapping has count outside range 0-2; should not happen.")
+
+        return func

--- a/pyoda_time/time_zones/_zone_local_mapping.py
+++ b/pyoda_time/time_zones/_zone_local_mapping.py
@@ -157,6 +157,24 @@ class ZoneLocalMapping:
             case _:
                 raise RuntimeError("Can't happen")
 
+    def last(self) -> ZonedDateTime:
+        """Returns a ``ZonedDateTime`` which maps to the original ``LocalDateTime`` in the mapped ``DateTimeZone``:
+        either the single result if the mapping is unambiguous, or the later result if the local date/time occurs twice
+        in the time zone due to a time zone offset change such as an autumnal daylight saving transition.
+
+        :raises SkippedTimeError: The local date/time was skipped in the time zone.
+        :return: The unambiguous result of mapping a local date/time in a time zone.
+        """
+        match self.count:
+            case 0:
+                raise SkippedTimeError(self.local_date_time, self.zone)
+            case 1:
+                return self.__build_zoned_date_time(self.early_interval)
+            case 2:
+                return self.__build_zoned_date_time(self.late_interval)
+            case _:
+                raise RuntimeError("Can't happen")
+
     def __build_zoned_date_time(self, interval: ZoneInterval) -> ZonedDateTime:
         return ZonedDateTime._ctor(
             offset_date_time=self.local_date_time.with_offset(interval.wall_offset), zone=self.zone

--- a/tests/time_zones/test_resolvers.py
+++ b/tests/time_zones/test_resolvers.py
@@ -1,0 +1,146 @@
+# Copyright 2024 The Pyoda Time Authors. All rights reserved.
+# Use of this source code is governed by the Apache License 2.0,
+# as found in the LICENSE.txt file.
+from typing import Final
+
+import pytest
+
+from pyoda_time import (
+    AmbiguousTimeError,
+    DateTimeZone,
+    Duration,
+    Instant,
+    LocalDateTime,
+    SkippedTimeError,
+    ZonedDateTime,
+)
+from pyoda_time.testing.time_zones import SingleTransitionDateTimeZone
+from pyoda_time.time_zones import Resolvers, ZoneInterval
+
+AMBIGUOUS_ZONE: Final[SingleTransitionDateTimeZone] = SingleTransitionDateTimeZone(
+    Instant.from_utc(2000, 1, 1, 0, 0), 1, 0
+)
+"""Zone where the clocks go back at 1am at the start of the year 2000, back to midnight."""
+
+GAP_ZONE: Final[SingleTransitionDateTimeZone] = SingleTransitionDateTimeZone(Instant.from_utc(2000, 1, 1, 0, 0), 0, 1)
+"""Zone where the clocks go forward at midnight at the start of the year 2000, to 1am."""
+
+TIME_IN_TRANSITION: Final[LocalDateTime] = LocalDateTime(2000, 1, 1, 0, 20)
+"""Local time which is either skipped or ambiguous, depending on the zones above."""
+
+
+class TestResolvers:
+    def test_return_earlier(self) -> None:
+        mapping = AMBIGUOUS_ZONE.map_local(TIME_IN_TRANSITION)
+        assert mapping.count == 2
+        resolved = Resolvers.return_earlier(mapping.first(), mapping.last())
+        assert resolved == mapping.first()
+
+    def test_return_later(self) -> None:
+        mapping = AMBIGUOUS_ZONE.map_local(TIME_IN_TRANSITION)
+        assert mapping.count == 2
+        resolved = Resolvers.return_later(mapping.first(), mapping.last())
+        assert resolved == mapping.last()
+
+    def throw_when_ambiguous(self) -> None:
+        mapping = AMBIGUOUS_ZONE.map_local(TIME_IN_TRANSITION)
+        assert mapping.count == 2
+        with pytest.raises(AmbiguousTimeError):
+            Resolvers.throw_when_ambiguous(mapping.first(), mapping.last())
+
+    def test_return_end_of_interval_before(self) -> None:
+        mapping = GAP_ZONE.map_local(TIME_IN_TRANSITION)
+        assert mapping.count == 0
+        resolved = Resolvers.return_end_of_interval_before(
+            TIME_IN_TRANSITION, GAP_ZONE, mapping.early_interval, mapping.late_interval
+        )
+        assert resolved.to_instant() == GAP_ZONE.early_interval.end - Duration.epsilon
+        assert resolved.zone == GAP_ZONE
+
+    def test_start_of_interval_after(self) -> None:
+        mapping = GAP_ZONE.map_local(TIME_IN_TRANSITION)
+        assert mapping.count == 0
+        resolved = Resolvers.return_start_of_interval_after(
+            TIME_IN_TRANSITION, GAP_ZONE, mapping.early_interval, mapping.late_interval
+        )
+        assert resolved.to_instant() == GAP_ZONE.late_interval.start
+        assert resolved.zone == GAP_ZONE
+
+    def test_return_forward_shifted(self) -> None:
+        mapping = GAP_ZONE.map_local(TIME_IN_TRANSITION)
+        assert mapping.count == 0
+        resolved = Resolvers.return_forward_shifted(
+            TIME_IN_TRANSITION, GAP_ZONE, mapping.early_interval, mapping.late_interval
+        )
+
+        gap = mapping.late_interval.wall_offset.ticks - mapping.early_interval.wall_offset.ticks
+        expected = TIME_IN_TRANSITION._to_local_instant().minus(mapping.late_interval.wall_offset).plus_ticks(gap)
+        assert resolved.to_instant() == expected
+        assert resolved.offset == mapping.late_interval.wall_offset
+        assert resolved.zone == GAP_ZONE
+
+    def test_throw_when_skipped(self) -> None:
+        mapping = GAP_ZONE.map_local(TIME_IN_TRANSITION)
+        assert mapping.count == 0
+        with pytest.raises(SkippedTimeError):
+            Resolvers.throw_when_skipped(TIME_IN_TRANSITION, GAP_ZONE, mapping.early_interval, mapping.late_interval)
+
+    def test_create_resolver_unambiguous(self) -> None:
+        def ambiguity_resolver(earlier: ZonedDateTime, later: ZonedDateTime) -> ZonedDateTime:
+            pytest.fail("Shouldn't be called")
+
+        def skipped_time_resolver(
+            local_date_time: LocalDateTime,
+            zone: DateTimeZone,
+            interval_before: ZoneInterval,
+            interval_after: ZoneInterval,
+        ) -> ZonedDateTime:
+            pytest.fail("Shouldn't be called")
+
+        resolver = Resolvers.create_mapping_resolver(ambiguity_resolver, skipped_time_resolver)
+
+        local_time = LocalDateTime(1900, 1, 1, 0, 0)
+        resolved = resolver(GAP_ZONE.map_local(local_time))
+        assert resolved == ZonedDateTime._ctor(local_time.with_offset(GAP_ZONE.early_interval.wall_offset), GAP_ZONE)
+
+    def test_create_resolver_ambiguous(self) -> None:
+        zoned = ZonedDateTime._ctor(
+            TIME_IN_TRANSITION.plus_days(1).with_offset(GAP_ZONE.early_interval.wall_offset), GAP_ZONE
+        )
+
+        def ambiguity_resolver(earlier: ZonedDateTime, later: ZonedDateTime) -> ZonedDateTime:
+            return zoned
+
+        def skipped_time_resolver(
+            local_date_time: LocalDateTime,
+            zone: DateTimeZone,
+            interval_before: ZoneInterval,
+            interval_after: ZoneInterval,
+        ) -> ZonedDateTime:
+            pytest.fail("Shouldn't be called")
+
+        resolver = Resolvers.create_mapping_resolver(ambiguity_resolver, skipped_time_resolver)
+
+        resolved = resolver(AMBIGUOUS_ZONE.map_local(TIME_IN_TRANSITION))
+        assert resolved == zoned
+
+    def test_create_resolver_skipped(self) -> None:
+        zoned = ZonedDateTime._ctor(
+            TIME_IN_TRANSITION.plus_days(1).with_offset(GAP_ZONE.early_interval.wall_offset), GAP_ZONE
+        )
+
+        def ambiguity_resolver(earlier: ZonedDateTime, later: ZonedDateTime) -> ZonedDateTime:
+            pytest.fail("Shouldn't be called")
+
+        def skipped_time_resolver(
+            local_date_time: LocalDateTime,
+            zone: DateTimeZone,
+            interval_before: ZoneInterval,
+            interval_after: ZoneInterval,
+        ) -> ZonedDateTime:
+            return zoned
+
+        resolver = Resolvers.create_mapping_resolver(ambiguity_resolver, skipped_time_resolver)
+
+        resolved = resolver(GAP_ZONE.map_local(TIME_IN_TRANSITION))
+        assert resolved == zoned


### PR DESCRIPTION
- Ports the following Noda Time delegates to Protocols which describe different types of "resolver":
  - `AmbiguousTimeResolver`
  - `SkippedTimeResolver`
  - `ZoneLocalMappingResolver`
- Implements the `Resolvers` class which contains commonly-used implementations of the above.

Relates to:
- #232 