### PR TITLE
feat: Implement `LocalDateTime`

### DIFF
--- a/pyoda_time/_local_date_time.py
+++ b/pyoda_time/_local_date_time.py
@@ -9,29 +9,63 @@ from typing import TYPE_CHECKING, final, overload
 
 from ._calendar_system import CalendarSystem
 from .utility._csharp_compatibility import _sealed, _to_ticks
+from .utility._hash_code_helper import _hash_code_helper
 from .utility._preconditions import _Preconditions
 from .utility._tick_arithmetic import _TickArithmetic
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from . import Offset, OffsetDateTime, Period, ZonedDateTime
+    from . import DateTimeZone, Offset, OffsetDateTime, Period, ZonedDateTime
     from ._iso_day_of_week import IsoDayOfWeek
     from ._local_date import LocalDate
     from ._local_instant import _LocalInstant
     from ._local_time import LocalTime
     from .calendars import Era
+    from .time_zones import ZoneLocalMappingResolver
 
 __all__ = ["LocalDateTime"]
 
 
 class _LocalDateTimeMeta(type):
-    pass
+    @property
+    def max_iso_value(self) -> LocalDateTime:
+        """The maximum (latest) date and time representable in the ISO calendar system.
+
+        This is a nanosecond before midnight at the end of ``LocalDate.max_iso_value``.
+        """
+        from pyoda_time import LocalDate, LocalTime
+
+        return LocalDate.max_iso_value + LocalTime.max_value
+
+    @property
+    def min_iso_value(self) -> LocalDateTime:
+        """The minimum (earliest) date and time representable in the ISO calendar system.
+
+        This is midnight at the start of ``LocalDate.min_iso_value``.
+        """
+        from pyoda_time import LocalDate, LocalTime
+
+        return LocalDate.min_iso_value + LocalTime.min_value
 
 
 @final
 @_sealed
 class LocalDateTime(metaclass=_LocalDateTimeMeta):
