### PR TITLE
feat: standardise `.With()` ports

### DIFF
--- a/pyoda_time/_local_date.py
+++ b/pyoda_time/_local_date.py
@@ -660,7 +660,7 @@ class LocalDate(metaclass=_LocalDateMeta):
         """
         return self + time
 
-    def with_(self, adjuster: Callable[[LocalDate], LocalDate]) -> LocalDate:
+    def with_date_adjuster(self, adjuster: Callable[[LocalDate], LocalDate]) -> LocalDate:
         """Returns this date, with the given adjuster applied to it.
 
         If the adjuster attempts to construct an invalid date (such as by trying to set a day-of-month of 30 in

--- a/pyoda_time/_local_date_time.py
+++ b/pyoda_time/_local_date_time.py
@@ -13,6 +13,8 @@ from .utility._preconditions import _Preconditions
 from .utility._tick_arithmetic import _TickArithmetic
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from . import Offset, OffsetDateTime, Period, ZonedDateTime
     from ._iso_day_of_week import IsoDayOfWeek
     from ._local_date import LocalDate
@@ -231,6 +233,28 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
         from ._local_instant import _LocalInstant
 
         return _LocalInstant._ctor(days=self.date._days_since_epoch, nano_of_day=self.__time.nanosecond_of_day)
+
+    def with_date_adjuster(self, adjuster: Callable[[LocalDate], LocalDate]) -> LocalDateTime:
+        """Returns this date/time, with the given date adjuster applied to it, maintaining the existing time of day.
+
+        If the adjuster attempts to construct an invalid date (such as by trying to set a day-of-month of 30 in
+        February), any exception thrown by that construction attempt will be propagated through this method.
+
+        :param adjuster: The adjuster to apply.
+        :return: The adjusted date/time.
+        """
+        return self.__date.with_date_adjuster(adjuster=adjuster) + self.__time
+
+    def with_time_adjuster(self, adjuster: Callable[[LocalTime], LocalTime]) -> LocalDateTime:
+        """Returns this date/time, with the given time adjuster applied to it, maintaining the existing date.
+
+        If the adjuster attempts to construct an invalid time, any exception thrown by that construction attempt will be
+        propagated through this method.
+
+        :param adjuster: The adjuster to apply.
+        :return: The adjusted date/time.
+        """
+        return self.__date + self.__time.with_time_adjuster(adjuster=adjuster)
 
     def with_calendar(self, calendar: CalendarSystem) -> LocalDateTime:
         """Creates a new LocalDateTime representing the same physical date and time, but in a different calendar. The

--- a/pyoda_time/_local_time.py
+++ b/pyoda_time/_local_time.py
@@ -613,7 +613,7 @@ class LocalTime(metaclass=_LocalTimeMeta):
 
         return _TimePeriodField._nanoseconds._add_local_time(self, nanoseconds)
 
-    def with_(self, adjuster: Callable[[LocalTime], LocalTime]) -> LocalTime:
+    def with_time_adjuster(self, adjuster: Callable[[LocalTime], LocalTime]) -> LocalTime:
         return _Preconditions._check_not_null(adjuster, "adjuster")(self)
 
     def with_offset(self, offset: Offset) -> OffsetTime:

--- a/pyoda_time/_offset_date.py
+++ b/pyoda_time/_offset_date.py
@@ -128,7 +128,7 @@ class OffsetDate:
         """
         return OffsetDate(self.__date, offset)
 
-    def with_(self, adjuster: Callable[[LocalDate], LocalDate]) -> OffsetDate:
+    def with_date_adjuster(self, adjuster: Callable[[LocalDate], LocalDate]) -> OffsetDate:
         """Returns this offset date, with the given date adjuster applied to it, maintaining the existing offset.
 
         If the adjuster attempts to construct an invalid date (such as by trying to set a day-of-month of 30 in
@@ -137,7 +137,7 @@ class OffsetDate:
         :param adjuster: The adjuster to apply.
         :return: The adjusted offset date.
         """
-        return OffsetDate(date=self.__date.with_(adjuster), offset=self.__offset)
+        return OffsetDate(date=self.__date.with_date_adjuster(adjuster), offset=self.__offset)
 
     def with_calendar(self, calendar: CalendarSystem) -> OffsetDate:
         """Creates a new ``OffsetDate`` representing the same physical date and offset, but in a different calendar.

--- a/pyoda_time/_offset_time.py
+++ b/pyoda_time/_offset_time.py
@@ -203,7 +203,7 @@ class OffsetTime:
         """
         return OffsetTime(self.time_of_day, offset)
 
-    def with_(self, adjuster: Callable[[LocalTime], LocalTime]) -> OffsetTime:
+    def with_time_adjuster(self, adjuster: Callable[[LocalTime], LocalTime]) -> OffsetTime:
         """Returns this offset time-of-day, with the given date adjuster applied to it, maintaining the existing offset.
 
         If the adjuster attempts to construct an invalid time-of-day, any exception thrown by that construction attempt
@@ -212,7 +212,7 @@ class OffsetTime:
         :param adjuster: The adjuster to apply.
         :return: The adjusted offset date.
         """
-        return OffsetTime(self.time_of_day.with_(adjuster), self.offset)
+        return OffsetTime(self.time_of_day.with_time_adjuster(adjuster), self.offset)
 
     def on(self, date: LocalDate) -> OffsetDateTime:
         """Combines this ``OffsetTime`` with the given ``LocalDate`` into an ``OffsetDateTime``.

--- a/tests/test_date_adjusters.py
+++ b/tests/test_date_adjusters.py
@@ -43,7 +43,7 @@ class TestDateAdjusters:
         expected_day: int,
     ) -> None:
         start = LocalDate(year, month, day)
-        actual = start.with_(DateAdjusters.next_or_same(day_of_week))
+        actual = start.with_date_adjuster(DateAdjusters.next_or_same(day_of_week))
         expected = LocalDate(expected_year, expected_month, expected_day)
         assert actual == expected
 
@@ -67,7 +67,7 @@ class TestDateAdjusters:
         expected_day: int,
     ) -> None:
         start = LocalDate(year, month, day)
-        actual = start.with_(DateAdjusters.previous_or_same(day_of_week))
+        actual = start.with_date_adjuster(DateAdjusters.previous_or_same(day_of_week))
         expected = LocalDate(expected_year, expected_month, expected_day)
         assert actual == expected
 
@@ -91,7 +91,7 @@ class TestDateAdjusters:
         expected_day: int,
     ) -> None:
         start = LocalDate(year, month, day)
-        actual = start.with_(DateAdjusters.next(day_of_week))
+        actual = start.with_date_adjuster(DateAdjusters.next(day_of_week))
         expected = LocalDate(expected_year, expected_month, expected_day)
         assert actual == expected
 
@@ -115,14 +115,14 @@ class TestDateAdjusters:
         expected_day: int,
     ) -> None:
         start = LocalDate(year, month, day)
-        actual = start.with_(DateAdjusters.previous(day_of_week))
+        actual = start.with_date_adjuster(DateAdjusters.previous(day_of_week))
         expected = LocalDate(expected_year, expected_month, expected_day)
         assert actual == expected
 
     def test_month_valid(self) -> None:
         adjuster = DateAdjusters.month(2)
         start = LocalDate(2017, 8, 21, CalendarSystem.julian)
-        actual = start.with_(adjuster)
+        actual = start.with_date_adjuster(adjuster)
         expected = LocalDate(2017, 2, 21, CalendarSystem.julian)
         assert actual == expected
 
@@ -130,7 +130,7 @@ class TestDateAdjusters:
         adjuster = DateAdjusters.month(2)
         start = LocalDate(2017, 8, 30, CalendarSystem.julian)
         with pytest.raises(ValueError):
-            start.with_(adjuster)
+            start.with_date_adjuster(adjuster)
 
     def test_iso_day_of_week_adjusters_invalid(self) -> None:
         invalid = IsoDayOfWeek.NONE
@@ -147,7 +147,7 @@ class TestDateAdjusters:
         period = Period.from_months(1) + Period.from_days(3)
         adjuster = DateAdjusters.add_period(period)
         start = LocalDate(2019, 5, 4)
-        assert start.with_(adjuster) == LocalDate(2019, 6, 7)
+        assert start.with_date_adjuster(adjuster) == LocalDate(2019, 6, 7)
 
     def test_add_period_null(self) -> None:
         with pytest.raises(TypeError):

--- a/tests/test_local_date.py
+++ b/tests/test_local_date.py
@@ -691,4 +691,4 @@ class TestLocalDatePseudomutators:
     def test_with(self) -> None:
         start = LocalDate(2014, 6, 27)
         expected = LocalDate(2014, 6, 30)
-        assert start.with_(DateAdjusters.end_of_month) == expected
+        assert start.with_date_adjuster(DateAdjusters.end_of_month) == expected

--- a/tests/test_local_date_time.py
+++ b/tests/test_local_date_time.py
@@ -6,7 +6,16 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from pyoda_time import CalendarSystem, DateTimeZone, DateTimeZoneProviders, LocalDate, LocalDateTime, PyodaConstants
+from pyoda_time import (
+    CalendarSystem,
+    DateAdjusters,
+    DateTimeZone,
+    DateTimeZoneProviders,
+    LocalDate,
+    LocalDateTime,
+    PyodaConstants,
+    TimeAdjusters,
+)
 
 PACIFIC: DateTimeZone = DateTimeZoneProviders.tzdb["America/Los_Angeles"]
 
@@ -65,3 +74,15 @@ class TestLocalDateTime:
         """Using the default constructor is equivalent to January 1st 1970, midnight, UTC, ISO calendar."""
         actual = LocalDateTime()
         assert actual == LocalDateTime(1, 1, 1, 0, 0)
+
+
+class TestLocalDateTimePseudomutators:
+    def test_with_time_adjuster(self) -> None:
+        start = LocalDateTime(2014, 6, 27, 12, 15, 8).plus_nanoseconds(123456789)
+        expected = LocalDateTime(2014, 6, 27, 12, 15, 8)
+        assert start.with_time_adjuster(TimeAdjusters.truncate_to_second) == expected
+
+    def test_with_date_adjuster(self) -> None:
+        start = LocalDateTime(2014, 6, 27, 12, 5, 8).plus_nanoseconds(123456789)
+        expected = LocalDateTime(2014, 6, 30, 12, 5, 8).plus_nanoseconds(123456789)
+        assert start.with_date_adjuster(DateAdjusters.end_of_month) == expected

--- a/tests/test_local_time.py
+++ b/tests/test_local_time.py
@@ -464,7 +464,7 @@ class TestLocalTimePseudomutators:
     def test_with(self) -> None:
         start = LocalTime.from_hour_minute_second_millisecond_tick(12, 15, 8, 100, 1234)
         expected = LocalTime(12, 15, 8)
-        assert start.with_(TimeAdjusters.truncate_to_second) == expected
+        assert start.with_time_adjuster(TimeAdjusters.truncate_to_second) == expected
 
     def test_plus_minutes_would_overflow_naively(self) -> None:
         start = LocalTime(12, 34, 56)

--- a/tests/test_offset_date.py
+++ b/tests/test_offset_date.py
@@ -73,7 +73,7 @@ class TestOffsetDate:
 
     def test_with_adjuster(self) -> None:
         initial = OffsetDate(LocalDate(2016, 6, 19), Offset.from_hours(-5))
-        actual = initial.with_(DateAdjusters.start_of_month)
+        actual = initial.with_date_adjuster(DateAdjusters.start_of_month)
         expected = OffsetDate(LocalDate(2016, 6, 1), Offset.from_hours(-5))
         assert actual == expected
 

--- a/tests/test_offset_date_time.py
+++ b/tests/test_offset_date_time.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the Apache License 2.0,
 # as found in the LICENSE.txt file.
 
-from pyoda_time import LocalDateTime, Offset, OffsetDateTime
+from pyoda_time import DateAdjusters, LocalDateTime, Offset, OffsetDateTime, TimeAdjusters
 
 
 class TestOffsetDateTime:
@@ -28,3 +28,15 @@ class TestOffsetDateTime:
         assert morning.local_date_time == LocalDateTime(2017, 8, 23, 6, 0, 0)
         back_again = morning.with_offset(Offset.from_hours(-18))
         assert back_again == night
+
+    def test_with_time_adjuster(self) -> None:
+        offset = Offset.from_hours_and_minutes(2, 30)
+        start = LocalDateTime(2014, 6, 27, 12, 5, 8).plus_nanoseconds(123456789).with_offset(offset)
+        expected = LocalDateTime(2014, 6, 27, 12, 5, 8).with_offset(offset)
+        assert start.with_time_adjuster(TimeAdjusters.truncate_to_second) == expected
+
+    def test_with_date_adjuster(self) -> None:
+        offset = Offset.from_hours_and_minutes(2, 30)
+        start = LocalDateTime(2014, 6, 27, 12, 5, 8).plus_nanoseconds(123456789).with_offset(offset)
+        expected = LocalDateTime(2014, 6, 30, 12, 5, 8).plus_nanoseconds(123456789).with_offset(offset)
+        assert start.with_date_adjuster(DateAdjusters.end_of_month) == expected

--- a/tests/test_offset_time.py
+++ b/tests/test_offset_time.py
@@ -73,7 +73,7 @@ class TestOffsetTime:
 
     def test_with_adjuster(self) -> None:
         initial = OffsetTime(LocalTime(14, 15, 12), Offset.from_hours(-5))
-        actual = initial.with_(TimeAdjusters.truncate_to_hour)
+        actual = initial.with_time_adjuster(TimeAdjusters.truncate_to_hour)
         expected = OffsetTime(LocalTime(14), Offset.from_hours(-5))
         assert actual == expected
 


### PR DESCRIPTION
Ports `.With()` methods for types which can be adjusted by "date adjusters" and "time adjusters" in a way which makes sense in Python.

|Noda|Pyoda|
|:-:|:-:|
|`LocalDate.With()`|`LocalDate.with_date_adjuster()`|
|`LocalTime.With()`|`LocalTime.with_time_adjuster()`|
|`LocalDateTime.With()`|`LocalDateTime.with_date_adjuster()` & `LocalDateTime.with_time_adjuster()`|
|`OffsetDate.With()`|`OffsetDate.with_date_adjuster()`|
|`OffsetTime.With()`|`OffsetTime.with_time_adjuster()`|
|`OffsetDateTime.With()`|`OffsetDateTime.with_date_adjuster()` & `OffsetDateTime.with_time_adjuster()`|

closes #257 