### PR TITLE
test: implement some tests marked TODO

### DIFF
--- a/tests/text/test_local_time_pattern.py
+++ b/tests/text/test_local_time_pattern.py
@@ -206,12 +206,6 @@ FORMAT_ONLY_DATA: Final[list[Data]] = [
     Data(LocalTime(14, 15, 16), culture=Cultures.invariant, text="14:15", pattern="t"),
 ]
 
-# TODO: This seems to be unused in Noda Time (https://github.com/nodatime/nodatime/pull/1800)
-DEFAULT_PATTERN_DATA: Final[list[Data]] = []
-
-# TODO: This seems to be unused in Noda Time (https://github.com/nodatime/nodatime/pull/1800)
-TEMPLATE_VALUE_DATA: Final[list[Data]] = []
-
 FORMAT_AND_PARSE_DATA: Final[list[Data]] = [
     Data(LocalTime.midnight, culture=Cultures.en_us, text=".", pattern="%."),
     Data(LocalTime.midnight, culture=Cultures.en_us, text=":", pattern="%:"),

--- a/tests/time_zones/test_tzdb_date_time_zone_source.py
+++ b/tests/time_zones/test_tzdb_date_time_zone_source.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from pyoda_time import DateTimeZone, Instant, LocalDateTime, PyodaConstants, ZonedDateTime
+from pyoda_time import DateTimeZone, DateTimeZoneProviders, Instant, LocalDateTime, PyodaConstants, ZonedDateTime
 from pyoda_time.time_zones import TzdbZone1970Location, TzdbZoneLocation
 from pyoda_time.time_zones._tzdb_date_time_zone_source import TzdbDateTimeZoneSource
 from pyoda_time.time_zones.cldr import MapZone, WindowsZones
@@ -155,8 +155,7 @@ class TestTzdbDateTimeZoneSource:
         assert source.tzdb_version.startswith("20")
 
     def test_fixed_date_time_zone_name(self) -> None:
-        # TODO: Use DateTimeZoneProviders here, when it is ported
-        zulu = TzdbDateTimeZoneSource.default.for_id("Etc/Zulu")
+        zulu = DateTimeZoneProviders.tzdb["Etc/Zulu"]
         assert zulu.get_zone_interval(PyodaConstants.UNIX_EPOCH).name == "UTC"
 
     def test_version_id(self) -> None:


### PR DESCRIPTION
Implements some tests that were marked as TODO, as they relied on functionality which hadn't been ported yet.

Also removes the unused test data as per:
- https://github.com/nodatime/nodatime/pull/1800