+    """A date and time in a particular calendar system.
+
+    A LocalDateTime value does not represent an instant on the global time line, because it has no associated time zone:
+    "November 12th 2009 7pm, ISO calendar" occurred at different instants for different people around the world.
+
+    This type defaults to using the ISO calendar system unless a different calendar system is specified.
+
+    Values can freely be compared for equality: a value in a different calendar system is not equal to
+    a value in a different calendar system. However, ordering comparisons fail with ``ValueError``;
+    attempting to compare values in different calendars almost always indicates a bug in the calling code.
+
+    The default value of this type is 0001-01-01T00:00:00 (midnight on January 1st, 1 C.E.) in the ISO calendar.
+    """
+
     def __init__(
         self,
         year: int = 1,
@@ -59,8 +93,8 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
         from ._local_date import LocalDate
         from ._local_time import LocalTime
 
-        self.__date = LocalDate(year=year, month=month, day=day, calendar=calendar)
-        self.__time = LocalTime(hour=hour, minute=minute, second=second, millisecond=millisecond)
+        self.__date: LocalDate = LocalDate(year=year, month=month, day=day, calendar=calendar)
+        self.__time: LocalTime = LocalTime(hour=hour, minute=minute, second=second, millisecond=millisecond)
 
     @classmethod
     @overload
@@ -234,6 +268,358 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
 
         return _LocalInstant._ctor(days=self.date._days_since_epoch, nano_of_day=self.__time.nanosecond_of_day)
 
+    @classmethod
+    def from_naive_datetime(cls, dt: datetime.datetime, calendar: CalendarSystem = CalendarSystem.iso) -> LocalDateTime:
+        """Converts a timezone-naive ``datetime.datetime`` to a ``LocalDateTime``, optionally in a specified calendar.
+
+        :param dt: Timezone-naive datetime to convert into a Pyoda Time local date and time.
+        :param calendar: The calendar system to convert into.
+        :return: A new ``LocalDateTime`` with the same values as the specified ``datetime.datetime``.
+        :raises ValueError: If ``dt`` is a timezone-aware ``datetime.datetime``.
+        """
+        # Unlike Noda Time, we need to verify the tzinfo of the datetime.
+        # In C#, DateTime doesn't have this...
+        # They have DateTimeKind, but that is irrelevant.
+        # What is important is that it is a DateTime, not a DateTimeOffset.
+
+        _Preconditions._check_argument(
+            expession=dt.tzinfo is None,
+            parameter="datetime",
+            message="Invalid datetime.tzinfo for LocalDateTime.from_datetime_utc",
+        )
+        from pyoda_time._local_date import LocalDate
+        from pyoda_time._local_time import LocalTime
+        from pyoda_time._pyoda_constants import PyodaConstants
+
+        days, tick_of_day = _TickArithmetic.ticks_to_days_and_tick_of_day(_to_ticks(dt))
+        days -= PyodaConstants._BCL_DAYS_AT_UNIX_EPOCH
+        return cls._ctor(
+            local_date=LocalDate._ctor(days_since_epoch=days, calendar=calendar),
+            local_time=LocalTime._ctor(nanoseconds=tick_of_day * PyodaConstants.NANOSECONDS_PER_TICK),
+        )
+
+    # region Implementation of IEquatable<LocalDateTime>
+
+    def equals(self, other: LocalDateTime) -> bool:
+        """Indicates whether the current object is equal to another object of the same type. See the type documentation
+        for a description of equality semantics.
+
+        :param other: An object to compare with this object.
+        :return: True if the current object is equal to the ``other`` parameter; otherwise, False.
+        """
+        return self == other
+
+    # endregion
+
+    # region Operators
+
+    def __eq__(self, other: object) -> bool:
+        """Implements the operator == (equality).
+
+        See the type documentation for a description of equality semantics.
+
+        :param other: An object to compare with this object.
+        :return: ``True`` if the current object is equal to the ``other`` parameter; otherwise, ``False``.
+        """
+        if not isinstance(other, LocalDateTime):
+            return NotImplemented
+        return self.__date == other.__date and self.__time == other.__time
+
+    def __ne__(self, other: object) -> bool:
+        """Implements the operator != (inequality).
+
+        See the type documentation for a description of equality semantics.
+
+        :param other: An object to compare with this object.
+        :return: ``True`` if the current object is not equal to the ``other`` parameter; otherwise, ``False``.
+        """
+        if not isinstance(other, LocalDateTime):
+            return NotImplemented
+        return not (self == other)
+
+    def __lt__(self, other: LocalDateTime) -> bool:
+        """Compares two LocalDateTime values to see if the left one is strictly earlier than the right one.
+
+        See the type documentation for a description of ordering semantics.
+
+        :param other: An object to compare with this object.
+        :return: ``True`` if the current object is equal to the ``other`` parameter; otherwise, ``False``.
+        """
+        if not isinstance(other, LocalDateTime):
+            return NotImplemented  # type: ignore[unreachable]
+        _Preconditions._check_argument(
+            self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
+        )
+        return self.compare_to(other) < 0
+
+    def __le__(self, other: LocalDateTime) -> bool:
+        """Compares two LocalDateTime values to see if the left one is earlier than or equal to the right one.
+
+        See the type documentation for a description of ordering semantics.
+
+        :param other: An object to compare with this object.
+        :return: ``True`` if the current object is earlier than or equal to the ``other`` parameter; otherwise,
+            ``False``.
+        """
+        if not isinstance(other, LocalDateTime):
+            return NotImplemented  # type: ignore[unreachable]
+        _Preconditions._check_argument(
+            self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
+        )
+        return self.compare_to(other) <= 0
+
+    def __gt__(self, other: LocalDateTime) -> bool:
+        """Compares two LocalDateTime values to see if the left one is later than the right one.
+
+        See the type documentation for a description of ordering semantics.
+
+        :param other: An object to compare with this object.
+        :return: ``True`` if the current object is strictly later than the ``other`` parameter; otherwise, ``False``.
+        """
+        if not isinstance(other, LocalDateTime):
+            return NotImplemented  # type: ignore[unreachable]
+        _Preconditions._check_argument(
+            self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
+        )
+        return self.compare_to(other) > 0
+
+    def __ge__(self, other: LocalDateTime) -> bool:
+        """Compares two LocalDateTime values to see if the left one is later than or equal to the right one.
+
+        See the type documentation for a description of ordering semantics.
+
+        :param other: An object to compare with this object.
+        :return: ``True`` if the current object is later than or equal to the ``other`` parameter; otherwise, ``False``.
+        """
+        if not isinstance(other, LocalDateTime):
+            return NotImplemented  # type: ignore[unreachable]
+        _Preconditions._check_argument(
+            self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
+        )
+        return self.compare_to(other) >= 0
+
+    def compare_to(self, other: LocalDateTime | None) -> int:
+        """Indicates whether this date/time is earlier, later or the same as another one.
+
+        See the type documentation for a description of ordering semantics.
+
+        :param other: The other local date/time to compare with this value.
+        :raises ValueError: The calendar system of ``other`` is not the same as the calendar system of this value.
+        :return: A value less than zero if this date/time is earlier than ``other``; zero if this date/time is the same
+            as ``other``; a value greater than zero if this value is later than ``other``.
+        """
+        if other is None:
+            return 1
+        if not isinstance(other, LocalDateTime):
+            raise TypeError(f"{self.__class__.__name__} cannot be compared to {other.__class__.__name__}")
+        # This will check calendars...
+        date_comparison = self.__date.compare_to(other.__date)
+        if date_comparison != 0:
+            return date_comparison
+        return self.__time.compare_to(other.__time)
+
+    def __add__(self, other: Period) -> LocalDateTime:
+        """Adds a period to a local date/time.
+
+        Fields are added in descending order of significance (years first, then months, and so on).
+
+        This is a convenience operator over the ``plus`` method.
+
+        :param other: Period to add
+        :return: The resulting local date and time
+        """
+        from . import Period
+
+        if isinstance(other, Period):
+            return self.plus(other)
+        return NotImplemented  # type: ignore[unreachable]
+
+    @staticmethod
+    def add(local_date_time: LocalDateTime, period: Period) -> LocalDateTime:
+        """Add the specified period to the date and time.
+
+        Fields are added in descending order of significance (years first, then months, and so on).
+
+        Friendly alternative to ``+``.
+
+        :param local_date_time: Initial local date and time
+        :param period: Period to add
+        :return: The resulting local date and time
+        """
+        return local_date_time.plus(period)
+
+    def plus(self, period: Period) -> LocalDateTime:
+        """Adds a period to this local date/time.
+
+        Fields are added in descending order of significance (years first, then months, and so on).
+
+        :param period: Period to add
+        :return: The resulting local date and time
+        """
+        _Preconditions._check_not_null(period, "period")
+        extra_days = 0
+        time = self.time_of_day
+        from .fields._time_period_field import _TimePeriodField
+
+        time, plus_extra_days = _TimePeriodField._hours._add_local_time_with_extra_days(time, period.hours)
+        extra_days += plus_extra_days
+        time, plus_extra_days = _TimePeriodField._minutes._add_local_time_with_extra_days(time, period.minutes)
+        extra_days += plus_extra_days
+        time, plus_extra_days = _TimePeriodField._seconds._add_local_time_with_extra_days(time, period.seconds)
+        extra_days += plus_extra_days
+        time, plus_extra_days = _TimePeriodField._milliseconds._add_local_time_with_extra_days(
+            time, period.milliseconds
+        )
+        extra_days += plus_extra_days
+        time, plus_extra_days = _TimePeriodField._ticks._add_local_time_with_extra_days(time, period.ticks)
+        extra_days += plus_extra_days
+        time, plus_extra_days = _TimePeriodField._nanoseconds._add_local_time_with_extra_days(time, period.nanoseconds)
+        extra_days += plus_extra_days
+        date = (
+            self.date.plus_years(period.years)
+            .plus_months(period.months)
+            .plus_weeks(period.weeks)
+            .plus_days(period.days + extra_days)
+        )
+        return LocalDateTime._ctor(local_date=date, local_time=time)
+
+    @overload
+    def __sub__(self, other: Period) -> LocalDateTime:
+        """Subtracts a period from a local date/time.
+
+        Fields are subtracted in descending order of significance (years first, then months, and so on).
+
+        This is a convenience operator over the ``minus(Period)`` method.
+
+        :param other: Period to subtract
+        :return: The resulting local date and time
+        """
+
+    @overload
+    def __sub__(self, other: LocalDateTime) -> Period:
+        """Subtracts one date/time from another, returning the result as a ``Period``.
+
+        This is simply a convenience operator for calling ``Period.between(LocalDateTime, LocalDateTime)``.
+
+        The calendar systems of the two date/times must be the same.
+
+        :param other: The date/time to subtract
+        :return: The result of subtracting one date/time from another.
+        """
+
+    def __sub__(self, other: Period | LocalDateTime) -> LocalDateTime | Period:
+        from . import Period
+
+        if isinstance(other, Period):
+            return self.minus(other)
+        if isinstance(other, LocalDateTime):
+            return Period.between(other, self)
+        return NotImplemented  # type: ignore[unreachable]
+
+    @staticmethod
+    @overload
+    def subtract(local_date_time: LocalDateTime, period: Period, /) -> LocalDateTime:
+        """Subtracts a period from a local date/time.
+
+        Friendly alternative to ``-``.
+
+        :param local_date_time: Initial local date and time
+        :param period: Period to subtract
+        :return: The resulting local date and time
+        """
+
+    @staticmethod
+    @overload
+    def subtract(lhs: LocalDateTime, rhs: LocalDateTime, /) -> Period:
+        """Subtracts one date/time from another, returning the result as a ``Period``.
+
+        This is simply a convenience method for calling ``Period.between(LocalDateTime, LocalDateTime)``.
+
+        The calendar systems of the two date/times must be the same.
+
+        :param lhs: The date/time to subtract from
+        :param rhs: The date/time to subtract
+        :return: The result of subtracting one date/time from another.
+        """
+
+    @staticmethod
+    def subtract(local_date_time: LocalDateTime, other: Period | LocalDateTime, /) -> LocalDateTime | Period:
+        return local_date_time.minus(other)
+
+    @overload
+    def minus(self, period: Period, /) -> LocalDateTime:
+        """Subtracts a period from a local date/time.
+
+        Fields are subtracted in descending order of significance (years first, then months, and so on.)
+
+        :param period: Period to subtract
+        :return: The resulting local date and time
+        """
+
+    @overload
+    def minus(self, local_date_time: LocalDateTime, /) -> Period:
+        """Subtracts the specified date/time from this date/time, returning the result as a ``Period``.
+
+        Fluent alternative to ``-``.
+
+        The specified date/time must be in the same calendar system as this.
+
+        :param local_date_time: The date/time to subtract from this
+        :return: The difference between the specified date/time and this one
+        """
+
+    def minus(self, other: Period | LocalDateTime, /) -> LocalDateTime | Period:
+        from pyoda_time import Period
+
+        if isinstance(other, Period):
+            _Preconditions._check_not_null(other, "period")
+            from .fields._time_period_field import _TimePeriodField
+
+            extra_days = 0
+            time = self.time_of_day
+            time, plus_extra_days = _TimePeriodField._hours._add_local_time_with_extra_days(time, -other.hours)
+            extra_days += plus_extra_days
+            time, plus_extra_days = _TimePeriodField._minutes._add_local_time_with_extra_days(time, -other.minutes)
+            extra_days += plus_extra_days
+            time, plus_extra_days = _TimePeriodField._seconds._add_local_time_with_extra_days(time, -other.seconds)
+            extra_days += plus_extra_days
+            time, plus_extra_days = _TimePeriodField._milliseconds._add_local_time_with_extra_days(
+                time, -other.milliseconds
+            )
+            extra_days += plus_extra_days
+            time, plus_extra_days = _TimePeriodField._ticks._add_local_time_with_extra_days(time, -other.ticks)
+            extra_days += plus_extra_days
+            time, plus_extra_days = _TimePeriodField._nanoseconds._add_local_time_with_extra_days(
+                time, -other.nanoseconds
+            )
+            extra_days += plus_extra_days
+            date = (
+                self.date.plus_years(-other.years)
+                .plus_months(-other.months)
+                .plus_weeks(-other.weeks)
+                .plus_days(extra_days - other.days)
+            )
+            return LocalDateTime._ctor(local_date=date, local_time=time)
+        return self - other
+
+    # endregion
+
+    # region object overrides
+
+    # TODO: Equals(object? obj)
+
+    def __hash__(self) -> int:
+        """Returns a hash code for this instance.
+
+        See the type documentation for a description of equality semantics.
+
+        :return: A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash
+            table.
+        """
+        return _hash_code_helper(self.__date, self.__time, self.calendar)
+
+    # endregion
+
     def with_date_adjuster(self, adjuster: Callable[[LocalDate], LocalDate]) -> LocalDateTime:
         """Returns this date/time, with the given date adjuster applied to it, maintaining the existing time of day.
 
@@ -295,175 +681,115 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
         return LocalDateTime._ctor(local_date=self.__date.plus_months(months), local_time=self.__time)
 
     def plus_days(self, days: int) -> LocalDateTime:
+        """Returns a new LocalDateTime representing the current value with the given number of days added.
+
+        This method does not try to maintain the month or year of the current value, so adding 3 days to a value on
+        January 30th will result in a value on February 2nd.
+
+        :param days: The number of days to add
+        :return: The current value plus the given number of days.
+        """
         return LocalDateTime._ctor(local_date=self.__date.plus_days(days), local_time=self.__time)
 
     def plus_weeks(self, weeks: int) -> LocalDateTime:
+        """Returns a new LocalDateTime representing the current value with the given number of weeks added.
+
+        :param weeks: The number of weeks to add
+        :return: The current value plus the given number of weeks.
+        """
         return LocalDateTime._ctor(local_date=self.__date.plus_weeks(weeks), local_time=self.__time)
 
     def plus_hours(self, hours: int) -> LocalDateTime:
+        """Returns a new LocalDateTime representing the current value with the given number of hours added.
+
+        :param hours: The number of hours to add
+        :return: The current value plus the given number of hours.
+        """
         from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._hours._add_local_date_time(self, hours)
 
     def plus_minutes(self, minutes: int) -> LocalDateTime:
+        """Returns a new LocalDateTime representing the current value with the given number of minutes added.
+
+        :param minutes: The number of minutes to add
+        :return: The current value plus the given number of minutes.
+        """
         from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._minutes._add_local_date_time(self, minutes)
 
     def plus_seconds(self, seconds: int) -> LocalDateTime:
+        """Returns a new LocalDateTime representing the current value with the given number of seconds added.
+
+        :param seconds: The number of seconds to add
+        :return: The current value plus the given number of seconds.
+        """
         from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._seconds._add_local_date_time(self, seconds)
 
     def plus_milliseconds(self, milliseconds: int) -> LocalDateTime:
+        """Returns a new LocalDateTime representing the current value with the given number of milliseconds added.
+
+        :param milliseconds: The number of milliseconds to add
+        :return: The current value plus the given number of milliseconds.
+        """
         from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._milliseconds._add_local_date_time(self, milliseconds)
 
     def plus_ticks(self, ticks: int) -> LocalDateTime:
+        """Returns a new LocalDateTime representing the current value with the given number of ticks added.
+
+        :param ticks: The number of ticks to add
+        :return: The current value plus the given number of ticks.
+        """
         from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._ticks._add_local_date_time(self, ticks)
 
     def plus_nanoseconds(self, nanoseconds: int) -> LocalDateTime:
+        """Returns a new LocalDateTime representing the current value with the given number of nanoseconds added.
+
+        :param nanoseconds: The number of nanoseconds to add
+        :return: The current value plus the given number of nanoseconds.
+        """
         from .fields._time_period_field import _TimePeriodField
 
         return _TimePeriodField._nanoseconds._add_local_date_time(self, nanoseconds)
 
-    @classmethod
-    def from_naive_datetime(cls, dt: datetime.datetime, calendar: CalendarSystem = CalendarSystem.iso) -> LocalDateTime:
-        """Converts a timezone-naive ``datetime.datetime`` to a ``LocalDateTime``, optionally in a specified calendar.
+    def next(self, target_day_of_week: IsoDayOfWeek) -> LocalDateTime:
+        """Returns the next ``LocalDateTime`` falling on the specified ``IsoDayOfWeek``, at the same time of day as this
+        value.
 
-        :param dt: Timezone-naive datetime to convert into a Pyoda Time local date and time.
-        :param calendar: The calendar system to convert into.
-        :return: A new ``LocalDateTime`` with the same values as the specified ``datetime.datetime``.
-        :raises ValueError: If ``dt`` is a timezone-aware ``datetime.datetime``.
+        This is a strict "next" - if this value on already falls on the target day of the week, the returned value will
+        be a week later.
+
+        :param target_day_of_week: The ISO day of the week to return the next date of.
+        :return: The next ``LocalDateTime`` falling on the specified day of the week.
+        :raises RuntimeError: The underlying calendar doesn't use ISO days of the week.
+        :raises ValueError: ``target_day_of_week`` is not a valid day of the week (Monday to Sunday).
         """
-        # Unlike Noda Time, we need to verify the tzinfo of the datetime.
-        # In C#, DateTime doesn't have this...
-        # They have DateTimeKind, but that is irrelevant.
-        # What is important is that it is a DateTime, not a DateTimeOffset.
-
-        _Preconditions._check_argument(
-            expession=dt.tzinfo is None,
-            parameter="datetime",
-            message="Invalid datetime.tzinfo for LocalDateTime.from_datetime_utc",
-        )
-        from pyoda_time._local_date import LocalDate
-        from pyoda_time._local_time import LocalTime
-        from pyoda_time._pyoda_constants import PyodaConstants
-
-        days, tick_of_day = _TickArithmetic.ticks_to_days_and_tick_of_day(_to_ticks(dt))
-        days -= PyodaConstants._BCL_DAYS_AT_UNIX_EPOCH
-        return cls._ctor(
-            local_date=LocalDate._ctor(days_since_epoch=days, calendar=calendar),
-            local_time=LocalTime._ctor(nanoseconds=tick_of_day * PyodaConstants.NANOSECONDS_PER_TICK),
+        return LocalDateTime._ctor(
+            local_date=self.__date.next(target_day_of_week=target_day_of_week), local_time=self.__time
         )
 
-    # region Implementation of IEquatable<LocalDateTime>
+    def previous(self, target_day_of_week: IsoDayOfWeek) -> LocalDateTime:
+        """Returns the previous ``LocalDateTime`` falling on the specified ``IsoDayOfWeek``, at the same time of day as
+        this value.
 
-    def equals(self, other: LocalDateTime) -> bool:
-        """Indicates whether the current object is equal to another object of the same type. See the type documentation
-        for a description of equality semantics.
+        This is a strict "previous" - if this value on already falls on the target day of the week, the returned value
+        will be a week earlier.
 
-        :param other: An object to compare with this object.
-        :return: True if the current object is equal to the ``other`` parameter; otherwise, False.
+        :param target_day_of_week: The ISO day of the week to return the previous date of.
+        :return: The previous ``LocalDateTime`` falling on the specified day of the week.
+        :raises RuntimeError: The underlying calendar doesn't use ISO days of the week.
+        :raises ValueError: ``target_day_of_week`` is not a valid day of the week (Monday to Sunday).
         """
-        return self == other
-
-    # endregion
-
-    # region Operators
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, LocalDateTime):
-            return NotImplemented
-        return self.__date == other.__date and self.__time == other.__time
-
-    def __ne__(self, other: object) -> bool:
-        if not isinstance(other, LocalDateTime):
-            return NotImplemented
-        return not (self == other)
-
-    def __lt__(self, other: LocalDateTime) -> bool:
-        if not isinstance(other, LocalDateTime):
-            return NotImplemented  # type: ignore[unreachable]
-        _Preconditions._check_argument(
-            self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
+        return LocalDateTime._ctor(
+            local_date=self.date.previous(target_day_of_week=target_day_of_week), local_time=self.__time
         )
-        return self.compare_to(other) < 0
-
-    def __le__(self, other: LocalDateTime) -> bool:
-        if not isinstance(other, LocalDateTime):
-            return NotImplemented  # type: ignore[unreachable]
-        _Preconditions._check_argument(
-            self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
-        )
-        return self.compare_to(other) <= 0
-
-    def __gt__(self, other: LocalDateTime) -> bool:
-        if not isinstance(other, LocalDateTime):
-            return NotImplemented  # type: ignore[unreachable]
-        _Preconditions._check_argument(
-            self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
-        )
-        return self.compare_to(other) > 0
-
-    def __ge__(self, other: LocalDateTime) -> bool:
-        if not isinstance(other, LocalDateTime):
-            return NotImplemented  # type: ignore[unreachable]
-        _Preconditions._check_argument(
-            self.calendar == other.calendar, "other", "Only values in the same calendar can be compared"
-        )
-        return self.compare_to(other) >= 0
-
-    def compare_to(self, other: LocalDateTime | None) -> int:
-        if other is None:
-            return 1
-        if not isinstance(other, LocalDateTime):
-            raise TypeError(f"{self.__class__.__name__} cannot be compared to {other.__class__.__name__}")
-        # This will check calendars...
-        date_comparison = self.__date.compare_to(other.__date)
-        if date_comparison != 0:
-            return date_comparison
-        return self.__time.compare_to(other.__time)
-
-    def __add__(self, other: Period) -> LocalDateTime:
-        from . import Period
-
-        if isinstance(other, Period):
-            return self.plus(other)
-        return NotImplemented  # type: ignore[unreachable]
-
-    def plus(self, period: Period) -> LocalDateTime:
-        _Preconditions._check_not_null(period, "period")
-        extra_days = 0
-        time = self.time_of_day
-        from .fields._time_period_field import _TimePeriodField
-
-        time, plus_extra_days = _TimePeriodField._hours._add_local_time_with_extra_days(time, period.hours)
-        extra_days += plus_extra_days
-        time, plus_extra_days = _TimePeriodField._minutes._add_local_time_with_extra_days(time, period.minutes)
-        extra_days += plus_extra_days
-        time, plus_extra_days = _TimePeriodField._seconds._add_local_time_with_extra_days(time, period.seconds)
-        extra_days += plus_extra_days
-        time, plus_extra_days = _TimePeriodField._milliseconds._add_local_time_with_extra_days(
-            time, period.milliseconds
-        )
-        extra_days += plus_extra_days
-        time, plus_extra_days = _TimePeriodField._ticks._add_local_time_with_extra_days(time, period.ticks)
-        extra_days += plus_extra_days
-        time, plus_extra_days = _TimePeriodField._nanoseconds._add_local_time_with_extra_days(time, period.nanoseconds)
-        extra_days += plus_extra_days
-        date = (
-            self.date.plus_years(period.years)
-            .plus_months(period.months)
-            .plus_weeks(period.weeks)
-            .plus_days(period.days + extra_days)
-        )
-        return LocalDateTime._ctor(local_date=date, local_time=time)
-
-    # endregion
 
     def with_offset(self, offset: Offset) -> OffsetDateTime:
         """Returns an ``OffsetDateTime`` for this local date/time with the given offset.
@@ -500,6 +826,79 @@ class LocalDateTime(metaclass=_LocalDateTimeMeta):
             ),
             zone=DateTimeZone.utc,
         )
