### PR TITLE
fix: `LocalInstant.Minus()` is internal

### DIFF
--- a/pyoda_time/_date_time_zone.py
+++ b/pyoda_time/_date_time_zone.py
@@ -243,7 +243,7 @@ class DateTimeZone(abc.ABC, _IZoneIntervalMap, metaclass=_DateTimeZoneMeta):
         # If the local interval occurs before the zone interval we're looking at starts,
         # we need to find the earlier one; otherwise this interval must come after the gap, and
         # it's therefore the one we want.
-        if local_instant.minus(guess_interval.wall_offset) < guess_interval._raw_start:
+        if local_instant._minus(guess_interval.wall_offset) < guess_interval._raw_start:
             return self.get_zone_interval(guess_interval.start - Duration.epsilon)
         return guess_interval
 
@@ -252,7 +252,7 @@ class DateTimeZone(abc.ABC, _IZoneIntervalMap, metaclass=_DateTimeZoneMeta):
         guess_interval = self.get_zone_interval(guess)
         # If the local interval occurs before the zone interval we're looking at starts,
         # it's the one we're looking for. Otherwise, we need to find the next interval.
-        if local_instant.minus(guess_interval.wall_offset) < guess_interval._raw_start:
+        if local_instant._minus(guess_interval.wall_offset) < guess_interval._raw_start:
             return guess_interval
         else:
             # Will definitely be valid - there can't be a gap after an infinite interval.

--- a/pyoda_time/_local_instant.py
+++ b/pyoda_time/_local_instant.py
@@ -111,7 +111,7 @@ class _LocalInstant:
 
         return Instant._from_trusted_duration(self.__duration)
 
-    def minus(self, offset: Offset) -> Instant:
+    def _minus(self, offset: Offset) -> Instant:
         """Subtracts the given time zone offset from this local instant, to give an ``Instant``.
 
         This would normally be implemented as an operator, but as the corresponding "plus" operation
@@ -137,7 +137,7 @@ class _LocalInstant:
         days = self.__duration._floor_days
         # If we can do the arithmetic safely, do so.
         if Instant._MIN_DAYS < days < Instant._MAX_DAYS:
-            return self.minus(offset)
+            return self._minus(offset)
         # Handle BeforeMinValue and BeforeMaxValue simply.
         if days < Instant._MIN_DAYS:
             return Instant._before_min_value()

--- a/pyoda_time/_zoned_date_time.py
+++ b/pyoda_time/_zoned_date_time.py
@@ -57,7 +57,7 @@ class ZonedDateTime:
 
         offset_date_time: OffsetDateTime
         if local_date_time is not None and offset is not None:
-            candidate_instant = local_date_time._to_local_instant().minus(offset)
+            candidate_instant = local_date_time._to_local_instant()._minus(offset)
             correct_offset: Offset = zone.get_utc_offset(candidate_instant)
             if correct_offset != offset:
                 raise ValueError(

--- a/tests/test_local_instant.py
+++ b/tests/test_local_instant.py
@@ -25,7 +25,7 @@ class TestLocalInstant:
     def test_minus_offset_zero_is_neutral_element(self) -> None:
         sample_instant = Instant._ctor(days=1, nano_of_day=23456)
         sample_local_instant = _LocalInstant._ctor(days=1, nano_of_day=23456)
-        assert sample_local_instant.minus(Offset.zero) == sample_instant
+        assert sample_local_instant._minus(Offset.zero) == sample_instant
         assert sample_local_instant._minus_zero_offset() == sample_instant
 
     @pytest.mark.parametrize(

--- a/tests/time_zones/test_resolvers.py
+++ b/tests/time_zones/test_resolvers.py
@@ -74,7 +74,7 @@ class TestResolvers:
         )
 
         gap = mapping.late_interval.wall_offset.ticks - mapping.early_interval.wall_offset.ticks
-        expected = TIME_IN_TRANSITION._to_local_instant().minus(mapping.late_interval.wall_offset).plus_ticks(gap)
+        expected = TIME_IN_TRANSITION._to_local_instant()._minus(mapping.late_interval.wall_offset).plus_ticks(gap)
         assert resolved.to_instant() == expected
         assert resolved.offset == mapping.late_interval.wall_offset
         assert resolved.zone == GAP_ZONE


### PR DESCRIPTION
Spotted while working on something else: I ported this method with the wrong "visibility".

By project convention, "internal" C# methods should be prefixed with an underscore in Python.