### PR TITLE
chore: update docformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,10 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+    # Workaround for latest release (1.7.5) being incompatible with
+    # pre-commit >= 4.
+    # https://github.com/PyCQA/docformatter/issues/293#issuecomment-2419238424
+    rev: "eb1df347edd128b30cd3368dddc3aa65edcfac38"
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]


### PR DESCRIPTION
Unfortunately the latest docformatter is not compatible with pre-commit > 3.

The commit which enables support is there, but a release is not forthcoming...

This should unblock #222 