+
+    def in_zone_strictly(self, zone: DateTimeZone) -> ZonedDateTime:
+        """Returns the mapping of this local date/time within the given ``DateTimeZone``, with "strict" rules applied
+        such that an exception is thrown if either the mapping is ambiguous or the time is skipped.
+
+        See ``in_zone_leniently`` and ``in_zone`` for alternative ways to map a local time to a specific instant.
+        This is solely a convenience method for calling ``DateTimeZone.at_strictly``.
+
+        :param zone: The time zone in which to map this local date/time.
+        :exception SkippedTimeError: This local date/time is skipped in the given time zone.
+        :exception AmbiguousTimeError: This local date/time is ambiguous in the given time zone.
+        :return: The result of mapping this local date/time in the given time zone.
+        """
+        _Preconditions._check_not_null(zone, "zone")
+        return zone.at_strictly(self)
+
+    def in_zone_leniently(self, zone: DateTimeZone) -> ZonedDateTime:
+        """Returns the mapping of this local date/time within the given ``DateTimeZone``, with "lenient" rules applied
+        such that ambiguous values map to the earlier of the alternatives, and "skipped" values are shifted forward by
+        the duration of the "gap".
+
+        See ``in_zone_strictly`` and ``in_zone`` for alternative ways to map a local time to a specific instant.
+        This is solely a convenience method for calling ``DateTimeZone.at_leniently``.
+
+        :param zone: The time zone in which to map this local date/time.
+        :return: The result of mapping this local date/time in the given time zone.
+        """
+        _Preconditions._check_not_null(zone, "zone")
+        return zone.at_leniently(self)
+
+    def in_zone(self, zone: DateTimeZone, resolver: ZoneLocalMappingResolver) -> ZonedDateTime:
+        """Resolves this local date and time into a ``ZonedDateTime`` in the given time zone, following the given
+        ``ZoneLocalMappingResolver`` to handle ambiguity and skipped times.
+
+        See ``in_zone_strictly`` and ``in_zone_leniently`` for alternative ways to map a local time to a specific
+        instant.
+
+        This is a convenience method for calling
+        ``DateTimeZone.resolve_local(LocalDateTime, ZoneLocalMappingResolver)``.
+
+        :param zone: The time zone in which to map this local date and time into.
+        :param resolver: The resolver to apply to the mapping.
+        :return: The result of resolving the mapping.
+        """
+        _Preconditions._check_not_null(zone, "zone")
+        _Preconditions._check_not_null(resolver, "resolver")
+        return zone.resolve_local(self, resolver)
+
+    # TODO: Deconstruct
+
+    @staticmethod
+    def max(x: LocalDateTime, y: LocalDateTime) -> LocalDateTime:
+        """Returns the later date/time of the given two.
+
+        :param x: The first date/time to compare.
+        :param y: The second date/time to compare.
+        :exception ValueError: The two date/times have different calendar systems.
+        :return: The later date/time of ``x`` or ``y``.
+        """
+        return max(x, y)
+
+    # TODO: Deconstruct
+
+    @staticmethod
+    def min(x: LocalDateTime, y: LocalDateTime) -> LocalDateTime:
+        """Returns the earlier date/time of the given two.
+
+        :param x: The first date/time to compare.
+        :param y: The second date/time to compare.
+        :exception ValueError: The two date/times have different calendar systems.
+        :return: The earlier date/time of ``x`` or ``y``.
+        """
+        return min(x, y)
 
     # region Formatting
 

