### PR TITLE
chore: update to mypy v1.18.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         args: ["--in-place", "--config", "./pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.17.1'
+    rev: 'v1.18.1'
     hooks:
     -   id: mypy
         additional_dependencies: [


### PR DESCRIPTION
Related to:
- #284 
- https://github.com/python/mypy/issues/10479
- https://github.com/python/mypy/pull/18883

Resolves these errors when upgrading from mypy 1.17.1 to 1.18.1:

```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

pyoda_time/text/_composite_pattern_builder.py:63: error: Type variable "T" is
bound by an outer class  [valid-type]
        class __CompositePattern(_IPartialPattern[T]):
        ^
pyoda_time/text/patterns/_stepped_pattern_builder.py:622: error: Type variable
"TResult" is bound by an outer class  [valid-type]
        class __SteppedPattern(_IPartialPattern[TResult]):

```