--- a/pyoda_time/fields/_time_period_field.py
+++ b/pyoda_time/fields/_time_period_field.py
@@ -88,9 +88,10 @@ class _TimePeriodField(metaclass=_TimePeriodFieldMeta):
         # It's possible that there are better ways to do this, but this at least feels simple.
         if value >= 0:
             if value >= self.__units_per_day:
-                # TODO: checked
+                long_days = _towards_zero_division(value, self.__units_per_day)
                 # If this overflows, that's fine. (An OverflowException is a reasonable outcome.)
-                # days = checked((int) longDays);
+                # TODO: checked
+                days = long_days
                 value = _csharp_modulo(value, self.__units_per_day)
             nanos_to_add = value * self.__unit_nanoseconds
             new_nanos = local_time.nanosecond_of_day + nanos_to_add
@@ -102,11 +103,11 @@ class _TimePeriodField(metaclass=_TimePeriodFieldMeta):
             extra_days += days
             return LocalTime._ctor(nanoseconds=new_nanos), extra_days
         else:
-            if value <= self.__units_per_day:
-                long_days = _towards_zero_division(value, self.__units_per_day)  # noqa
-                # TODO: checked
+            if value <= -self.__units_per_day:
+                long_days = _towards_zero_division(value, self.__units_per_day)
                 # If this overflows, that's fine. (An OverflowException is a reasonable outcome.)
-                # days = checked((int) longDays);
+                # TODO: checked
+                days = long_days
                 value = _csharp_modulo(value, self.__units_per_day)
             nanos_to_add = value * self.__unit_nanoseconds
             new_nanos = local_time.nanosecond_of_day + nanos_to_add

--- a/tests/test_local_date_time.py
+++ b/tests/test_local_date_time.py
@@ -7,15 +7,27 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from pyoda_time import (
+    AmbiguousTimeError,
     CalendarSystem,
     DateAdjusters,
     DateTimeZone,
     DateTimeZoneProviders,
+    IsoDayOfWeek,
     LocalDate,
     LocalDateTime,
+    LocalTime,
+    Offset,
+    Period,
+    PeriodBuilder,
     PyodaConstants,
+    SkippedTimeError,
     TimeAdjusters,
 )
+from pyoda_time.calendars import IslamicEpoch, IslamicLeapYearPattern
+from pyoda_time.calendars._gregorian_year_month_day_calculator import _GregorianYearMonthDayCalculator
+from pyoda_time.time_zones import Resolvers
+from pyoda_time.utility._csharp_compatibility import _CsharpConstants
+from tests import helpers
 
 PACIFIC: DateTimeZone = DateTimeZoneProviders.tzdb["America/Los_Angeles"]
 
@@ -30,6 +42,8 @@ class TestLocalDateTime:
         assert actual.tzinfo is None
 
     def test_to_naive_datetime_julian_calendar(self) -> None:
+        # In Noda Time, `expected` is also in the Julian calendar.
+        # Not possible with Python's datetime module.
         ldt = LocalDateTime(2011, 3, 5, 1, 0, 0, calendar=CalendarSystem.julian)
         expected = datetime(2011, 3, 18, 1, 0, 0)
         actual = ldt.to_naive_datetime()
@@ -70,13 +84,535 @@ class TestLocalDateTime:
         assert str(e.value) == "Invalid datetime.tzinfo for LocalDateTime.from_datetime_utc"
         assert e.value.__notes__ == ["Parameter name: datetime"]
 
+    def test_time_properties_after_epoch(self) -> None:
+        # Use the largest valid year as part of validating against overflow
+        ldt = LocalDateTime(_GregorianYearMonthDayCalculator._MAX_GREGORIAN_YEAR, 1, 2, 15, 48, 25).plus_nanoseconds(
+            123456789
+        )
+        assert ldt.hour == 15
+        assert ldt.clock_hour_of_half_day == 3
+        assert ldt.minute == 48
+        assert ldt.second == 25
+        assert ldt.millisecond == 123
+        assert ldt.microsecond == 123456
+        assert ldt.tick_of_second == 1234567
+        assert (
+            ldt.tick_of_day
+            == 15 * PyodaConstants.TICKS_PER_HOUR
+            + 48 * PyodaConstants.TICKS_PER_MINUTE
+            + 25 * PyodaConstants.TICKS_PER_SECOND
+            + 1234567
+        )
+        assert (
+            ldt.nanosecond_of_day
+            == 15 * PyodaConstants.NANOSECONDS_PER_HOUR
+            + 48 * PyodaConstants.NANOSECONDS_PER_MINUTE
+            + 25 * PyodaConstants.NANOSECONDS_PER_SECOND
+            + 123456789
+        )
+        assert ldt.nanosecond_of_second == 123456789
+
+    def test_time_properties_before_epoch(self) -> None:
+        # Use the smallest valid year number as part of validating against overflow
+        ldt = LocalDateTime(_GregorianYearMonthDayCalculator._MIN_GREGORIAN_YEAR, 1, 2, 15, 48, 25).plus_nanoseconds(
+            123456789
+        )
+        assert ldt.hour == 15
+        assert ldt.clock_hour_of_half_day == 3
+        assert ldt.minute == 48
+        assert ldt.second == 25
+        assert ldt.millisecond == 123
+        assert ldt.microsecond == 123456
+        assert ldt.tick_of_second == 1234567
+        assert (
+            ldt.tick_of_day
+            == 15 * PyodaConstants.TICKS_PER_HOUR
+            + 48 * PyodaConstants.TICKS_PER_MINUTE
+            + 25 * PyodaConstants.TICKS_PER_SECOND
+            + 1234567
+        )
+        assert (
+            ldt.nanosecond_of_day
+            == 15 * PyodaConstants.NANOSECONDS_PER_HOUR
+            + 48 * PyodaConstants.NANOSECONDS_PER_MINUTE
+            + 25 * PyodaConstants.NANOSECONDS_PER_SECOND
+            + 123456789
+        )
+        assert ldt.nanosecond_of_second == 123456789
+
+    # TODO: DateTime_Roundtrip_OtherCalendarInBcl
+
+    def test_with_calendar(self) -> None:
+        iso_epoch = LocalDateTime(1970, 1, 1, 0, 0, 0)
+        julian_epoch = iso_epoch.with_calendar(CalendarSystem.julian)
+        assert julian_epoch.year == 1969
+        assert julian_epoch.month == 12
+        assert julian_epoch.day == 19
+        assert julian_epoch.time_of_day == iso_epoch.time_of_day
+
+    def test_time_of_day_before_1970(self) -> None:
+        """Verifies that negative local instant ticks don't cause a problem with the date."""
+        date_time = LocalDateTime(1965, 11, 8, 12, 5, 23)
+        expected = LocalTime(12, 5, 23)
+        assert date_time.time_of_day == expected
+
+    def test_time_of_day_after_1970(self) -> None:
+        """Verifies that positive local instant ticks don't cause a problem with the date."""
+        date_time = LocalDateTime(1975, 11, 8, 12, 5, 23)
+        expected = LocalTime(12, 5, 23)
+        assert date_time.time_of_day == expected
+
+    def test_date_before_1970(self) -> None:
+        """Verifies that negative local instant ticks don't cause a problem with the date."""
+        date_time = LocalDateTime(1965, 11, 8, 12, 5, 23)
+        expected = LocalDate(1965, 11, 8)
+        assert date_time.date == expected
+
+    def test_date_after_1970(self) -> None:
+        """Verifies that positive local instant ticks don't cause a problem with the date."""
+        date_time = LocalDateTime(1975, 11, 8, 12, 5, 23)
+        expected = LocalDate(1975, 11, 8)
+        assert date_time.date == expected
+
+    # TODO: def test_day_of_week_around_epoch(self) -> None: [requires bcl]
+
+    def test_clock_hour_of_half_day(self) -> None:
+        assert LocalDateTime(1975, 11, 8, 0, 0, 0).clock_hour_of_half_day == 12
+        assert LocalDateTime(1975, 11, 8, 1, 0, 0).clock_hour_of_half_day == 1
+        assert LocalDateTime(1975, 11, 8, 12, 0, 0).clock_hour_of_half_day == 12
+        assert LocalDateTime(1975, 11, 8, 13, 0, 0).clock_hour_of_half_day == 1
+        assert LocalDateTime(1975, 11, 8, 23, 0, 0).clock_hour_of_half_day == 11
+
+    def test_operators_same_calendar(self) -> None:
+        value1 = LocalDateTime(2011, 1, 2, 10, 30, 0)
+        value2 = LocalDateTime(2011, 1, 2, 10, 30, 0)
+        value3 = LocalDateTime(2011, 1, 2, 10, 45, 0)
+        helpers.test_operator_comparison_equality(value1, value2, value3)
+
+    def test_operator_different_calendars_throws(self) -> None:
+        value1 = LocalDateTime(2011, 1, 2, 10, 30)
+        value2 = LocalDateTime(2011, 1, 2, 10, 30, calendar=CalendarSystem.julian)
+
+        assert not value1 == value2
+        assert value1 != value2
+
+        with pytest.raises(ValueError):  # ArgumentException in Noda Time
+            value1 < value2
+        with pytest.raises(ValueError):
+            value1 <= value2
+        with pytest.raises(ValueError):
+            value1 > value2
+        with pytest.raises(ValueError):
+            value1 >= value2
+
+    def test_compare_to_same_calendar(self) -> None:
+        value1 = LocalDateTime(2011, 1, 2, 10, 30)
+        value2 = LocalDateTime(2011, 1, 2, 10, 30)
+        value3 = LocalDateTime(2011, 1, 2, 10, 45)
+
+        assert value1.compare_to(value2) == 0
+        assert value1.compare_to(value3) < 0
+        assert value3.compare_to(value2) > 0
+
+    def test_compare_to_different_calendars_throws(self) -> None:
+        islamic = CalendarSystem.get_islamic_calendar(IslamicLeapYearPattern.BASE15, IslamicEpoch.ASTRONOMICAL)
+        value1 = LocalDateTime(2011, 1, 2, 10, 30)
+        value2 = LocalDateTime(2011, 1, 2, 10, 30, calendar=islamic)
+
+        with pytest.raises(ValueError):  # ArgumentException in Noda Time
+            value1.compare_to(value2)
+
+    # The `IComparableCompareTo_SameCalendar` test is redundant here.
+
+    def test_icomparable_compare_to_null_positive(self) -> None:
+        instance = LocalDateTime(2012, 3, 5, 10, 45)
+        result = instance.compare_to(None)
+        assert result > 0
+
+    def test_icomparable_compare_to_wrong_type_argument_exception(self) -> None:
+        instance = LocalDateTime(2012, 3, 5, 10, 45)
+        arg = LocalDate(2012, 3, 6)
+        with pytest.raises(TypeError):
+            instance.compare_to(arg)  # type: ignore[arg-type]
+
+    def test_with_offset(self) -> None:
+        offset = Offset.from_hours_and_minutes(5, 10)
+        local_date_time = LocalDateTime(2009, 12, 22, 21, 39, 30)
+        offset_date_time = local_date_time.with_offset(offset)
+        assert offset_date_time.local_date_time == local_date_time
+
+    def test_in_utc(self) -> None:
+        local = LocalDateTime(2009, 12, 22, 21, 39, 30)
+        zoned = local.in_utc()
+        assert zoned.local_date_time == local
+        assert zoned.offset == Offset.zero
+        assert zoned.zone is DateTimeZone.utc
+
+    def test_in_zone_strictly_in_winter(self) -> None:
+        local = LocalDateTime(2009, 12, 22, 21, 39, 30)
+        zoned = local.in_zone_strictly(PACIFIC)
+        assert zoned.local_date_time == local
+        assert zoned.offset == Offset.from_hours(-8)
+
+    def test_in_zone_strictly_in_summer(self) -> None:
+        local = LocalDateTime(2009, 6, 22, 21, 39, 30)
+        zoned = local.in_zone_strictly(PACIFIC)
+        assert zoned.local_date_time == local
+        assert zoned.offset == Offset.from_hours(-7)
+
+    def test_in_zone_strictly_throws_when_ambiguous(self) -> None:
+        """Pacific time changed from -7 to -8 at 2am wall time on November 2nd 2009, so 2am became 1am."""
+        local = LocalDateTime(2009, 11, 1, 1, 30, 0)
+        with pytest.raises(AmbiguousTimeError):
+            local.in_zone_strictly(PACIFIC)
+
+    def test_in_zone_strictly_throws_when_skipped(self) -> None:
+        """Pacific time changed from -8 to -7 at 2am wall time on March 8th 2009, so 2am became 3am.
+
+        This means that 2.30am doesn't exist on that day.
+        """
+        local = LocalDateTime(2009, 3, 8, 2, 30, 0)
+        with pytest.raises(SkippedTimeError):
+            local.in_zone_strictly(PACIFIC)
+
+    def test_in_zone_leniently_ambiguous_time_returns_earlier_mapping(self) -> None:
+        """Pacific time changed from -7 to -8 at 2am wall time on November 2nd 2009, so 2am became 1am.
+
+        We'll return the earlier result, i.e. with the offset of -7
+        """
+        local = LocalDateTime(2009, 11, 1, 1, 30, 0)
+        zoned = local.in_zone_leniently(PACIFIC)
+        assert zoned.local_date_time == local
+        assert zoned.offset == Offset.from_hours(-7)
+
+    def test_in_zone_leniently_returns_start_of_second_interval(self) -> None:
+        """Pacific time changed from -8 to -7 at 2am wall time on March 8th 2009, so 2am became 3am.
+
+        This means that 2:30am doesn't exist on that day. We'll return 3:30am, the forward-shifted value.
+        """
+        local = LocalDateTime(2009, 3, 8, 2, 30, 0)
+        zoned = local.in_zone_leniently(PACIFIC)
+        assert zoned.local_date_time == LocalDateTime(2009, 3, 8, 3, 30, 0)
+        assert zoned.offset == Offset.from_hours(-7)
+
+    def test_in_zone(self) -> None:
+        # Don't need much for this - it only delegates.
+        ambiguous = LocalDateTime()
+        skipped = LocalDateTime()
+        assert ambiguous.in_zone(PACIFIC, Resolvers.lenient_resolver) == PACIFIC.at_leniently(ambiguous)
+        assert skipped.in_zone(PACIFIC, Resolvers.lenient_resolver) == PACIFIC.at_leniently(skipped)
+
     def test_default_constructor(self) -> None:
         """Using the default constructor is equivalent to January 1st 1970, midnight, UTC, ISO calendar."""
         actual = LocalDateTime()
         assert actual == LocalDateTime(1, 1, 1, 0, 0)
 
+    # TODO:
+    #  XmlSerialization_Iso
+    #  XmlSerialization_NonIso
+    #  XmlSerialization_Invalid
+    #  XmlSerialization_Invalid
+
+    def test_min_max_different_calendars_throws(self) -> None:
+        ldt1 = LocalDateTime(2011, 1, 2, 2, 20)
+        ldt2 = LocalDateTime(1500, 1, 1, 5, 10, calendar=CalendarSystem.julian)
+
+        with pytest.raises(ValueError):
+            LocalDateTime.max(ldt1, ldt2)
+        with pytest.raises(ValueError):
+            LocalDateTime.min(ldt1, ldt2)
+
+    def test_min_max_same_calendar(self) -> None:
+        ldt1 = LocalDateTime(1500, 1, 1, 7, 20, calendar=CalendarSystem.julian)
+        ldt2 = LocalDateTime(1500, 1, 1, 5, 10, calendar=CalendarSystem.julian)
+
+        assert LocalDateTime.max(ldt1, ldt2) == ldt1
+        assert LocalDateTime.max(ldt2, ldt1) == ldt1
+        assert LocalDateTime.min(ldt1, ldt2) == ldt2
+        assert LocalDateTime.min(ldt2, ldt1) == ldt2
+
+    # TODO: Deconstruction (see Pyoda Time issue 248)
+
+    def test_equality(self) -> None:
+        value = LocalDateTime(2017, 10, 15, 21, 30, 0, 0, calendar=CalendarSystem.iso)
+        equal_value = LocalDateTime(2017, 10, 15, 21, 30, 0, 0, calendar=CalendarSystem.iso)
+        unequal_values = [
+            LocalDateTime(2018, 10, 15, 21, 30, 0, 0, CalendarSystem.iso),
+            LocalDateTime(2017, 11, 15, 21, 30, 0, 0, CalendarSystem.iso),
+            LocalDateTime(2017, 10, 16, 21, 30, 0, 0, CalendarSystem.iso),
+            LocalDateTime(2017, 10, 15, 22, 30, 0, 0, CalendarSystem.iso),
+            LocalDateTime(2017, 10, 15, 21, 31, 0, 0, CalendarSystem.iso),
+            LocalDateTime(2017, 10, 15, 21, 30, 1, 0, CalendarSystem.iso),
+            LocalDateTime(2017, 10, 15, 21, 30, 0, 1, CalendarSystem.iso),
+            LocalDateTime(2017, 10, 15, 21, 30, 0, 0, CalendarSystem.gregorian),
+        ]
+        helpers.test_equals_struct(
+            value,
+            equal_value,
+            *unequal_values,
+        )
+
+    def test_max_iso_value(self) -> None:
+        value = LocalDateTime.max_iso_value
+        assert value.calendar == CalendarSystem.iso
+        with pytest.raises(OverflowError):
+            value.plus_nanoseconds(1)
+
+    def test_min_iso_value(self) -> None:
+        value = LocalDateTime.min_iso_value
+        assert value.calendar == CalendarSystem.iso
+        with pytest.raises(OverflowError):
+            value.plus_nanoseconds(-1)
+
 
 class TestLocalDateTimePseudomutators:
+    def test_plus_year_simple(self) -> None:
+        start = LocalDateTime(2011, 6, 26, 12, 15, 8)
+        expected = LocalDateTime(2016, 6, 26, 12, 15, 8)
+        assert start.plus_years(5) == expected
+
+        expected = LocalDateTime(2006, 6, 26, 12, 15, 8)
+        assert start.plus_years(-5) == expected
+
+    def test_assert_plus_year_leap_to_non_leap(self) -> None:
+        start = LocalDateTime(2012, 2, 29, 12, 15, 8)
+        expected = LocalDateTime(2013, 2, 28, 12, 15, 8)
+        assert start.plus_years(1) == expected
+
+        expected = LocalDateTime(2011, 2, 28, 12, 15, 8)
+        assert start.plus_years(-1) == expected
+
+    def test_plus_year_leap_to_leap(self) -> None:
+        start = LocalDateTime(2012, 2, 29, 12, 15, 8)
+        expected = LocalDateTime(2016, 2, 29, 12, 15, 8)
+        assert start.plus_years(4) == expected
+
+    def test_plus_month_simple(self) -> None:
+        start = LocalDateTime(2012, 4, 15, 12, 15, 8)
+        expected = LocalDateTime(2012, 8, 15, 12, 15, 8)
+        assert start.plus_months(4) == expected
+
+    def test_plus_month_changing_year(self) -> None:
+        start = LocalDateTime(2012, 10, 15, 12, 15, 8)
+        expected = LocalDateTime(2013, 2, 15, 12, 15, 8)
+        assert start.plus_months(4) == expected
+
+    def test_plus_month_with_truncation(self) -> None:
+        start = LocalDateTime(2011, 1, 30, 12, 15, 8)
+        expected = LocalDateTime(2011, 2, 28, 12, 15, 8)
+        assert start.plus_months(1) == expected
+
+    def test_plus_days_simple(self) -> None:
+        start = LocalDateTime(2011, 1, 15, 12, 15, 8)
+        expected = LocalDateTime(2011, 1, 23, 12, 15, 8)
+        assert start.plus_days(8) == expected
+
+        expected = LocalDateTime(2011, 1, 7, 12, 15, 8)
+        assert start.plus_days(-8) == expected
+
+    def test_plus_days_month_boundary(self) -> None:
+        start = LocalDateTime(2011, 1, 26, 12, 15, 8)
+        expected = LocalDateTime(2011, 2, 3, 12, 15, 8)
+        assert start.plus_days(8) == expected
+
+        # Round-trip back across the boundary
+        assert start.plus_days(8).plus_days(-8) == start
+
+    def test_plus_days_year_boundary(self) -> None:
+        start = LocalDateTime(2011, 12, 26, 12, 15, 8)
+        expected = LocalDateTime(2012, 1, 3, 12, 15, 8)
+        assert start.plus_days(8) == expected
+
+        # Round-trip back across the boundary
+        assert start.plus_days(8).plus_days(-8) == start
+
+    def test_plus_days_end_of_february_in_leap_year(self) -> None:
+        start = LocalDateTime(2012, 2, 26, 12, 15, 8)
+        expected = LocalDateTime(2012, 3, 5, 12, 15, 8)
+        assert start.plus_days(8) == expected
+        # Round-trip back across the boundary
+        assert start.plus_days(8).plus_days(-8) == start
+
+    def test_plus_days_end_of_february_not_in_leap_year(self) -> None:
+        start = LocalDateTime(2011, 2, 26, 12, 15, 8)
+        expected = LocalDateTime(2011, 3, 6, 12, 15, 8)
+        assert start.plus_days(8) == expected
+
+        # Round-trip back across the boundary
+        assert start.plus_days(8).plus_days(-8) == start
+
+    def test_plus_weeks_simple(self) -> None:
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        expected_forward = LocalDateTime(2011, 4, 23, 12, 15, 8)
+        expected_backward = LocalDateTime(2011, 3, 12, 12, 15, 8)
+        assert start.plus_weeks(3) == expected_forward
+        assert start.plus_weeks(-3) == expected_backward
+
+    def test_plus_hours_simple(self) -> None:
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        expected_forward = LocalDateTime(2011, 4, 2, 14, 15, 8)
+        expected_backward = LocalDateTime(2011, 4, 2, 10, 15, 8)
+        assert start.plus_hours(2) == expected_forward
+        assert start.plus_hours(-2) == expected_backward
+
+    def test_plus_hours_crossing_day_boundary(self) -> None:
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        expected = LocalDateTime(2011, 4, 3, 8, 15, 8)
+        assert start.plus_hours(20) == expected
+        assert start.plus_hours(20).plus_hours(-20) == start
+
+    def test_plus_hours_crossing_year_boundary(self) -> None:
+        # Christmas day + 10 days and 1 hour
+        start = LocalDateTime(2011, 12, 25, 12, 15, 8)
+        expected = LocalDateTime(2012, 1, 4, 13, 15, 8)
+        assert start.plus_hours(241) == expected
+        assert start.plus_hours(241).plus_hours(-241) == start
+
+    def test_plus_minutes_simple(self) -> None:
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        expected_forward = LocalDateTime(2011, 4, 2, 12, 17, 8)
+        expected_backward = LocalDateTime(2011, 4, 2, 12, 13, 8)
+        assert start.plus_minutes(2) == expected_forward
+        assert start.plus_minutes(-2) == expected_backward
+
+    def test_plus_seconds_simple(self) -> None:
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        expected_forward = LocalDateTime(2011, 4, 2, 12, 15, 18)
+        expected_backward = LocalDateTime(2011, 4, 2, 12, 14, 58)
+        assert start.plus_seconds(10) == expected_forward
+        assert start.plus_seconds(-10) == expected_backward
+
+    def test_plus_milliseconds_simple(self) -> None:
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8, 300)
+        expected_forward = LocalDateTime(2011, 4, 2, 12, 15, 8, 700)
+        expected_backward = LocalDateTime(2011, 4, 2, 12, 15, 7, 900)
+        assert start.plus_milliseconds(400) == expected_forward
+        assert start.plus_milliseconds(-400) == expected_backward
+
+    def test_plus_ticks_simple(self) -> None:
+        date = LocalDate(2011, 4, 2)
+        start_time = LocalTime.from_hour_minute_second_millisecond_tick(12, 15, 8, 300, 7500)
+        expected_forward_time = LocalTime.from_hour_minute_second_millisecond_tick(12, 15, 8, 301, 1500)
+        expected_backward_time = LocalTime.from_hour_minute_second_millisecond_tick(12, 15, 8, 300, 3500)
+        assert (date + start_time).plus_ticks(4000) == date + expected_forward_time
+        assert (date + start_time).plus_ticks(-4000) == date + expected_backward_time
+
+    def test_plus_ticks_long(self) -> None:
+        assert PyodaConstants.TICKS_PER_DAY > _CsharpConstants.INT_MAX_VALUE
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        expected_forward = LocalDateTime(2011, 4, 3, 12, 15, 8)
+        expected_backward = LocalDateTime(2011, 4, 1, 12, 15, 8)
+
+        assert start.plus_ticks(PyodaConstants.TICKS_PER_DAY) == expected_forward
+        assert start.plus_ticks(-PyodaConstants.TICKS_PER_DAY) == expected_backward
+
+    def test_plus_nanoseconds_simple(self) -> None:
+        # Just use the ticks values
+        date = LocalDate(2011, 4, 2)
+        start_time = LocalTime.from_hour_minute_second_millisecond_tick(12, 15, 8, 300, 7500)
+        expected_forward_time = LocalTime.from_hour_minute_second_millisecond_tick(12, 15, 8, 300, 7540)
+        expected_backward_time = LocalTime.from_hour_minute_second_millisecond_tick(12, 15, 8, 300, 7460)
+        assert (date + start_time).plus_nanoseconds(4000) == date + expected_forward_time
+        assert (date + start_time).plus_nanoseconds(-4000) == date + expected_backward_time
+
+    def test_plus_ticks_crossing_day(self) -> None:
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        expected_forward = LocalDateTime(2011, 4, 3, 12, 15, 8)
+        expected_backward = LocalDateTime(2011, 4, 1, 12, 15, 8)
+        assert start.plus_nanoseconds(PyodaConstants.NANOSECONDS_PER_DAY) == expected_forward
+        assert start.plus_nanoseconds(-PyodaConstants.NANOSECONDS_PER_DAY) == expected_backward
+
+    def test_plus_full_period(self) -> None:
+        # Period deliberately chosen to require date rollover
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        period = PeriodBuilder(
+            years=1, months=2, weeks=3, days=4, hours=15, minutes=6, seconds=7, milliseconds=8, ticks=9, nanoseconds=11
+        ).build()
+        actual = start.plus(period)
+        expected = LocalDateTime(2012, 6, 28, 3, 21, 15).plus_nanoseconds(8000911)
+        assert actual == expected, f"{expected:uuuu-MM-dd HH:mm:ss.fffffffff} != {actual:uuuu-MM-dd HH:mm:ss.fffffffff}"
+
+    def test_minus_full_period(self) -> None:
+        # Period deliberately chosen to require date rollover
+        start = LocalDateTime(2011, 4, 2, 12, 15, 8)
+        period = PeriodBuilder(
+            years=1, months=2, weeks=3, days=4, hours=15, minutes=6, seconds=7, milliseconds=8, ticks=9, nanoseconds=11
+        ).build()
+        actual = start.minus(period)
+        expected = LocalDateTime(2010, 1, 7, 21, 9, 0).plus_nanoseconds(991999089)
+        assert actual == expected, f"{expected:uuuu-MM-dd HH:mm:ss.fffffffff} != {actual:uuuu-MM-dd HH:mm:ss.fffffffff}"
+
+    @pytest.mark.parametrize(
+        ("day_of_month", "target_day_of_week", "expected"),
+        [
+            (10, IsoDayOfWeek.WEDNESDAY, 16),
+            (10, IsoDayOfWeek.FRIDAY, 11),
+            (10, IsoDayOfWeek.THURSDAY, 17),
+            (11, IsoDayOfWeek.WEDNESDAY, 16),
+            (11, IsoDayOfWeek.THURSDAY, 17),
+            (11, IsoDayOfWeek.FRIDAY, 18),
+            (11, IsoDayOfWeek.SATURDAY, 12),
+            (11, IsoDayOfWeek.SUNDAY, 13),
+            (12, IsoDayOfWeek.FRIDAY, 18),
+            (13, IsoDayOfWeek.FRIDAY, 18),
+        ],
+    )
+    def test_next(self, day_of_month: int, target_day_of_week: IsoDayOfWeek, expected: int) -> None:
+        """Each test case gives a day-of-month in November 2011 and a target "next day of week"; the result is the next
+        day-of-month in November 2011 with that target day.
+
+        The tests are picked somewhat arbitrarily...
+        """
+        start = LocalDateTime(2011, 11, day_of_month, 15, 25, 30).plus_nanoseconds(123456789)
+        target = start.next(target_day_of_week)
+        assert target.year == 2011
+        assert target.month == 11
+        assert target.time_of_day == start.time_of_day
+        assert target.day == expected
+
+    # TODO: def test_next_invalid_argument(self, target_day_of_week: IsoDayOfWeek) -> None:
+
+    @pytest.mark.parametrize(
+        ("day_of_month", "target_day_of_week", "expected"),
+        [
+            (10, IsoDayOfWeek.WEDNESDAY, 9),
+            (10, IsoDayOfWeek.FRIDAY, 4),
+            (10, IsoDayOfWeek.THURSDAY, 3),
+            (11, IsoDayOfWeek.WEDNESDAY, 9),
+            (11, IsoDayOfWeek.THURSDAY, 10),
+            (11, IsoDayOfWeek.FRIDAY, 4),
+            (11, IsoDayOfWeek.SATURDAY, 5),
+            (11, IsoDayOfWeek.SUNDAY, 6),
+            (12, IsoDayOfWeek.FRIDAY, 11),
+            (13, IsoDayOfWeek.FRIDAY, 11),
+        ],
+    )
+    def test_previous(self, day_of_month: int, target_day_of_week: IsoDayOfWeek, expected: int) -> None:
+        """Each test case gives a day-of-month in November 2011 and a target "next day of week"; the result is the next
+        day-of-month in November 2011 with that target day."""
+        start = LocalDateTime(2011, 11, day_of_month, 15, 25, 30).plus_nanoseconds(123456789)
+        target = start.previous(target_day_of_week)
+        assert target.year == 2011
+        assert target.month == 11
+        assert target.time_of_day == start.time_of_day
+        assert target.day == expected
+
+    # TODO: def test_previous_invalid_argument(self, target_day_of_week: IsoDayOfWeek) -> None:
+
+    # No tests for non-ISO-day-of-week calendars as we don't have any yet.
+
+    def test_operator_method_equivalents(self) -> None:
+        start = LocalDateTime(2011, 1, 1, 15, 25, 30).plus_nanoseconds(123456789)
+        period = Period.from_hours(1) + Period.from_days(1)
+        end: LocalDateTime = start + period
+        assert LocalDateTime.add(start, period) == start + period
+        assert start.plus(period) == start + period
+        assert LocalDateTime.subtract(start, period) == start - period
+        assert start.minus(period) == start - period
+        assert end - start == period
+        assert LocalDateTime.subtract(end, start) == period
+        assert end.minus(start) == period
+
     def test_with_time_adjuster(self) -> None:
         start = LocalDateTime(2014, 6, 27, 12, 15, 8).plus_nanoseconds(123456789)
         expected = LocalDateTime(2014, 6, 27, 12, 15, 8)
@@ -86,3 +622,15 @@ class TestLocalDateTimePseudomutators:
         start = LocalDateTime(2014, 6, 27, 12, 5, 8).plus_nanoseconds(123456789)
         expected = LocalDateTime(2014, 6, 30, 12, 5, 8).plus_nanoseconds(123456789)
         assert start.with_date_adjuster(DateAdjusters.end_of_month) == expected
+
+    @pytest.mark.parametrize(
+        ("year", "month", "day", "hours"),
+        [
+            (-9998, 1, 1, -1),
+            (9999, 12, 31, 24),
+            (1970, 1, 1, _CsharpConstants.LONG_MAX_VALUE),
+            (1970, 1, 1, _CsharpConstants.LONG_MIN_VALUE),
+        ],
+    )
+    def test_plus_hours_overflow(self, year: int, month: int, day: int, hours: int) -> None:
+        helpers.assert_overflow(LocalDateTime(year, month, day, 0, 0).plus_hours, hours)


### PR DESCRIPTION
As usual, large portions of this type were already implemented as a by-product of previous ports of other types.

This adds all the missing bits, including the `TestLocalDateTime.cs` port (at least, as much as it makes sense to do so).

It also fixes a couple of lurking bugs in `_TimePeriodField` which were unearthed along the way.